### PR TITLE
Removed webview because it is broken in wxWidgets

### DIFF
--- a/wxLua/CMakeLists.txt
+++ b/wxLua/CMakeLists.txt
@@ -46,8 +46,8 @@ set( wxLua_SUBRELEASE_NUMBER "3")
 # Specify what wxWidgets libs we need to link to. Note: 'core' must be before 'base'.
 # If this CMakeLists.txt was called from another, FIND_WXWIDGETS() may have already been called.
 if (NOT DEFINED wxWidgets_COMPONENTS)
-    set(wxWidgets_COMPONENTS webview gl xrc xml net media propgrid richtext aui stc html adv core base)  # complete set for static lib/dll
-    #set(wxWidgets_COMPONENTS webview gl xrc xml net media propgrid richtext aui stc html adv core base) # for multilib/dll
+    set(wxWidgets_COMPONENTS gl xrc xml net media propgrid richtext aui stc html adv core base)  # complete set for static lib/dll
+    #set(wxWidgets_COMPONENTS gl xrc xml net media propgrid richtext aui stc html adv core base) # for multilib/dll
     #set(wxWidgets_COMPONENTS stc mono) # for monolithic
 endif()
 
@@ -76,7 +76,7 @@ endif()
 # ---------------------------------------------------------------------------
 
 # This is the list of all the wxLua bindings for wxWidgets with the same names as the wxWidgets libs.
-set(wxLuaBind_ALL_COMPONENTS webview gl stc xrc richtext propgrid html media aui adv core xml net base )
+set(wxLuaBind_ALL_COMPONENTS gl stc xrc richtext propgrid html media aui adv core xml net base )
 
 if (NOT DEFINED wxLuaBind_COMPONENTS)
     set(wxLuaBind_COMPONENTS ${wxLuaBind_ALL_COMPONENTS})


### PR DESCRIPTION
This may be an @openSUSE specific problem. I just ported the patch from @jengelh to GitHub:

```diff
From: Jan Engelhardt
Date: 2017-09-07 23:28:26.066615635 +0200

Unlike FindwxWidgets.cmake suggests, there is no autodetection of wx components
- at least not for Linux - just this manual list.

Remove webview because it is no longer available in wxWidgets (itself because
webkit is exiting openSUSE:Factory).

---
 CMakeLists.txt |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Index: wxlua-2.8.12.3.r252/CMakeLists.txt
===================================================================
--- wxlua-2.8.12.3.r252.orig/CMakeLists.txt
+++ wxlua-2.8.12.3.r252/CMakeLists.txt
@@ -46,7 +46,7 @@ set( wxLua_SUBRELEASE_NUMBER "3")
 # Specify what wxWidgets libs we need to link to. Note: 'core' must be before 'base'.
 # If this CMakeLists.txt was called from another, FIND_WXWIDGETS() may have already been called.
 if (NOT DEFINED wxWidgets_COMPONENTS)
-    set(wxWidgets_COMPONENTS webview gl xrc xml net media propgrid richtext aui stc html adv core base)  # complete set for static lib/dll
+    set(wxWidgets_COMPONENTS gl xrc xml net media propgrid richtext aui stc html adv core base)  # complete set for static lib/dll
     #set(wxWidgets_COMPONENTS webview gl xrc xml net media propgrid richtext aui stc html adv core base) # for multilib/dll
     #set(wxWidgets_COMPONENTS stc mono) # for monolithic
 endif()
```