### PR TITLE
Updates for building with LuaJIT and wxWidgets 3.0

### DIFF
--- a/wxLua/modules/wxbind/src/wxaui_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxaui_bind.cpp
@@ -310,11 +310,11 @@ static int LUACALL wxLua_wxAuiToolBarItem_Assign(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarItem_GetAlignment[] = { &wxluatype_wxAuiToolBarItem, NULL };
 static int LUACALL wxLua_wxAuiToolBarItem_GetAlignment(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBarItem_GetAlignment[1] = {{ wxLua_wxAuiToolBarItem_GetAlignment, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAuiToolBarItem_GetAlignment }};
-//     %wxchkver_3_1_1 int GetAlignment() const;
+//     %wxchkver_3_0_0 int GetAlignment() const;
 static int LUACALL wxLua_wxAuiToolBarItem_GetAlignment(lua_State *L)
 {
     // get this
@@ -327,7 +327,7 @@ static int LUACALL wxLua_wxAuiToolBarItem_GetAlignment(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarItem_GetBitmap[] = { &wxluatype_wxAuiToolBarItem, NULL };
@@ -645,11 +645,11 @@ static int LUACALL wxLua_wxAuiToolBarItem_SetActive(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarItem_SetAlignment[] = { &wxluatype_wxAuiToolBarItem, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiToolBarItem_SetAlignment(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBarItem_SetAlignment[1] = {{ wxLua_wxAuiToolBarItem_SetAlignment, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAuiToolBarItem_SetAlignment }};
-//     %wxchkver_3_1_1 void SetAlignment(int l);
+//     %wxchkver_3_0_0 void SetAlignment(int l);
 static int LUACALL wxLua_wxAuiToolBarItem_SetAlignment(lua_State *L)
 {
     // int l
@@ -662,7 +662,7 @@ static int LUACALL wxLua_wxAuiToolBarItem_SetAlignment(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarItem_SetBitmap[] = { &wxluatype_wxAuiToolBarItem, &wxluatype_wxBitmap, NULL };
@@ -1023,9 +1023,9 @@ void wxLua_wxAuiToolBarItem_delete_function(void** p)
 wxLuaBindMethod wxAuiToolBarItem_methods[] = {
     { "Assign", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_Assign, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "GetAlignment", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_GetAlignment, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
     { "GetBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_GetBitmap, 1, NULL },
@@ -1058,9 +1058,9 @@ wxLuaBindMethod wxAuiToolBarItem_methods[] = {
     { "IsSticky", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_IsSticky, 1, NULL },
     { "SetActive", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_SetActive, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "SetAlignment", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_SetAlignment, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
     { "SetBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarItem_SetBitmap, 1, NULL },
@@ -1490,11 +1490,11 @@ static int LUACALL wxLua_wxAuiToolBarArt_DrawOverflowButton(lua_State *L)
 
 #endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_DrawPlainBackground[] = { &wxluatype_wxAuiToolBarArt, &wxluatype_wxDC, &wxluatype_wxWindow, &wxluatype_wxRect, NULL };
 static int LUACALL wxLua_wxAuiToolBarArt_DrawPlainBackground(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBarArt_DrawPlainBackground[1] = {{ wxLua_wxAuiToolBarArt_DrawPlainBackground, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxAuiToolBarArt_DrawPlainBackground }};
-//     %wxchkver_3_1_1 void DrawPlainBackground(wxDC& dc, wxWindow* wnd, const wxRect& rect);
+//     %wxchkver_3_0_0 void DrawPlainBackground(wxDC& dc, wxWindow* wnd, const wxRect& rect);
 static int LUACALL wxLua_wxAuiToolBarArt_DrawPlainBackground(lua_State *L)
 {
     // const wxRect rect
@@ -1511,7 +1511,7 @@ static int LUACALL wxLua_wxAuiToolBarArt_DrawPlainBackground(lua_State *L)
     return 0;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_DrawSeparator[] = { &wxluatype_wxAuiToolBarArt, &wxluatype_wxDC, &wxluatype_wxWindow, &wxluatype_wxRect, NULL };
@@ -1555,11 +1555,11 @@ static int LUACALL wxLua_wxAuiToolBarArt_GetElementSize(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetFlags[] = { &wxluatype_wxAuiToolBarArt, NULL };
 static int LUACALL wxLua_wxAuiToolBarArt_GetFlags(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBarArt_GetFlags[1] = {{ wxLua_wxAuiToolBarArt_GetFlags, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetFlags }};
-//     %wxchkver_3_1_1 unsigned int GetFlags();
+//     %wxchkver_3_0_0 unsigned int GetFlags();
 static int LUACALL wxLua_wxAuiToolBarArt_GetFlags(lua_State *L)
 {
     // get this
@@ -1572,13 +1572,13 @@ static int LUACALL wxLua_wxAuiToolBarArt_GetFlags(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetFont[] = { &wxluatype_wxAuiToolBarArt, NULL };
 static int LUACALL wxLua_wxAuiToolBarArt_GetFont(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBarArt_GetFont[1] = {{ wxLua_wxAuiToolBarArt_GetFont, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetFont }};
-//     %wxchkver_3_1_1 wxFont GetFont();
+//     %wxchkver_3_0_0 wxFont GetFont();
 static int LUACALL wxLua_wxAuiToolBarArt_GetFont(lua_State *L)
 {
     // get this
@@ -1594,7 +1594,7 @@ static int LUACALL wxLua_wxAuiToolBarArt_GetFont(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetLabelSize[] = { &wxluatype_wxAuiToolBarArt, &wxluatype_wxDC, &wxluatype_wxWindow, &wxluatype_wxAuiToolBarItem, NULL };
@@ -1624,11 +1624,11 @@ static int LUACALL wxLua_wxAuiToolBarArt_GetLabelSize(lua_State *L)
 
 #endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetTextOrientation[] = { &wxluatype_wxAuiToolBarArt, NULL };
 static int LUACALL wxLua_wxAuiToolBarArt_GetTextOrientation(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBarArt_GetTextOrientation[1] = {{ wxLua_wxAuiToolBarArt_GetTextOrientation, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetTextOrientation }};
-//     %wxchkver_3_1_1 int GetTextOrientation();
+//     %wxchkver_3_0_0 int GetTextOrientation();
 static int LUACALL wxLua_wxAuiToolBarArt_GetTextOrientation(lua_State *L)
 {
     // get this
@@ -1641,7 +1641,7 @@ static int LUACALL wxLua_wxAuiToolBarArt_GetTextOrientation(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBarArt_GetToolSize[] = { &wxluatype_wxAuiToolBarArt, &wxluatype_wxDC, &wxluatype_wxWindow, &wxluatype_wxAuiToolBarItem, NULL };
@@ -1784,9 +1784,9 @@ wxLuaBindMethod wxAuiToolBarArt_methods[] = {
     { "DrawOverflowButton", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_DrawOverflowButton, 1, NULL },
 #endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
     { "DrawPlainBackground", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_DrawPlainBackground, 1, NULL },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
     { "DrawSeparator", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_DrawSeparator, 1, NULL },
@@ -1794,21 +1794,21 @@ wxLuaBindMethod wxAuiToolBarArt_methods[] = {
 
     { "GetElementSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_GetElementSize, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "GetFlags", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_GetFlags, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
     { "GetFont", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_GetFont, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxFont)
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
     { "GetLabelSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_GetLabelSize, 1, NULL },
 #endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "GetTextOrientation", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_GetTextOrientation, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
     { "GetToolSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBarArt_GetToolSize, 1, NULL },
@@ -2097,11 +2097,11 @@ static int LUACALL wxLua_wxAuiToolBar_ClearTools(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBar_Create[] = { &wxluatype_wxAuiToolBar, &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiToolBar_Create(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBar_Create[1] = {{ wxLua_wxAuiToolBar_Create, WXLUAMETHOD_METHOD, 2, 6, s_wxluatypeArray_wxLua_wxAuiToolBar_Create }};
-//     %wxchkver_3_1_1 bool Create(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxAUI_TB_DEFAULT_STYLE);
+//     %wxchkver_3_0_0 bool Create(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxAUI_TB_DEFAULT_STYLE);
 static int LUACALL wxLua_wxAuiToolBar_Create(lua_State *L)
 {
     // get number of arguments
@@ -2126,7 +2126,7 @@ static int LUACALL wxLua_wxAuiToolBar_Create(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiToolBar_DeleteByIndex[] = { &wxluatype_wxAuiToolBar, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiToolBar_DeleteByIndex(lua_State *L);
@@ -3147,10 +3147,10 @@ static int LUACALL wxLua_wxAuiToolBar_constructor1(lua_State *L)
 
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static int LUACALL wxLua_wxAuiToolBar_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBar_constructor[1] = {{ wxLua_wxAuiToolBar_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxAuiToolBar();
+//     %wxchkver_3_0_0 wxAuiToolBar();
 static int LUACALL wxLua_wxAuiToolBar_constructor(lua_State *L)
 {
     // call constructor
@@ -3163,7 +3163,7 @@ static int LUACALL wxLua_wxAuiToolBar_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 
 
@@ -3203,7 +3203,7 @@ static int s_wxluafunc_wxLua_wxAuiToolBar_SetMargins_overload_count = sizeof(s_w
 
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))
 
-#if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
+#if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBar_constructor_overload[] =
 {
@@ -3212,13 +3212,13 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiToolBar_constructor_overload[] =
     { wxLua_wxAuiToolBar_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 5, s_wxluatypeArray_wxLua_wxAuiToolBar_constructor1 },
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { wxLua_wxAuiToolBar_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 };
 static int s_wxluafunc_wxLua_wxAuiToolBar_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxAuiToolBar_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
+#endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
 
 void wxLua_wxAuiToolBar_delete_function(void** p)
 {
@@ -3241,9 +3241,9 @@ wxLuaBindMethod wxAuiToolBar_methods[] = {
     { "Clear", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_Clear, 1, NULL },
     { "ClearTools", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_ClearTools, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_Create, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxPointSizeRect)
 
     { "DeleteByIndex", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_DeleteByIndex, 1, NULL },
     { "DeleteTool", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_DeleteTool, 1, NULL },
@@ -3325,9 +3325,9 @@ wxLuaBindMethod wxAuiToolBar_methods[] = {
     { "SetWindowStyleFlag", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_SetWindowStyleFlag, 1, NULL },
     { "ToggleTool", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiToolBar_ToggleTool, 1, NULL },
 
-#if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
+#if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
     { "wxAuiToolBar", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxAuiToolBar_constructor_overload, s_wxluafunc_wxLua_wxAuiToolBar_constructor_overload_count, 0 },
-#endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
+#endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))
 
     { 0, 0, 0, 0 },
 };
@@ -4570,11 +4570,11 @@ static int LUACALL wxLua_wxAuiTabArt_GetTabSize(lua_State *L)
 
 #endif // (((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiTabArt_SetActiveColour[] = { &wxluatype_wxAuiTabArt, &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxAuiTabArt_SetActiveColour(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiTabArt_SetActiveColour[1] = {{ wxLua_wxAuiTabArt_SetActiveColour, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAuiTabArt_SetActiveColour }};
-//     %wxchkver_3_1_1 void SetActiveColour(const wxColour& colour);
+//     %wxchkver_3_0_0 void SetActiveColour(const wxColour& colour);
 static int LUACALL wxLua_wxAuiTabArt_SetActiveColour(lua_State *L)
 {
     // const wxColour colour
@@ -4590,7 +4590,7 @@ static int LUACALL wxLua_wxAuiTabArt_SetActiveColour(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiTabArt_SetColour[] = { &wxluatype_wxAuiTabArt, &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxAuiTabArt_SetColour(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiTabArt_SetColour[1] = {{ wxLua_wxAuiTabArt_SetColour, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAuiTabArt_SetColour }};
-//     %wxchkver_3_1_1 void SetColour(const wxColour& colour);
+//     %wxchkver_3_0_0 void SetColour(const wxColour& colour);
 static int LUACALL wxLua_wxAuiTabArt_SetColour(lua_State *L)
 {
     // const wxColour colour
@@ -4603,7 +4603,7 @@ static int LUACALL wxLua_wxAuiTabArt_SetColour(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiTabArt_SetFlags[] = { &wxluatype_wxAuiTabArt, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxAuiTabArt_SetFlags(lua_State *L);
@@ -4748,10 +4748,10 @@ wxLuaBindMethod wxAuiTabArt_methods[] = {
     { "GetTabSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiTabArt_GetTabSize, 1, NULL },
 #endif // (((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
     { "SetActiveColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiTabArt_SetActiveColour, 1, NULL },
     { "SetColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiTabArt_SetColour, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 
     { "SetFlags", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiTabArt_SetFlags, 1, NULL },
 
@@ -5621,11 +5621,11 @@ int wxAuiTabCtrl_methodCount = sizeof(wxAuiTabCtrl_methods)/sizeof(wxLuaBindMeth
 // Lua MetaTable Tag for Class 'wxAuiNotebook'
 int wxluatype_wxAuiNotebook = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_AddPage1[] = { &wxluatype_wxAuiNotebook, &wxluatype_wxWindow, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiNotebook_AddPage1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_AddPage1[1] = {{ wxLua_wxAuiNotebook_AddPage1, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxAuiNotebook_AddPage1 }};
-//     %wxchkver_3_1_1 bool AddPage(wxWindow *page, const wxString &text, bool select, int imageId);
+//     %wxchkver_3_0_0 bool AddPage(wxWindow *page, const wxString &text, bool select, int imageId);
 static int LUACALL wxLua_wxAuiNotebook_AddPage1(lua_State *L)
 {
     // int imageId
@@ -5646,7 +5646,7 @@ static int LUACALL wxLua_wxAuiNotebook_AddPage1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_AddPage[] = { &wxluatype_wxAuiNotebook, &wxluatype_wxWindow, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, &wxluatype_wxBitmap, NULL };
@@ -5717,11 +5717,11 @@ static int LUACALL wxLua_wxAuiNotebook_AssignImageList(lua_State *L)
 
 #endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxImageList)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_ChangeSelection[] = { &wxluatype_wxAuiNotebook, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxAuiNotebook_ChangeSelection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_ChangeSelection[1] = {{ wxLua_wxAuiNotebook_ChangeSelection, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAuiNotebook_ChangeSelection }};
-//     %wxchkver_3_1_1 int ChangeSelection(size_t n);
+//     %wxchkver_3_0_0 int ChangeSelection(size_t n);
 static int LUACALL wxLua_wxAuiNotebook_ChangeSelection(lua_State *L)
 {
     // size_t n
@@ -5736,7 +5736,7 @@ static int LUACALL wxLua_wxAuiNotebook_ChangeSelection(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_Create[] = { &wxluatype_wxAuiNotebook, &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, NULL };
@@ -5769,11 +5769,11 @@ static int LUACALL wxLua_wxAuiNotebook_Create(lua_State *L)
 
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_DeleteAllPages[] = { &wxluatype_wxAuiNotebook, NULL };
 static int LUACALL wxLua_wxAuiNotebook_DeleteAllPages(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_DeleteAllPages[1] = {{ wxLua_wxAuiNotebook_DeleteAllPages, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAuiNotebook_DeleteAllPages }};
-//     %wxchkver_3_1_1 bool DeleteAllPages();
+//     %wxchkver_3_0_0 bool DeleteAllPages();
 static int LUACALL wxLua_wxAuiNotebook_DeleteAllPages(lua_State *L)
 {
     // get this
@@ -5786,7 +5786,7 @@ static int LUACALL wxLua_wxAuiNotebook_DeleteAllPages(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_DeletePage[] = { &wxluatype_wxAuiNotebook, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxAuiNotebook_DeletePage(lua_State *L);
@@ -6052,11 +6052,11 @@ static int LUACALL wxLua_wxAuiNotebook_GetTabCtrlHeight(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,5)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_InsertPage1[] = { &wxluatype_wxAuiNotebook, &wxluatype_TINTEGER, &wxluatype_wxWindow, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiNotebook_InsertPage1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_InsertPage1[1] = {{ wxLua_wxAuiNotebook_InsertPage1, WXLUAMETHOD_METHOD, 4, 6, s_wxluatypeArray_wxLua_wxAuiNotebook_InsertPage1 }};
-//     %wxchkver_3_1_1 bool InsertPage(size_t index, wxWindow *page, const wxString &text, bool select=false, int imageId=-1);
+//     %wxchkver_3_0_0 bool InsertPage(size_t index, wxWindow *page, const wxString &text, bool select=false, int imageId=-1);
 static int LUACALL wxLua_wxAuiNotebook_InsertPage1(lua_State *L)
 {
     // get number of arguments
@@ -6081,7 +6081,7 @@ static int LUACALL wxLua_wxAuiNotebook_InsertPage1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_InsertPage[] = { &wxluatype_wxAuiNotebook, &wxluatype_TINTEGER, &wxluatype_wxWindow, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, &wxluatype_wxBitmap, NULL };
@@ -6248,11 +6248,11 @@ static int LUACALL wxLua_wxAuiNotebook_SetPageBitmap(lua_State *L)
 
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_SetPageImage[] = { &wxluatype_wxAuiNotebook, &wxluatype_TINTEGER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiNotebook_SetPageImage(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_SetPageImage[1] = {{ wxLua_wxAuiNotebook_SetPageImage, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxAuiNotebook_SetPageImage }};
-//     %wxchkver_3_1_1 bool SetPageImage(size_t n, int imageId);
+//     %wxchkver_3_0_0 bool SetPageImage(size_t n, int imageId);
 static int LUACALL wxLua_wxAuiNotebook_SetPageImage(lua_State *L)
 {
     // int imageId
@@ -6269,7 +6269,7 @@ static int LUACALL wxLua_wxAuiNotebook_SetPageImage(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiNotebook_SetPageText[] = { &wxluatype_wxAuiNotebook, &wxluatype_TINTEGER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxAuiNotebook_SetPageText(lua_State *L);
@@ -6492,14 +6492,14 @@ static int LUACALL wxLua_wxAuiNotebook_constructor(lua_State *L)
 
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_AddPage_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { wxLua_wxAuiNotebook_AddPage1, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxAuiNotebook_AddPage1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
     { wxLua_wxAuiNotebook_AddPage, WXLUAMETHOD_METHOD, 3, 5, s_wxluatypeArray_wxLua_wxAuiNotebook_AddPage },
@@ -6511,9 +6511,9 @@ static int s_wxluafunc_wxLua_wxAuiNotebook_AddPage_overload_count = sizeof(s_wxl
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_InsertPage_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { wxLua_wxAuiNotebook_InsertPage1, WXLUAMETHOD_METHOD, 4, 6, s_wxluatypeArray_wxLua_wxAuiNotebook_InsertPage1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
     { wxLua_wxAuiNotebook_InsertPage, WXLUAMETHOD_METHOD, 4, 6, s_wxluatypeArray_wxLua_wxAuiNotebook_InsertPage },
@@ -6521,7 +6521,7 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiNotebook_InsertPage_overload[] =
 };
 static int s_wxluafunc_wxLua_wxAuiNotebook_InsertPage_overload_count = sizeof(s_wxluafunc_wxLua_wxAuiNotebook_InsertPage_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
 
 #if ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 // function overload table
@@ -6545,9 +6545,9 @@ void wxLua_wxAuiNotebook_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxAuiNotebook_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
     { "AddPage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_AddPage_overload, s_wxluafunc_wxLua_wxAuiNotebook_AddPage_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
 
 #if (wxCHECK_VERSION(2,8,5)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "AdvanceSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_AdvanceSelection, 1, NULL },
@@ -6557,17 +6557,17 @@ wxLuaBindMethod wxAuiNotebook_methods[] = {
     { "AssignImageList", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_AssignImageList, 1, NULL },
 #endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxImageList)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "ChangeSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_ChangeSelection, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_Create, 1, NULL },
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "DeleteAllPages", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_DeleteAllPages, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
     { "DeletePage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_DeletePage, 1, NULL },
     { "GetArtProvider", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_GetArtProvider, 1, NULL },
@@ -6606,9 +6606,9 @@ wxLuaBindMethod wxAuiNotebook_methods[] = {
     { "GetTabCtrlHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_GetTabCtrlHeight, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,5)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
     { "InsertPage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_InsertPage_overload, s_wxluafunc_wxLua_wxAuiNotebook_InsertPage_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI))||((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap))
 
     { "RemovePage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_RemovePage, 1, NULL },
     { "SetArtProvider", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_SetArtProvider, 1, NULL },
@@ -6630,9 +6630,9 @@ wxLuaBindMethod wxAuiNotebook_methods[] = {
     { "SetPageBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_SetPageBitmap, 1, NULL },
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxBitmap)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "SetPageImage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_SetPageImage, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
     { "SetPageText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiNotebook_SetPageText, 1, NULL },
 
@@ -6820,11 +6820,11 @@ static int LUACALL wxLua_wxAuiDockArt_DrawSash(lua_State *L)
 
 #endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiDockArt_GetColor[] = { &wxluatype_wxAuiDockArt, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAuiDockArt_GetColor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiDockArt_GetColor[1] = {{ wxLua_wxAuiDockArt_GetColor, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAuiDockArt_GetColor }};
-//     !%wxchkver_3_1_1 wxColour GetColor(int id);
+//     !%wxchkver_3_0_0 wxColour GetColor(int id);
 static int LUACALL wxLua_wxAuiDockArt_GetColor(lua_State *L)
 {
     // int id
@@ -6842,7 +6842,7 @@ static int LUACALL wxLua_wxAuiDockArt_GetColor(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiDockArt_GetColour[] = { &wxluatype_wxAuiDockArt, &wxluatype_TNUMBER, NULL };
@@ -6911,11 +6911,11 @@ static int LUACALL wxLua_wxAuiDockArt_GetMetric(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiDockArt_SetColor[] = { &wxluatype_wxAuiDockArt, &wxluatype_TNUMBER, &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxAuiDockArt_SetColor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiDockArt_SetColor[1] = {{ wxLua_wxAuiDockArt_SetColor, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxAuiDockArt_SetColor }};
-//     !%wxchkver_3_1_1 void SetColor(int id, const wxColour& color);
+//     !%wxchkver_3_0_0 void SetColor(int id, const wxColour& color);
 static int LUACALL wxLua_wxAuiDockArt_SetColor(lua_State *L)
 {
     // const wxColour color
@@ -6930,7 +6930,7 @@ static int LUACALL wxLua_wxAuiDockArt_SetColor(lua_State *L)
     return 0;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiDockArt_SetColour[] = { &wxluatype_wxAuiDockArt, &wxluatype_TNUMBER, &wxluatype_wxColour, NULL };
@@ -7015,9 +7015,9 @@ wxLuaBindMethod wxAuiDockArt_methods[] = {
     { "DrawSash", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiDockArt_DrawSash, 1, NULL },
 #endif // ((wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxDC)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
     { "GetColor", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiDockArt_GetColor, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxColourPenBrush)
     { "GetColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiDockArt_GetColour, 1, NULL },
@@ -7029,9 +7029,9 @@ wxLuaBindMethod wxAuiDockArt_methods[] = {
 
     { "GetMetric", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiDockArt_GetMetric, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
     { "SetColor", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiDockArt_SetColor, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxColourPenBrush)
     { "SetColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiDockArt_SetColour, 1, NULL },
@@ -9784,11 +9784,11 @@ static int LUACALL wxLua_wxAuiManager_CalculateHintRect(lua_State *L)
 
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiManager_CanDockPanel[] = { &wxluatype_wxAuiManager, &wxluatype_wxAuiPaneInfo, NULL };
 static int LUACALL wxLua_wxAuiManager_CanDockPanel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAuiManager_CanDockPanel[1] = {{ wxLua_wxAuiManager_CanDockPanel, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAuiManager_CanDockPanel }};
-//     %wxchkver_3_1_1 bool CanDockPanel(const wxAuiPaneInfo & p);
+//     %wxchkver_3_0_0 bool CanDockPanel(const wxAuiPaneInfo & p);
 static int LUACALL wxLua_wxAuiManager_CanDockPanel(lua_State *L)
 {
     // const wxAuiPaneInfo p
@@ -9803,7 +9803,7 @@ static int LUACALL wxLua_wxAuiManager_CanDockPanel(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAuiManager_ClosePane[] = { &wxluatype_wxAuiManager, &wxluatype_wxAuiPaneInfo, NULL };
 static int LUACALL wxLua_wxAuiManager_ClosePane(lua_State *L);
@@ -10410,9 +10410,9 @@ wxLuaBindMethod wxAuiManager_methods[] = {
     { "CalculateHintRect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiManager_CalculateHintRect, 1, NULL },
 #endif // (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
     { "CanDockPanel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiManager_CanDockPanel, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
 
     { "ClosePane", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiManager_ClosePane, 1, NULL },
     { "CreateFloatingFrame", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAuiManager_CreateFloatingFrame, 1, NULL },

--- a/wxLua/modules/wxbind/src/wxbase_base.cpp
+++ b/wxLua/modules/wxbind/src/wxbase_base.cpp
@@ -2504,11 +2504,11 @@ int wxRegEx_methodCount = sizeof(wxRegEx_methods)/sizeof(wxLuaBindMethod) - 1;
 // Lua MetaTable Tag for Class 'wxEventLoopBase'
 int wxluatype_wxEventLoopBase = WXLUA_TUNKNOWN;
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_Dispatch[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_Dispatch(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_Dispatch[1] = {{ wxLua_wxEventLoopBase_Dispatch, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_Dispatch }};
-//     %wxchkver_3_1_1 bool Dispatch();
+//     %wxchkver_3_0_0 bool Dispatch();
 static int LUACALL wxLua_wxEventLoopBase_Dispatch(lua_State *L)
 {
     // get this
@@ -2524,7 +2524,7 @@ static int LUACALL wxLua_wxEventLoopBase_Dispatch(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_DispatchTimeout[] = { &wxluatype_wxEventLoopBase, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxEventLoopBase_DispatchTimeout(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_DispatchTimeout[1] = {{ wxLua_wxEventLoopBase_DispatchTimeout, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEventLoopBase_DispatchTimeout }};
-//     %wxchkver_3_1_1 int DispatchTimeout(unsigned long timeout);
+//     %wxchkver_3_0_0 int DispatchTimeout(unsigned long timeout);
 static int LUACALL wxLua_wxEventLoopBase_DispatchTimeout(lua_State *L)
 {
     // unsigned long timeout
@@ -2542,7 +2542,7 @@ static int LUACALL wxLua_wxEventLoopBase_DispatchTimeout(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_Exit[] = { &wxluatype_wxEventLoopBase, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxEventLoopBase_Exit(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_Exit[1] = {{ wxLua_wxEventLoopBase_Exit, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxEventLoopBase_Exit }};
-//     %wxchkver_3_1_1 void Exit(int rc = 0);
+//     %wxchkver_3_0_0 void Exit(int rc = 0);
 static int LUACALL wxLua_wxEventLoopBase_Exit(lua_State *L)
 {
     // get number of arguments
@@ -2559,7 +2559,7 @@ static int LUACALL wxLua_wxEventLoopBase_Exit(lua_State *L)
 
 static int LUACALL wxLua_wxEventLoopBase_GetActive(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_GetActive[1] = {{ wxLua_wxEventLoopBase_GetActive, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 static wxEventLoopBase *GetActive();
+//     %wxchkver_3_0_0 static wxEventLoopBase *GetActive();
 static int LUACALL wxLua_wxEventLoopBase_GetActive(lua_State *L)
 {
     // call GetActive
@@ -2573,7 +2573,7 @@ static int LUACALL wxLua_wxEventLoopBase_GetActive(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_IsEventAllowedInsideYield[] = { &wxluatype_wxEventLoopBase, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxEventLoopBase_IsEventAllowedInsideYield(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_IsEventAllowedInsideYield[1] = {{ wxLua_wxEventLoopBase_IsEventAllowedInsideYield, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEventLoopBase_IsEventAllowedInsideYield }};
-//     %wxchkver_3_1_1 bool IsEventAllowedInsideYield(wxEventCategory cat) const;
+//     %wxchkver_3_0_0 bool IsEventAllowedInsideYield(wxEventCategory cat) const;
 static int LUACALL wxLua_wxEventLoopBase_IsEventAllowedInsideYield(lua_State *L)
 {
     // wxEventCategory cat
@@ -2591,7 +2591,7 @@ static int LUACALL wxLua_wxEventLoopBase_IsEventAllowedInsideYield(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_IsMain[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_IsMain(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_IsMain[1] = {{ wxLua_wxEventLoopBase_IsMain, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_IsMain }};
-//     %wxchkver_3_1_1 bool IsMain() const;
+//     %wxchkver_3_0_0 bool IsMain() const;
 static int LUACALL wxLua_wxEventLoopBase_IsMain(lua_State *L)
 {
     // get this
@@ -2607,7 +2607,7 @@ static int LUACALL wxLua_wxEventLoopBase_IsMain(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_IsOk[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_IsOk[1] = {{ wxLua_wxEventLoopBase_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxEventLoopBase_IsOk(lua_State *L)
 {
     // get this
@@ -2623,7 +2623,7 @@ static int LUACALL wxLua_wxEventLoopBase_IsOk(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_IsRunning[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_IsRunning(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_IsRunning[1] = {{ wxLua_wxEventLoopBase_IsRunning, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_IsRunning }};
-//     %wxchkver_3_1_1 bool IsRunning() const;
+//     %wxchkver_3_0_0 bool IsRunning() const;
 static int LUACALL wxLua_wxEventLoopBase_IsRunning(lua_State *L)
 {
     // get this
@@ -2639,7 +2639,7 @@ static int LUACALL wxLua_wxEventLoopBase_IsRunning(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_IsYielding[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_IsYielding(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_IsYielding[1] = {{ wxLua_wxEventLoopBase_IsYielding, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_IsYielding }};
-//     %wxchkver_3_1_1 bool IsYielding() const;
+//     %wxchkver_3_0_0 bool IsYielding() const;
 static int LUACALL wxLua_wxEventLoopBase_IsYielding(lua_State *L)
 {
     // get this
@@ -2655,7 +2655,7 @@ static int LUACALL wxLua_wxEventLoopBase_IsYielding(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_Pending[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_Pending(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_Pending[1] = {{ wxLua_wxEventLoopBase_Pending, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_Pending }};
-//     %wxchkver_3_1_1 bool Pending() const;
+//     %wxchkver_3_0_0 bool Pending() const;
 static int LUACALL wxLua_wxEventLoopBase_Pending(lua_State *L)
 {
     // get this
@@ -2671,7 +2671,7 @@ static int LUACALL wxLua_wxEventLoopBase_Pending(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_ProcessIdle[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_ProcessIdle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_ProcessIdle[1] = {{ wxLua_wxEventLoopBase_ProcessIdle, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_ProcessIdle }};
-//     %wxchkver_3_1_1 bool ProcessIdle();
+//     %wxchkver_3_0_0 bool ProcessIdle();
 static int LUACALL wxLua_wxEventLoopBase_ProcessIdle(lua_State *L)
 {
     // get this
@@ -2687,7 +2687,7 @@ static int LUACALL wxLua_wxEventLoopBase_ProcessIdle(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_Run[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_Run(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_Run[1] = {{ wxLua_wxEventLoopBase_Run, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_Run }};
-//     %wxchkver_3_1_1 int Run();
+//     %wxchkver_3_0_0 int Run();
 static int LUACALL wxLua_wxEventLoopBase_Run(lua_State *L)
 {
     // get this
@@ -2703,7 +2703,7 @@ static int LUACALL wxLua_wxEventLoopBase_Run(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_ScheduleExit[] = { &wxluatype_wxEventLoopBase, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxEventLoopBase_ScheduleExit(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_ScheduleExit[1] = {{ wxLua_wxEventLoopBase_ScheduleExit, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxEventLoopBase_ScheduleExit }};
-//     %wxchkver_3_1_1 void ScheduleExit(int rc = 0);
+//     %wxchkver_3_0_0 void ScheduleExit(int rc = 0);
 static int LUACALL wxLua_wxEventLoopBase_ScheduleExit(lua_State *L)
 {
     // get number of arguments
@@ -2721,7 +2721,7 @@ static int LUACALL wxLua_wxEventLoopBase_ScheduleExit(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_SetActive[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_SetActive(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_SetActive[1] = {{ wxLua_wxEventLoopBase_SetActive, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_SetActive }};
-//     %wxchkver_3_1_1 static void SetActive(wxEventLoopBase* loop);
+//     %wxchkver_3_0_0 static void SetActive(wxEventLoopBase* loop);
 static int LUACALL wxLua_wxEventLoopBase_SetActive(lua_State *L)
 {
     // wxEventLoopBase loop
@@ -2735,7 +2735,7 @@ static int LUACALL wxLua_wxEventLoopBase_SetActive(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_WakeUp[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_WakeUp(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_WakeUp[1] = {{ wxLua_wxEventLoopBase_WakeUp, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_WakeUp }};
-//     %wxchkver_3_1_1 void WakeUp();
+//     %wxchkver_3_0_0 void WakeUp();
 static int LUACALL wxLua_wxEventLoopBase_WakeUp(lua_State *L)
 {
     // get this
@@ -2749,7 +2749,7 @@ static int LUACALL wxLua_wxEventLoopBase_WakeUp(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_WakeUpIdle[] = { &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxEventLoopBase_WakeUpIdle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_WakeUpIdle[1] = {{ wxLua_wxEventLoopBase_WakeUpIdle, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_WakeUpIdle }};
-//     %wxchkver_3_1_1 void WakeUpIdle();
+//     %wxchkver_3_0_0 void WakeUpIdle();
 static int LUACALL wxLua_wxEventLoopBase_WakeUpIdle(lua_State *L)
 {
     // get this
@@ -2763,7 +2763,7 @@ static int LUACALL wxLua_wxEventLoopBase_WakeUpIdle(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_Yield[] = { &wxluatype_wxEventLoopBase, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxEventLoopBase_Yield(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_Yield[1] = {{ wxLua_wxEventLoopBase_Yield, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxEventLoopBase_Yield }};
-//     %wxchkver_3_1_1 bool Yield(bool onlyIfNeeded = false);
+//     %wxchkver_3_0_0 bool Yield(bool onlyIfNeeded = false);
 static int LUACALL wxLua_wxEventLoopBase_Yield(lua_State *L)
 {
     // get number of arguments
@@ -2783,7 +2783,7 @@ static int LUACALL wxLua_wxEventLoopBase_Yield(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_YieldFor[] = { &wxluatype_wxEventLoopBase, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxEventLoopBase_YieldFor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_YieldFor[1] = {{ wxLua_wxEventLoopBase_YieldFor, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEventLoopBase_YieldFor }};
-//     %wxchkver_3_1_1 bool YieldFor(long eventsToProcess);
+//     %wxchkver_3_0_0 bool YieldFor(long eventsToProcess);
 static int LUACALL wxLua_wxEventLoopBase_YieldFor(lua_State *L)
 {
     // long eventsToProcess
@@ -2798,7 +2798,7 @@ static int LUACALL wxLua_wxEventLoopBase_YieldFor(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventLoopBase_delete[] = { &wxluatype_wxEventLoopBase, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventLoopBase_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxEventLoopBase_delete }};
@@ -2813,7 +2813,7 @@ void wxLua_wxEventLoopBase_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxEventLoopBase_methods[] = {
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "Dispatch", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventLoopBase_Dispatch, 1, NULL },
     { "DispatchTimeout", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventLoopBase_DispatchTimeout, 1, NULL },
     { "Exit", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventLoopBase_Exit, 1, NULL },
@@ -2832,7 +2832,7 @@ wxLuaBindMethod wxEventLoopBase_methods[] = {
     { "WakeUpIdle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventLoopBase_WakeUpIdle, 1, NULL },
     { "Yield", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventLoopBase_Yield, 1, NULL },
     { "YieldFor", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventLoopBase_YieldFor, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxEventLoopBase_delete, 1, NULL },
     { 0, 0, 0, 0 },
@@ -2848,11 +2848,11 @@ int wxEventLoopBase_methodCount = sizeof(wxEventLoopBase_methods)/sizeof(wxLuaBi
 // Lua MetaTable Tag for Class 'wxEventFilter'
 int wxluatype_wxEventFilter = WXLUA_TUNKNOWN;
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEventFilter_FilterEvent[] = { &wxluatype_wxEventFilter, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEventFilter_FilterEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEventFilter_FilterEvent[1] = {{ wxLua_wxEventFilter_FilterEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEventFilter_FilterEvent }};
-//     %wxchkver_3_1_1 int FilterEvent(wxEvent& event);
+//     %wxchkver_3_0_0 int FilterEvent(wxEvent& event);
 static int LUACALL wxLua_wxEventFilter_FilterEvent(lua_State *L)
 {
     // wxEvent event
@@ -2867,7 +2867,7 @@ static int LUACALL wxLua_wxEventFilter_FilterEvent(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 
 
@@ -2879,9 +2879,9 @@ void wxLua_wxEventFilter_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxEventFilter_methods[] = {
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "FilterEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEventFilter_FilterEvent, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { 0, 0, 0, 0 },
 };
@@ -2896,11 +2896,11 @@ int wxEventFilter_methodCount = sizeof(wxEventFilter_methods)/sizeof(wxLuaBindMe
 // Lua MetaTable Tag for Class 'wxEvtHandler'
 int wxluatype_wxEvtHandler = WXLUA_TUNKNOWN;
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_AddFilter[] = { &wxluatype_wxEventFilter, NULL };
 static int LUACALL wxLua_wxEvtHandler_AddFilter(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_AddFilter[1] = {{ wxLua_wxEvtHandler_AddFilter, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_AddFilter }};
-//     %wxchkver_3_1_1 static void AddFilter(wxEventFilter* filter);
+//     %wxchkver_3_0_0 static void AddFilter(wxEventFilter* filter);
 static int LUACALL wxLua_wxEvtHandler_AddFilter(lua_State *L)
 {
     // wxEventFilter filter
@@ -2911,13 +2911,13 @@ static int LUACALL wxLua_wxEvtHandler_AddFilter(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_AddPendingEvent1[] = { &wxluatype_wxEvtHandler, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvtHandler_AddPendingEvent1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent1[1] = {{ wxLua_wxEvtHandler_AddPendingEvent1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEvtHandler_AddPendingEvent1 }};
-//     !%wxchkver_3_1_1 void AddPendingEvent(wxEvent& event);
+//     !%wxchkver_3_0_0 void AddPendingEvent(wxEvent& event);
 static int LUACALL wxLua_wxEvtHandler_AddPendingEvent1(lua_State *L)
 {
     // wxEvent event
@@ -2930,13 +2930,13 @@ static int LUACALL wxLua_wxEvtHandler_AddPendingEvent1(lua_State *L)
     return 0;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_AddPendingEvent[] = { &wxluatype_wxEvtHandler, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvtHandler_AddPendingEvent(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent[1] = {{ wxLua_wxEvtHandler_AddPendingEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEvtHandler_AddPendingEvent }};
-//     %wxchkver_3_1_1 void AddPendingEvent(const wxEvent& event);
+//     %wxchkver_3_0_0 void AddPendingEvent(const wxEvent& event);
 static int LUACALL wxLua_wxEvtHandler_AddPendingEvent(lua_State *L)
 {
     // const wxEvent event
@@ -2949,7 +2949,7 @@ static int LUACALL wxLua_wxEvtHandler_AddPendingEvent(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_Connect[] = { &wxluatype_wxEvtHandler, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TFUNCTION, NULL };
 static int LUACALL wxLua_wxEvtHandler_Connect(lua_State *L);
@@ -3084,11 +3084,11 @@ static int LUACALL wxLua_wxEvtHandler_Connect(lua_State *L)
 
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_DeletePendingEvents[] = { &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxEvtHandler_DeletePendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_DeletePendingEvents[1] = {{ wxLua_wxEvtHandler_DeletePendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_DeletePendingEvents }};
-//     %wxchkver_3_1_1 void DeletePendingEvents();
+//     %wxchkver_3_0_0 void DeletePendingEvents();
 static int LUACALL wxLua_wxEvtHandler_DeletePendingEvents(lua_State *L)
 {
     // get this
@@ -3099,7 +3099,7 @@ static int LUACALL wxLua_wxEvtHandler_DeletePendingEvents(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_Disconnect[] = { &wxluatype_wxEvtHandler, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxEvtHandler_Disconnect(lua_State *L);
@@ -3275,11 +3275,11 @@ static int LUACALL wxLua_wxEvtHandler_GetPreviousHandler(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_IsUnlinked[] = { &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxEvtHandler_IsUnlinked(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_IsUnlinked[1] = {{ wxLua_wxEvtHandler_IsUnlinked, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_IsUnlinked }};
-//     %wxchkver_3_1_1 bool IsUnlinked() const;
+//     %wxchkver_3_0_0 bool IsUnlinked() const;
 static int LUACALL wxLua_wxEvtHandler_IsUnlinked(lua_State *L)
 {
     // get this
@@ -3292,7 +3292,7 @@ static int LUACALL wxLua_wxEvtHandler_IsUnlinked(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_ProcessEvent[] = { &wxluatype_wxEvtHandler, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvtHandler_ProcessEvent(lua_State *L);
@@ -3313,11 +3313,11 @@ static int LUACALL wxLua_wxEvtHandler_ProcessEvent(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_ProcessEventLocally[] = { &wxluatype_wxEvtHandler, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvtHandler_ProcessEventLocally(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_ProcessEventLocally[1] = {{ wxLua_wxEvtHandler_ProcessEventLocally, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEvtHandler_ProcessEventLocally }};
-//     %wxchkver_3_1_1 bool ProcessEventLocally(wxEvent& event);
+//     %wxchkver_3_0_0 bool ProcessEventLocally(wxEvent& event);
 static int LUACALL wxLua_wxEvtHandler_ProcessEventLocally(lua_State *L)
 {
     // wxEvent event
@@ -3335,7 +3335,7 @@ static int LUACALL wxLua_wxEvtHandler_ProcessEventLocally(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_ProcessPendingEvents[] = { &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxEvtHandler_ProcessPendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_ProcessPendingEvents[1] = {{ wxLua_wxEvtHandler_ProcessPendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_ProcessPendingEvents }};
-//     %wxchkver_3_1_1 void ProcessPendingEvents();
+//     %wxchkver_3_0_0 void ProcessPendingEvents();
 static int LUACALL wxLua_wxEvtHandler_ProcessPendingEvents(lua_State *L)
 {
     // get this
@@ -3346,7 +3346,7 @@ static int LUACALL wxLua_wxEvtHandler_ProcessPendingEvents(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(2,9,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_QueueEvent[] = { &wxluatype_wxEvtHandler, &wxluatype_wxEvent, NULL };
@@ -3368,11 +3368,11 @@ static int LUACALL wxLua_wxEvtHandler_QueueEvent(lua_State *L)
 
 #endif // wxCHECK_VERSION(2,9,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_RemoveFilter[] = { &wxluatype_wxEventFilter, NULL };
 static int LUACALL wxLua_wxEvtHandler_RemoveFilter(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_RemoveFilter[1] = {{ wxLua_wxEvtHandler_RemoveFilter, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_RemoveFilter }};
-//     %wxchkver_3_1_1 static void RemoveFilter(wxEventFilter* filter);
+//     %wxchkver_3_0_0 static void RemoveFilter(wxEventFilter* filter);
 static int LUACALL wxLua_wxEvtHandler_RemoveFilter(lua_State *L)
 {
     // wxEventFilter filter
@@ -3386,7 +3386,7 @@ static int LUACALL wxLua_wxEvtHandler_RemoveFilter(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_SafelyProcessEvent[] = { &wxluatype_wxEvtHandler, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvtHandler_SafelyProcessEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_SafelyProcessEvent[1] = {{ wxLua_wxEvtHandler_SafelyProcessEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEvtHandler_SafelyProcessEvent }};
-//     %wxchkver_3_1_1 bool SafelyProcessEvent(wxEvent& event);
+//     %wxchkver_3_0_0 bool SafelyProcessEvent(wxEvent& event);
 static int LUACALL wxLua_wxEvtHandler_SafelyProcessEvent(lua_State *L)
 {
     // wxEvent event
@@ -3401,7 +3401,7 @@ static int LUACALL wxLua_wxEvtHandler_SafelyProcessEvent(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_SetClientData[] = { &wxluatype_wxEvtHandler, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxEvtHandler_SetClientData(lua_State *L);
@@ -3484,11 +3484,11 @@ static int LUACALL wxLua_wxEvtHandler_SetPreviousHandler(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_Unlink[] = { &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxEvtHandler_Unlink(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_Unlink[1] = {{ wxLua_wxEvtHandler_Unlink, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_Unlink }};
-//     %wxchkver_3_1_1 void Unlink();
+//     %wxchkver_3_0_0 void Unlink();
 static int LUACALL wxLua_wxEvtHandler_Unlink(lua_State *L)
 {
     // get this
@@ -3499,7 +3499,7 @@ static int LUACALL wxLua_wxEvtHandler_Unlink(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvtHandler_delete[] = { &wxluatype_wxEvtHandler, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxEvtHandler_delete }};
@@ -3521,22 +3521,22 @@ static int LUACALL wxLua_wxEvtHandler_constructor(lua_State *L)
 
 
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxEvtHandler_AddPendingEvent1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEvtHandler_AddPendingEvent1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxEvtHandler_AddPendingEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxEvtHandler_AddPendingEvent },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent_overload_count = sizeof(s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 void wxLua_wxEvtHandler_delete_function(void** p)
 {
@@ -3546,19 +3546,19 @@ void wxLua_wxEvtHandler_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxEvtHandler_methods[] = {
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "AddFilter", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxEvtHandler_AddFilter, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
     { "AddPendingEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent_overload, s_wxluafunc_wxLua_wxEvtHandler_AddPendingEvent_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
     { "Connect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_Connect, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "DeletePendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_DeletePendingEvents, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "Disconnect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_Disconnect, 1, NULL },
     { "GetClientData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_GetClientData, 1, NULL },
@@ -3567,25 +3567,25 @@ wxLuaBindMethod wxEvtHandler_methods[] = {
     { "GetNextHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_GetNextHandler, 1, NULL },
     { "GetPreviousHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_GetPreviousHandler, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "IsUnlinked", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_IsUnlinked, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "ProcessEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_ProcessEvent, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "ProcessEventLocally", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_ProcessEventLocally, 1, NULL },
     { "ProcessPendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_ProcessPendingEvents, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(2,9,0)
     { "QueueEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_QueueEvent, 1, NULL },
 #endif // wxCHECK_VERSION(2,9,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "RemoveFilter", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxEvtHandler_RemoveFilter, 1, NULL },
     { "SafelyProcessEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_SafelyProcessEvent, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "SetClientData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_SetClientData, 1, NULL },
     { "SetClientObject", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_SetClientObject, 1, NULL },
@@ -3593,9 +3593,9 @@ wxLuaBindMethod wxEvtHandler_methods[] = {
     { "SetNextHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_SetNextHandler, 1, NULL },
     { "SetPreviousHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_SetPreviousHandler, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "Unlink", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvtHandler_Unlink, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxEvtHandler_delete, 1, NULL },
     { "wxEvtHandler", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxEvtHandler_constructor, 1, NULL },
@@ -3612,11 +3612,11 @@ int wxEvtHandler_methodCount = sizeof(wxEvtHandler_methods)/sizeof(wxLuaBindMeth
 // Lua MetaTable Tag for Class 'wxEvent'
 int wxluatype_wxEvent = WXLUA_TUNKNOWN;
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvent_GetEventCategory[] = { &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvent_GetEventCategory(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvent_GetEventCategory[1] = {{ wxLua_wxEvent_GetEventCategory, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEvent_GetEventCategory }};
-//     %wxchkver_3_1_1 wxEventCategory GetEventCategory() const;
+//     %wxchkver_3_0_0 wxEventCategory GetEventCategory() const;
 static int LUACALL wxLua_wxEvent_GetEventCategory(lua_State *L)
 {
     // get this
@@ -3629,7 +3629,7 @@ static int LUACALL wxLua_wxEvent_GetEventCategory(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxObject
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvent_GetEventObject[] = { &wxluatype_wxEvent, NULL };
@@ -3667,11 +3667,11 @@ static int LUACALL wxLua_wxEvent_GetEventType(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxObject)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxObject)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvent_GetEventUserData[] = { &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvent_GetEventUserData(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxEvent_GetEventUserData[1] = {{ wxLua_wxEvent_GetEventUserData, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxEvent_GetEventUserData }};
-//     %wxchkver_3_1_1 wxObject *GetEventUserData() const;
+//     %wxchkver_3_0_0 wxObject *GetEventUserData() const;
 static int LUACALL wxLua_wxEvent_GetEventUserData(lua_State *L)
 {
     // get this
@@ -3684,7 +3684,7 @@ static int LUACALL wxLua_wxEvent_GetEventUserData(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxObject)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxObject)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxEvent_GetId[] = { &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxEvent_GetId(lua_State *L);
@@ -3897,9 +3897,9 @@ void wxLua_wxEvent_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxEvent_methods[] = {
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetEventCategory", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvent_GetEventCategory, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxObject
     { "GetEventObject", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvent_GetEventObject, 1, NULL },
@@ -3907,9 +3907,9 @@ wxLuaBindMethod wxEvent_methods[] = {
 
     { "GetEventType", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvent_GetEventType, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxObject)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxObject)
     { "GetEventUserData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvent_GetEventUserData, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxObject)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxObject)
 
     { "GetId", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvent_GetId, 1, NULL },
     { "GetSkipped", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxEvent_GetSkipped, 1, NULL },

--- a/wxLua/modules/wxbind/src/wxbase_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxbase_bind.cpp
@@ -254,14 +254,14 @@ wxLuaBindNumber* wxLuaGetDefineList_wxbase(size_t &count)
         { "wxEVENT_PROPAGATE_MAX", wxEVENT_PROPAGATE_MAX },
         { "wxEVENT_PROPAGATE_NONE", wxEVENT_PROPAGATE_NONE },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
         { "wxEVT_CATEGORY_ALL", wxEVT_CATEGORY_ALL },
         { "wxEVT_CATEGORY_SOCKET", wxEVT_CATEGORY_SOCKET },
         { "wxEVT_CATEGORY_THREAD", wxEVT_CATEGORY_THREAD },
         { "wxEVT_CATEGORY_TIMER", wxEVT_CATEGORY_TIMER },
         { "wxEVT_CATEGORY_UI", wxEVT_CATEGORY_UI },
         { "wxEVT_CATEGORY_USER_INPUT", wxEVT_CATEGORY_USER_INPUT },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxFileName
         { "wxFILE", wxFILE },
@@ -806,11 +806,11 @@ wxLuaBindNumber* wxLuaGetDefineList_wxbase(size_t &count)
         { "wxRE_NOTEOL", wxRE_NOTEOL },
 #endif // wxLUA_USE_wxRegEx && wxUSE_REGEX
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
         { "wxSIZE_CONV_IEC", wxSIZE_CONV_IEC },
         { "wxSIZE_CONV_SI", wxSIZE_CONV_SI },
         { "wxSIZE_CONV_TRADITIONAL", wxSIZE_CONV_TRADITIONAL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 #if wxUSE_STREAMS
         { "wxSTREAM_EOF", wxSTREAM_EOF },

--- a/wxLua/modules/wxbind/src/wxbase_file.cpp
+++ b/wxLua/modules/wxbind/src/wxbase_file.cpp
@@ -37,11 +37,11 @@
 // Lua MetaTable Tag for Class 'wxStandardPaths'
 int wxluatype_wxStandardPaths = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_DontIgnoreAppSubDir[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_DontIgnoreAppSubDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_DontIgnoreAppSubDir[1] = {{ wxLua_wxStandardPaths_DontIgnoreAppSubDir, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStandardPaths_DontIgnoreAppSubDir }};
-//     %wxchkver_3_1_1 && %win void DontIgnoreAppSubDir();
+//     %wxchkver_3_0_0 && %win void DontIgnoreAppSubDir();
 static int LUACALL wxLua_wxStandardPaths_DontIgnoreAppSubDir(lua_State *L)
 {
     // get this
@@ -52,7 +52,7 @@ static int LUACALL wxLua_wxStandardPaths_DontIgnoreAppSubDir(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
 
 static int LUACALL wxLua_wxStandardPaths_Get(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_Get[1] = {{ wxLua_wxStandardPaths_Get, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
@@ -70,11 +70,11 @@ static int LUACALL wxLua_wxStandardPaths_Get(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_GetAppDocumentsDir[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_GetAppDocumentsDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_GetAppDocumentsDir[1] = {{ wxLua_wxStandardPaths_GetAppDocumentsDir, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStandardPaths_GetAppDocumentsDir }};
-//     %wxchkver_3_1_1 wxString GetAppDocumentsDir() const;
+//     %wxchkver_3_0_0 wxString GetAppDocumentsDir() const;
 static int LUACALL wxLua_wxStandardPaths_GetAppDocumentsDir(lua_State *L)
 {
     // get this
@@ -87,7 +87,7 @@ static int LUACALL wxLua_wxStandardPaths_GetAppDocumentsDir(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_GetConfigDir[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_GetConfigDir(lua_State *L);
@@ -154,11 +154,11 @@ static int LUACALL wxLua_wxStandardPaths_GetExecutablePath(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_GetInstallPrefix[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_GetInstallPrefix(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_GetInstallPrefix[1] = {{ wxLua_wxStandardPaths_GetInstallPrefix, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStandardPaths_GetInstallPrefix }};
-//     %wxchkver_3_1_1 && %gtk wxString GetInstallPrefix() const;
+//     %wxchkver_3_0_0 && %gtk wxString GetInstallPrefix() const;
 static int LUACALL wxLua_wxStandardPaths_GetInstallPrefix(lua_State *L)
 {
     // get this
@@ -171,7 +171,7 @@ static int LUACALL wxLua_wxStandardPaths_GetInstallPrefix(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_GetLocalDataDir[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_GetLocalDataDir(lua_State *L);
@@ -292,11 +292,11 @@ static int LUACALL wxLua_wxStandardPaths_GetUserDataDir(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_GetUserDir[] = { &wxluatype_wxStandardPaths, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxStandardPaths_GetUserDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_GetUserDir[1] = {{ wxLua_wxStandardPaths_GetUserDir, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStandardPaths_GetUserDir }};
-//     %wxchkver_3_1_1 wxString GetUserDir(wxStandardPaths::Dir userDir) const; // %override parameter type
+//     %wxchkver_3_1_0 wxString GetUserDir(wxStandardPaths::Dir userDir) const; // %override parameter type
 static int LUACALL wxLua_wxStandardPaths_GetUserDir(lua_State *L)
 {
     // wxStandardPaths::Dir userDir
@@ -311,7 +311,7 @@ static int LUACALL wxLua_wxStandardPaths_GetUserDir(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_GetUserLocalDataDir[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_GetUserLocalDataDir(lua_State *L);
@@ -330,11 +330,11 @@ static int LUACALL wxLua_wxStandardPaths_GetUserLocalDataDir(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_IgnoreAppBuildSubDirs[] = { &wxluatype_wxStandardPaths, NULL };
 static int LUACALL wxLua_wxStandardPaths_IgnoreAppBuildSubDirs(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_IgnoreAppBuildSubDirs[1] = {{ wxLua_wxStandardPaths_IgnoreAppBuildSubDirs, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStandardPaths_IgnoreAppBuildSubDirs }};
-//     %wxchkver_3_1_1 && %win void IgnoreAppBuildSubDirs();
+//     %wxchkver_3_0_0 && %win void IgnoreAppBuildSubDirs();
 static int LUACALL wxLua_wxStandardPaths_IgnoreAppBuildSubDirs(lua_State *L)
 {
     // get this
@@ -348,7 +348,7 @@ static int LUACALL wxLua_wxStandardPaths_IgnoreAppBuildSubDirs(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_IgnoreAppSubDir[] = { &wxluatype_wxStandardPaths, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxStandardPaths_IgnoreAppSubDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_IgnoreAppSubDir[1] = {{ wxLua_wxStandardPaths_IgnoreAppSubDir, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStandardPaths_IgnoreAppSubDir }};
-//     %wxchkver_3_1_1 && %win void IgnoreAppSubDir(const wxString& subdirPattern);
+//     %wxchkver_3_0_0 && %win void IgnoreAppSubDir(const wxString& subdirPattern);
 static int LUACALL wxLua_wxStandardPaths_IgnoreAppSubDir(lua_State *L)
 {
     // const wxString subdirPattern
@@ -364,7 +364,7 @@ static int LUACALL wxLua_wxStandardPaths_IgnoreAppSubDir(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_MSWGetShellDir[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStandardPaths_MSWGetShellDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_MSWGetShellDir[1] = {{ wxLua_wxStandardPaths_MSWGetShellDir, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxStandardPaths_MSWGetShellDir }};
-//     %wxchkver_3_1_1 && %win static wxString MSWGetShellDir(int csidl);
+//     %wxchkver_3_0_0 && %win static wxString MSWGetShellDir(int csidl);
 static int LUACALL wxLua_wxStandardPaths_MSWGetShellDir(lua_State *L)
 {
     // int csidl
@@ -377,13 +377,13 @@ static int LUACALL wxLua_wxStandardPaths_MSWGetShellDir(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_SetInstallPrefix[] = { &wxluatype_wxStandardPaths, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxStandardPaths_SetInstallPrefix(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_SetInstallPrefix[1] = {{ wxLua_wxStandardPaths_SetInstallPrefix, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStandardPaths_SetInstallPrefix }};
-//     %wxchkver_3_1_1 && %gtk void SetInstallPrefix(const wxString& prefix);
+//     %wxchkver_3_0_0 && %gtk void SetInstallPrefix(const wxString& prefix);
 static int LUACALL wxLua_wxStandardPaths_SetInstallPrefix(lua_State *L)
 {
     // const wxString prefix
@@ -396,13 +396,13 @@ static int LUACALL wxLua_wxStandardPaths_SetInstallPrefix(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStandardPaths_UseAppInfo[] = { &wxluatype_wxStandardPaths, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStandardPaths_UseAppInfo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStandardPaths_UseAppInfo[1] = {{ wxLua_wxStandardPaths_UseAppInfo, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStandardPaths_UseAppInfo }};
-//     %wxchkver_3_1_1 void UseAppInfo(int info);
+//     %wxchkver_3_0_0 void UseAppInfo(int info);
 static int LUACALL wxLua_wxStandardPaths_UseAppInfo(lua_State *L)
 {
     // int info
@@ -415,7 +415,7 @@ static int LUACALL wxLua_wxStandardPaths_UseAppInfo(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
 
 
 
@@ -427,24 +427,24 @@ void wxLua_wxStandardPaths_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxStandardPaths_methods[] = {
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
     { "DontIgnoreAppSubDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_DontIgnoreAppSubDir, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
 
     { "Get", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxStandardPaths_Get, 1, NULL },
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
     { "GetAppDocumentsDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetAppDocumentsDir, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
 
     { "GetConfigDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetConfigDir, 1, NULL },
     { "GetDataDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetDataDir, 1, NULL },
     { "GetDocumentsDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetDocumentsDir, 1, NULL },
     { "GetExecutablePath", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetExecutablePath, 1, NULL },
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
     { "GetInstallPrefix", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetInstallPrefix, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
 
     { "GetLocalDataDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetLocalDataDir, 1, NULL },
     { "GetLocalizedResourcesDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetLocalizedResourcesDir, 1, NULL },
@@ -454,25 +454,25 @@ wxLuaBindMethod wxStandardPaths_methods[] = {
     { "GetUserConfigDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetUserConfigDir, 1, NULL },
     { "GetUserDataDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetUserDataDir, 1, NULL },
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,0))
     { "GetUserDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetUserDir, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,0))
 
     { "GetUserLocalDataDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_GetUserLocalDataDir, 1, NULL },
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
     { "IgnoreAppBuildSubDirs", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_IgnoreAppBuildSubDirs, 1, NULL },
     { "IgnoreAppSubDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_IgnoreAppSubDir, 1, NULL },
     { "MSWGetShellDir", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxStandardPaths_MSWGetShellDir, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__))
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
     { "SetInstallPrefix", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_SetInstallPrefix, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1) && defined(__WXGTK__))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0) && defined(__WXGTK__))
 
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
     { "UseAppInfo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStandardPaths_UseAppInfo, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,0,0))
 
     { 0, 0, 0, 0 },
 };
@@ -480,18 +480,18 @@ wxLuaBindMethod wxStandardPaths_methods[] = {
 int wxStandardPaths_methodCount = sizeof(wxStandardPaths_methods)/sizeof(wxLuaBindMethod) - 1;
 
 wxLuaBindNumber wxStandardPaths_enums[] = {
-#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,0))
         { "Dir_Desktop", wxStandardPaths::Dir_Desktop },
         { "Dir_Documents", wxStandardPaths::Dir_Documents },
         { "Dir_Downloads", wxStandardPaths::Dir_Downloads },
         { "Dir_Music", wxStandardPaths::Dir_Music },
         { "Dir_Pictures", wxStandardPaths::Dir_Pictures },
         { "Dir_Videos", wxStandardPaths::Dir_Videos },
-#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths) && (wxCHECK_VERSION(3,1,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths)
         { "ResourceCat_Max", wxStandardPaths::ResourceCat_Max },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths)
 
 #if wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxStandardPaths
         { "ResourceCat_Messages", wxStandardPaths::ResourceCat_Messages },
@@ -830,11 +830,11 @@ static int LUACALL wxLua_wxFileName_Assign3(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Assign2[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_Assign2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Assign2[1] = {{ wxLua_wxFileName_Assign2, WXLUAMETHOD_METHOD, 6, 7, s_wxluatypeArray_wxLua_wxFileName_Assign2 }};
-//     %wxchkver_3_1_1 void Assign(const wxString& volume, const wxString& path, const wxString& name, const wxString& ext, bool hasExt, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 void Assign(const wxString& volume, const wxString& path, const wxString& name, const wxString& ext, bool hasExt, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_Assign2(lua_State *L)
 {
     // get number of arguments
@@ -859,7 +859,7 @@ static int LUACALL wxLua_wxFileName_Assign2(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Assign1[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_Assign1(lua_State *L);
@@ -1019,11 +1019,11 @@ static int LUACALL wxLua_wxFileName_ClearExt(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_CreateTempFileName1[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_CreateTempFileName1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_CreateTempFileName1[1] = {{ wxLua_wxFileName_CreateTempFileName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_CreateTempFileName1 }};
-//     !%wxchkver_3_1_1 && %wxchkver_2_8 && (wxUSE_FILE||wxUSE_FFILE) static wxString CreateTempFileName(const wxString& prefix);
+//     !%wxchkver_3_0_0 && %wxchkver_2_8 && (wxUSE_FILE||wxUSE_FFILE) static wxString CreateTempFileName(const wxString& prefix);
 static int LUACALL wxLua_wxFileName_CreateTempFileName1(lua_State *L)
 {
     // const wxString prefix
@@ -1036,7 +1036,7 @@ static int LUACALL wxLua_wxFileName_CreateTempFileName1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
 
 #if ((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_CreateTempFileName[] = { &wxluatype_TSTRING, &wxluatype_wxFile, NULL };
@@ -1092,11 +1092,11 @@ static int LUACALL wxLua_wxFileName_DirExists(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_DirName1[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_DirName1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_DirName1[1] = {{ wxLua_wxFileName_DirName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_DirName1 }};
-//     !%wxchkver_3_1_1 static wxFileName DirName(const wxString& dir);
+//     !%wxchkver_3_0_0 static wxFileName DirName(const wxString& dir);
 static int LUACALL wxLua_wxFileName_DirName1(lua_State *L)
 {
     // const wxString dir
@@ -1112,13 +1112,13 @@ static int LUACALL wxLua_wxFileName_DirName1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_DirName[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_DirName(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_DirName[1] = {{ wxLua_wxFileName_DirName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_DirName }};
-//     %wxchkver_3_1_1 static wxFileName DirName(const wxString& dir, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 static wxFileName DirName(const wxString& dir, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_DirName(lua_State *L)
 {
     // get number of arguments
@@ -1138,13 +1138,13 @@ static int LUACALL wxLua_wxFileName_DirName(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_DontFollowLink[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_DontFollowLink(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_DontFollowLink[1] = {{ wxLua_wxFileName_DontFollowLink, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFileName_DontFollowLink }};
-//     %wxchkver_3_1_1 void DontFollowLink();
+//     %wxchkver_3_0_0 void DontFollowLink();
 static int LUACALL wxLua_wxFileName_DontFollowLink(lua_State *L)
 {
     // get this
@@ -1158,7 +1158,7 @@ static int LUACALL wxLua_wxFileName_DontFollowLink(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Exists1[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_Exists1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Exists1[1] = {{ wxLua_wxFileName_Exists1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Exists1 }};
-//     %wxchkver_3_1_1 static bool Exists(const wxString& path, int flags = wxFILE_EXISTS_ANY);
+//     %wxchkver_3_0_0 static bool Exists(const wxString& path, int flags = wxFILE_EXISTS_ANY);
 static int LUACALL wxLua_wxFileName_Exists1(lua_State *L)
 {
     // get number of arguments
@@ -1178,7 +1178,7 @@ static int LUACALL wxLua_wxFileName_Exists1(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Exists[] = { &wxluatype_wxFileName, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_Exists(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Exists[1] = {{ wxLua_wxFileName_Exists, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Exists }};
-//     %wxchkver_3_1_1 bool Exists(int flags = wxFILE_EXISTS_ANY) const;
+//     %wxchkver_3_0_0 bool Exists(int flags = wxFILE_EXISTS_ANY) const;
 static int LUACALL wxLua_wxFileName_Exists(lua_State *L)
 {
     // get number of arguments
@@ -1195,7 +1195,7 @@ static int LUACALL wxLua_wxFileName_Exists(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_FileExists1[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_FileExists1(lua_State *L);
@@ -1230,11 +1230,11 @@ static int LUACALL wxLua_wxFileName_FileExists(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_FileName1[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_FileName1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_FileName1[1] = {{ wxLua_wxFileName_FileName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_FileName1 }};
-//     !%wxchkver_3_1_1 static wxFileName FileName(const wxString& file);
+//     !%wxchkver_3_0_0 static wxFileName FileName(const wxString& file);
 static int LUACALL wxLua_wxFileName_FileName1(lua_State *L)
 {
     // const wxString file
@@ -1250,13 +1250,13 @@ static int LUACALL wxLua_wxFileName_FileName1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_FileName[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_FileName(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_FileName[1] = {{ wxLua_wxFileName_FileName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_FileName }};
-//     %wxchkver_3_1_1 static wxFileName FileName(const wxString& file, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 static wxFileName FileName(const wxString& file, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_FileName(lua_State *L)
 {
     // get number of arguments
@@ -1276,7 +1276,7 @@ static int LUACALL wxLua_wxFileName_FileName(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetCwd[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_GetCwd(lua_State *L);
@@ -1436,11 +1436,11 @@ static int LUACALL wxLua_wxFileName_GetHomeDir(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize3[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize3[1] = {{ wxLua_wxFileName_GetHumanReadableSize3, WXLUAMETHOD_METHOD, 1, 4, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize3 }};
-//     %wxchkver_3_1_1 wxString GetHumanReadableSize(const wxString& failmsg = "Not available", int precision = 1, wxSizeConvention conv = wxSIZE_CONV_TRADITIONAL) const; // %override to remote _() as it's not handled by wxlua
+//     %wxchkver_3_0_0 wxString GetHumanReadableSize(const wxString& failmsg = "Not available", int precision = 1, wxSizeConvention conv = wxSIZE_CONV_TRADITIONAL) const; // %override to remote _() as it's not handled by wxlua
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize3(lua_State *L)
 {
     // get number of arguments
@@ -1461,13 +1461,13 @@ static int LUACALL wxLua_wxFileName_GetHumanReadableSize3(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize2[] = { &wxluatype_wxULongLong, &wxluatype_TSTRING, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize2[1] = {{ wxLua_wxFileName_GetHumanReadableSize2, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 4, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize2 }};
-//     %wxchkver_3_1_1 static wxString GetHumanReadableSize(const wxULongLong& bytes, const wxString& nullsize = "Not available", int precision = 1, wxSizeConvention conv = wxSIZE_CONV_TRADITIONAL); // %override to remote _() as it's not handled by wxlua
+//     %wxchkver_3_0_0 static wxString GetHumanReadableSize(const wxULongLong& bytes, const wxString& nullsize = "Not available", int precision = 1, wxSizeConvention conv = wxSIZE_CONV_TRADITIONAL); // %override to remote _() as it's not handled by wxlua
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize2(lua_State *L)
 {
     // get number of arguments
@@ -1488,13 +1488,13 @@ static int LUACALL wxLua_wxFileName_GetHumanReadableSize2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 
-#if (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize1[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize1[1] = {{ wxLua_wxFileName_GetHumanReadableSize1, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize1 }};
-//     !%wxchkver_3_1_1 && %wxchkver_2_8 wxString GetHumanReadableSize(const wxString &nullsize = "Not available", int precision = 1) const;
+//     !%wxchkver_3_0_0 && %wxchkver_2_8 wxString GetHumanReadableSize(const wxString &nullsize = "Not available", int precision = 1) const;
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize1(lua_State *L)
 {
     // get number of arguments
@@ -1513,13 +1513,13 @@ static int LUACALL wxLua_wxFileName_GetHumanReadableSize1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize[] = { &wxluatype_wxULongLong, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize[1] = {{ wxLua_wxFileName_GetHumanReadableSize, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 3, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize }};
-//     !%wxchkver_3_1_1 && %wxchkver_2_8 static wxString GetHumanReadableSize(const wxULongLong &sz, const wxString &nullsize = "Not available", int precision = 1);
+//     !%wxchkver_3_0_0 && %wxchkver_2_8 static wxString GetHumanReadableSize(const wxULongLong &sz, const wxString &nullsize = "Not available", int precision = 1);
 static int LUACALL wxLua_wxFileName_GetHumanReadableSize(lua_State *L)
 {
     // get number of arguments
@@ -1538,7 +1538,7 @@ static int LUACALL wxLua_wxFileName_GetHumanReadableSize(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetLongPath[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_GetLongPath(lua_State *L);
@@ -1749,10 +1749,10 @@ static int LUACALL wxLua_wxFileName_GetSize(lua_State *L)
 
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static int LUACALL wxLua_wxFileName_GetTempDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetTempDir[1] = {{ wxLua_wxFileName_GetTempDir, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 static wxString GetTempDir();
+//     %wxchkver_3_0_0 static wxString GetTempDir();
 static int LUACALL wxLua_wxFileName_GetTempDir(lua_State *L)
 {
     // call GetTempDir
@@ -1763,7 +1763,7 @@ static int LUACALL wxLua_wxFileName_GetTempDir(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetTimes[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_GetTimes(lua_State *L);
@@ -1829,11 +1829,11 @@ static int LUACALL wxLua_wxFileName_GetVolumeSeparator(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_GetVolumeString[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_GetVolumeString(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetVolumeString[1] = {{ wxLua_wxFileName_GetVolumeString, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_GetVolumeString }};
-//     %wxchkver_3_1_1 && %win static wxString GetVolumeString(char drive, int flags = wxPATH_GET_SEPARATOR); // %override as it's win-only
+//     %wxchkver_3_0_0 && %win static wxString GetVolumeString(char drive, int flags = wxPATH_GET_SEPARATOR); // %override as it's win-only
 static int LUACALL wxLua_wxFileName_GetVolumeString(lua_State *L)
 {
     // get number of arguments
@@ -1850,7 +1850,7 @@ static int LUACALL wxLua_wxFileName_GetVolumeString(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_HasExt[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_HasExt(lua_State *L);
@@ -1901,11 +1901,11 @@ static int LUACALL wxLua_wxFileName_HasVolume(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_InsertDir1[] = { &wxluatype_wxFileName, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_InsertDir1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_InsertDir1[1] = {{ wxLua_wxFileName_InsertDir1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxFileName_InsertDir1 }};
-//     !%wxchkver_3_1_1 void InsertDir(int before, const wxString& dir);
+//     !%wxchkver_3_0_0 void InsertDir(int before, const wxString& dir);
 static int LUACALL wxLua_wxFileName_InsertDir1(lua_State *L)
 {
     // const wxString dir
@@ -1920,13 +1920,13 @@ static int LUACALL wxLua_wxFileName_InsertDir1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_InsertDir[] = { &wxluatype_wxFileName, &wxluatype_TINTEGER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_InsertDir(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_InsertDir[1] = {{ wxLua_wxFileName_InsertDir, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxFileName_InsertDir }};
-//     %wxchkver_3_1_1 bool InsertDir(size_t before, const wxString& dir);
+//     %wxchkver_3_0_0 bool InsertDir(size_t before, const wxString& dir);
 static int LUACALL wxLua_wxFileName_InsertDir(lua_State *L)
 {
     // const wxString dir
@@ -1943,7 +1943,7 @@ static int LUACALL wxLua_wxFileName_InsertDir(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_IsAbsolute[] = { &wxluatype_wxFileName, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_IsAbsolute(lua_State *L);
@@ -2163,11 +2163,11 @@ static int LUACALL wxLua_wxFileName_IsFileWritable(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_IsMSWUniqueVolumeNamePath[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_IsMSWUniqueVolumeNamePath(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_IsMSWUniqueVolumeNamePath[1] = {{ wxLua_wxFileName_IsMSWUniqueVolumeNamePath, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_IsMSWUniqueVolumeNamePath }};
-//     %wxchkver_3_1_1 && %win static bool IsMSWUniqueVolumeNamePath(const wxString& path, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 && %win static bool IsMSWUniqueVolumeNamePath(const wxString& path, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_IsMSWUniqueVolumeNamePath(lua_State *L)
 {
     // get number of arguments
@@ -2184,7 +2184,7 @@ static int LUACALL wxLua_wxFileName_IsMSWUniqueVolumeNamePath(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_IsOk[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_IsOk(lua_State *L);
@@ -2203,11 +2203,11 @@ static int LUACALL wxLua_wxFileName_IsOk(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_IsPathSeparator1[] = { &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_IsPathSeparator1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_IsPathSeparator1[1] = {{ wxLua_wxFileName_IsPathSeparator1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_IsPathSeparator1 }};
-//     !%wxchkver_3_1_1 static bool IsPathSeparator(int ch, wxPathFormat format = wxPATH_NATIVE);
+//     !%wxchkver_3_0_0 static bool IsPathSeparator(int ch, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_IsPathSeparator1(lua_State *L)
 {
     // get number of arguments
@@ -2224,13 +2224,13 @@ static int LUACALL wxLua_wxFileName_IsPathSeparator1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_IsPathSeparator[] = { &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_IsPathSeparator(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_IsPathSeparator[1] = {{ wxLua_wxFileName_IsPathSeparator, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_IsPathSeparator }};
-//     %wxchkver_3_1_1 static bool IsPathSeparator(wxChar ch, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 static bool IsPathSeparator(wxChar ch, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_IsPathSeparator(lua_State *L)
 {
     // get number of arguments
@@ -2247,7 +2247,7 @@ static int LUACALL wxLua_wxFileName_IsPathSeparator(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_IsRelative[] = { &wxluatype_wxFileName, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_IsRelative(lua_State *L);
@@ -2398,11 +2398,11 @@ static int LUACALL wxLua_wxFileName_PrependDir(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_RemoveDir1[] = { &wxluatype_wxFileName, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_RemoveDir1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_RemoveDir1[1] = {{ wxLua_wxFileName_RemoveDir1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_RemoveDir1 }};
-//     !%wxchkver_3_1_1 void RemoveDir(int pos);
+//     !%wxchkver_3_0_0 void RemoveDir(int pos);
 static int LUACALL wxLua_wxFileName_RemoveDir1(lua_State *L)
 {
     // int pos
@@ -2415,13 +2415,13 @@ static int LUACALL wxLua_wxFileName_RemoveDir1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_RemoveDir[] = { &wxluatype_wxFileName, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_RemoveDir(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_RemoveDir[1] = {{ wxLua_wxFileName_RemoveDir, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_RemoveDir }};
-//     %wxchkver_3_1_1 void RemoveDir(size_t pos);
+//     %wxchkver_3_0_0 void RemoveDir(size_t pos);
 static int LUACALL wxLua_wxFileName_RemoveDir(lua_State *L)
 {
     // size_t pos
@@ -2434,7 +2434,7 @@ static int LUACALL wxLua_wxFileName_RemoveDir(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_RemoveLastDir[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_RemoveLastDir(lua_State *L);
@@ -2451,11 +2451,11 @@ static int LUACALL wxLua_wxFileName_RemoveLastDir(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_ReplaceEnvVariable[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_ReplaceEnvVariable(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_ReplaceEnvVariable[1] = {{ wxLua_wxFileName_ReplaceEnvVariable, WXLUAMETHOD_METHOD, 2, 4, s_wxluatypeArray_wxLua_wxFileName_ReplaceEnvVariable }};
-//     %wxchkver_3_1_1 bool ReplaceEnvVariable(const wxString& envname, const wxString& replacementFmtString = "$%s", wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 bool ReplaceEnvVariable(const wxString& envname, const wxString& replacementFmtString = "$%s", wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_ReplaceEnvVariable(lua_State *L)
 {
     // get number of arguments
@@ -2479,7 +2479,7 @@ static int LUACALL wxLua_wxFileName_ReplaceEnvVariable(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_ReplaceHomeDir[] = { &wxluatype_wxFileName, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_ReplaceHomeDir(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_ReplaceHomeDir[1] = {{ wxLua_wxFileName_ReplaceHomeDir, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFileName_ReplaceHomeDir }};
-//     %wxchkver_3_1_1 bool ReplaceHomeDir(wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 bool ReplaceHomeDir(wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_ReplaceHomeDir(lua_State *L)
 {
     // get number of arguments
@@ -2496,13 +2496,13 @@ static int LUACALL wxLua_wxFileName_ReplaceHomeDir(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Rmdir3[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_Rmdir3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Rmdir3[1] = {{ wxLua_wxFileName_Rmdir3, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_Rmdir3 }};
-//     !%wxchkver_3_1_1 static bool Rmdir(const wxString& dir);
+//     !%wxchkver_3_0_0 static bool Rmdir(const wxString& dir);
 static int LUACALL wxLua_wxFileName_Rmdir3(lua_State *L)
 {
     // const wxString dir
@@ -2518,7 +2518,7 @@ static int LUACALL wxLua_wxFileName_Rmdir3(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Rmdir2[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_Rmdir2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Rmdir2[1] = {{ wxLua_wxFileName_Rmdir2, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFileName_Rmdir2 }};
-//     !%wxchkver_3_1_1 bool Rmdir();
+//     !%wxchkver_3_0_0 bool Rmdir();
 static int LUACALL wxLua_wxFileName_Rmdir2(lua_State *L)
 {
     // get this
@@ -2531,13 +2531,13 @@ static int LUACALL wxLua_wxFileName_Rmdir2(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Rmdir1[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_Rmdir1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Rmdir1[1] = {{ wxLua_wxFileName_Rmdir1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Rmdir1 }};
-//     %wxchkver_3_1_1 static bool Rmdir(const wxString& dir, int flags = 0);
+//     %wxchkver_3_0_0 static bool Rmdir(const wxString& dir, int flags = 0);
 static int LUACALL wxLua_wxFileName_Rmdir1(lua_State *L)
 {
     // get number of arguments
@@ -2557,7 +2557,7 @@ static int LUACALL wxLua_wxFileName_Rmdir1(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Rmdir[] = { &wxluatype_wxFileName, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_Rmdir(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Rmdir[1] = {{ wxLua_wxFileName_Rmdir, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Rmdir }};
-//     %wxchkver_3_1_1 bool Rmdir(int flags = 0) const;
+//     %wxchkver_3_0_0 bool Rmdir(int flags = 0) const;
 static int LUACALL wxLua_wxFileName_Rmdir(lua_State *L)
 {
     // get number of arguments
@@ -2574,7 +2574,7 @@ static int LUACALL wxLua_wxFileName_Rmdir(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_SameAs[] = { &wxluatype_wxFileName, &wxluatype_wxFileName, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_SameAs(lua_State *L);
@@ -2693,11 +2693,11 @@ static int LUACALL wxLua_wxFileName_SetName(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_SetPath[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_SetPath(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_SetPath[1] = {{ wxLua_wxFileName_SetPath, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxFileName_SetPath }};
-//     %wxchkver_3_1_1 void SetPath(const wxString& path, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 void SetPath(const wxString& path, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_SetPath(lua_State *L)
 {
     // get number of arguments
@@ -2714,13 +2714,13 @@ static int LUACALL wxLua_wxFileName_SetPath(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_SetPermissions[] = { &wxluatype_wxFileName, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFileName_SetPermissions(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_SetPermissions[1] = {{ wxLua_wxFileName_SetPermissions, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_SetPermissions }};
-//     %wxchkver_3_1_1 bool SetPermissions(int permissions);
+//     %wxchkver_3_0_0 bool SetPermissions(int permissions);
 static int LUACALL wxLua_wxFileName_SetPermissions(lua_State *L)
 {
     // int permissions
@@ -2735,7 +2735,7 @@ static int LUACALL wxLua_wxFileName_SetPermissions(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 #if (wxLUA_USE_wxDateTime && wxUSE_DATETIME) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_SetTimes[] = { &wxluatype_wxFileName, &wxluatype_wxDateTime, &wxluatype_wxDateTime, &wxluatype_wxDateTime, NULL };
@@ -2779,11 +2779,11 @@ static int LUACALL wxLua_wxFileName_SetVolume(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_ShouldFollowLink[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_ShouldFollowLink(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_ShouldFollowLink[1] = {{ wxLua_wxFileName_ShouldFollowLink, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFileName_ShouldFollowLink }};
-//     %wxchkver_3_1_1 bool ShouldFollowLink() const;
+//     %wxchkver_3_0_0 bool ShouldFollowLink() const;
 static int LUACALL wxLua_wxFileName_ShouldFollowLink(lua_State *L)
 {
     // get this
@@ -2796,7 +2796,7 @@ static int LUACALL wxLua_wxFileName_ShouldFollowLink(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_SplitPath[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_SplitPath(lua_State *L);
@@ -2879,11 +2879,11 @@ static int LUACALL wxLua_wxFileName_SplitVolume(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_StripExtension[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_StripExtension(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_StripExtension[1] = {{ wxLua_wxFileName_StripExtension, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_StripExtension }};
-//     %wxchkver_3_1_1 static wxString StripExtension(const wxString& fullname);
+//     %wxchkver_3_0_0 static wxString StripExtension(const wxString& fullname);
 static int LUACALL wxLua_wxFileName_StripExtension(lua_State *L)
 {
     // const wxString fullname
@@ -2896,7 +2896,7 @@ static int LUACALL wxLua_wxFileName_StripExtension(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_Touch[] = { &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_Touch(lua_State *L);
@@ -2918,11 +2918,11 @@ static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_delete[] = { &wxluatype_wx
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxFileName_delete }};
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_op_eq1[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_op_eq1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_eq1[1] = {{ wxLua_wxFileName_op_eq1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_eq1 }};
-//     %wxchkver_3_1_1 bool operator==(const wxString& filename) const;
+//     %wxchkver_3_0_0 bool operator==(const wxString& filename) const;
 static int LUACALL wxLua_wxFileName_op_eq1(lua_State *L)
 {
     // const wxString filename
@@ -2937,7 +2937,7 @@ static int LUACALL wxLua_wxFileName_op_eq1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_op_eq[] = { &wxluatype_wxFileName, &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_op_eq(lua_State *L);
@@ -2958,11 +2958,11 @@ static int LUACALL wxLua_wxFileName_op_eq(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_op_ne1[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_op_ne1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_ne1[1] = {{ wxLua_wxFileName_op_ne1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_ne1 }};
-//     %wxchkver_3_1_1 bool operator!=(const wxString& filename) const;
+//     %wxchkver_3_0_0 bool operator!=(const wxString& filename) const;
 static int LUACALL wxLua_wxFileName_op_ne1(lua_State *L)
 {
     // const wxString filename
@@ -2977,13 +2977,13 @@ static int LUACALL wxLua_wxFileName_op_ne1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_op_ne[] = { &wxluatype_wxFileName, &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_op_ne(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_ne[1] = {{ wxLua_wxFileName_op_ne, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_ne }};
-//     %wxchkver_3_1_1 bool operator!=(const wxFileName& filename) const;
+//     %wxchkver_3_0_0 bool operator!=(const wxFileName& filename) const;
 static int LUACALL wxLua_wxFileName_op_ne(lua_State *L)
 {
     // const wxFileName filename
@@ -3001,7 +3001,7 @@ static int LUACALL wxLua_wxFileName_op_ne(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_op_set1[] = { &wxluatype_wxFileName, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFileName_op_set1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_set1[1] = {{ wxLua_wxFileName_op_set1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_set1 }};
-//     %wxchkver_3_1_1 wxFileName& operator=(const wxString& filename);
+//     %wxchkver_3_0_0 wxFileName& operator=(const wxString& filename);
 static int LUACALL wxLua_wxFileName_op_set1(lua_State *L)
 {
     // const wxString filename
@@ -3017,7 +3017,7 @@ static int LUACALL wxLua_wxFileName_op_set1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_op_set[] = { &wxluatype_wxFileName, &wxluatype_wxFileName, NULL };
 static int LUACALL wxLua_wxFileName_op_set(lua_State *L);
@@ -3067,11 +3067,11 @@ static int LUACALL wxLua_wxFileName_constructor5(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_constructor4[] = { &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_constructor4[1] = {{ wxLua_wxFileName_constructor4, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxFileName_constructor4 }};
-//     %wxchkver_3_1_1 wxFileName(const wxString& path, const wxString& name, const wxString& ext, wxPathFormat format = wxPATH_NATIVE);
+//     %wxchkver_3_0_0 wxFileName(const wxString& path, const wxString& name, const wxString& ext, wxPathFormat format = wxPATH_NATIVE);
 static int LUACALL wxLua_wxFileName_constructor4(lua_State *L)
 {
     // get number of arguments
@@ -3094,7 +3094,7 @@ static int LUACALL wxLua_wxFileName_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFileName_constructor3[] = { &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFileName_constructor3(lua_State *L);
@@ -3178,7 +3178,7 @@ static int LUACALL wxLua_wxFileName_constructor(lua_State *L)
 
 
 
-#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Assign_overload[] =
 {
@@ -3186,15 +3186,15 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Assign_overload[] =
     { wxLua_wxFileName_Assign4, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxFileName_Assign4 },
     { wxLua_wxFileName_Assign3, WXLUAMETHOD_METHOD, 5, 6, s_wxluatypeArray_wxLua_wxFileName_Assign3 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Assign2, WXLUAMETHOD_METHOD, 6, 7, s_wxluatypeArray_wxLua_wxFileName_Assign2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Assign1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxFileName_Assign1 },
     { wxLua_wxFileName_Assign, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_Assign },
 };
 static int s_wxluafunc_wxLua_wxFileName_Assign_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_Assign_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
 #if (((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))||((wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))
 // function overload table
@@ -3213,14 +3213,14 @@ static int s_wxluafunc_wxLua_wxFileName_AssignTempFileName_overload_count = size
 
 #endif // (((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))||((wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_CreateTempFileName_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_CreateTempFileName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_CreateTempFileName1 },
-#endif // (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName)
 
 #if ((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE)
     { wxLua_wxFileName_CreateTempFileName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxFileName_CreateTempFileName },
@@ -3228,7 +3228,7 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_CreateTempFileName_overload[]
 };
 static int s_wxluafunc_wxLua_wxFileName_CreateTempFileName_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_CreateTempFileName_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
 
 #if (wxLUA_USE_wxFileName)
 // function overload table
@@ -3241,39 +3241,39 @@ static int s_wxluafunc_wxLua_wxFileName_DirExists_overload_count = sizeof(s_wxlu
 
 #endif // (wxLUA_USE_wxFileName)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_DirName_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_DirName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_DirName1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_DirName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_DirName },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_DirName_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_DirName_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Exists_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Exists1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Exists1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Exists, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Exists },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_Exists_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_Exists_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
 #if (wxLUA_USE_wxFileName)
 // function overload table
@@ -3286,47 +3286,47 @@ static int s_wxluafunc_wxLua_wxFileName_FileExists_overload_count = sizeof(s_wxl
 
 #endif // (wxLUA_USE_wxFileName)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_FileName_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_FileName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_FileName1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_FileName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_FileName },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_FileName_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_FileName_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_GetHumanReadableSize3, WXLUAMETHOD_METHOD, 1, 4, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize3 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
     { wxLua_wxFileName_GetHumanReadableSize2, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 4, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 
-#if (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_GetHumanReadableSize1, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize1 },
-#endif // (!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
     { wxLua_wxFileName_GetHumanReadableSize, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 3, s_wxluatypeArray_wxLua_wxFileName_GetHumanReadableSize },
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG)
 };
 static int s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
 
 #if (((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
 // function overload table
@@ -3345,22 +3345,22 @@ static int s_wxluafunc_wxLua_wxFileName_GetSize_overload_count = sizeof(s_wxluaf
 
 #endif // (((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_InsertDir_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_InsertDir1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxFileName_InsertDir1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_InsertDir, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxFileName_InsertDir },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_InsertDir_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_InsertDir_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
 #if ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))
 // function overload table
@@ -3435,22 +3435,22 @@ static int s_wxluafunc_wxLua_wxFileName_IsFileWritable_overload_count = sizeof(s
 
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_IsPathSeparator_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_IsPathSeparator1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_IsPathSeparator1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_IsPathSeparator, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_IsPathSeparator },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_IsPathSeparator_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_IsPathSeparator_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
 #if (wxLUA_USE_wxFileName)
 // function overload table
@@ -3463,18 +3463,18 @@ static int s_wxluafunc_wxLua_wxFileName_Mkdir_overload_count = sizeof(s_wxluafun
 
 #endif // (wxLUA_USE_wxFileName)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_RemoveDir_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_RemoveDir1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_RemoveDir1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_RemoveDir, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_RemoveDir },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_RemoveDir_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_RemoveDir_overload)/sizeof(wxLuaBindCFunc);
 
@@ -3482,25 +3482,25 @@ static int s_wxluafunc_wxLua_wxFileName_RemoveDir_overload_count = sizeof(s_wxlu
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_Rmdir_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Rmdir3, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxFileName_Rmdir3 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Rmdir2, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFileName_Rmdir2 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Rmdir1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Rmdir1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_Rmdir, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFileName_Rmdir },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_Rmdir_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_Rmdir_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
 #if (wxLUA_USE_wxFileName)
 // function overload table
@@ -3513,60 +3513,60 @@ static int s_wxluafunc_wxLua_wxFileName_SetCwd_overload_count = sizeof(s_wxluafu
 
 #endif // (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_eq_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_op_eq1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_eq1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_op_eq, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_eq },
 };
 static int s_wxluafunc_wxLua_wxFileName_op_eq_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_op_eq_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_ne_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_op_ne1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_ne1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_op_ne, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_ne },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 };
 static int s_wxluafunc_wxLua_wxFileName_op_ne_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_op_ne_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_op_set_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_op_set1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_set1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_op_set, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFileName_op_set },
 };
 static int s_wxluafunc_wxLua_wxFileName_op_set_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_op_set_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
 
-#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_constructor_overload[] =
 {
     { wxLua_wxFileName_constructor5, WXLUAMETHOD_CONSTRUCTOR, 4, 5, s_wxluatypeArray_wxLua_wxFileName_constructor5 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_constructor4, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxFileName_constructor4 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { wxLua_wxFileName_constructor3, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxFileName_constructor3 },
     { wxLua_wxFileName_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxFileName_constructor2 },
     { wxLua_wxFileName_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFileName_constructor1 },
@@ -3574,7 +3574,7 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxFileName_constructor_overload[] =
 };
 static int s_wxluafunc_wxLua_wxFileName_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxFileName_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
 void wxLua_wxFileName_delete_function(void** p)
 {
@@ -3586,9 +3586,9 @@ void wxLua_wxFileName_delete_function(void** p)
 wxLuaBindMethod wxFileName_methods[] = {
     { "AppendDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_AppendDir, 1, NULL },
 
-#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
     { "Assign", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_Assign_overload, s_wxluafunc_wxLua_wxFileName_Assign_overload_count, 0 },
-#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
     { "AssignCwd", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_AssignCwd, 1, NULL },
     { "AssignDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_AssignDir, 1, NULL },
@@ -3601,33 +3601,33 @@ wxLuaBindMethod wxFileName_methods[] = {
     { "Clear", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_Clear, 1, NULL },
     { "ClearExt", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_ClearExt, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
     { "CreateTempFileName", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_CreateTempFileName_overload, s_wxluafunc_wxLua_wxFileName_CreateTempFileName_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0) && (wxUSE_FILE || wxUSE_FFILE )) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(2,8,0) && wxUSE_FILE) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFile && wxUSE_FILE))
 
 #if (wxLUA_USE_wxFileName)
     { "DirExists", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_DirExists_overload, s_wxluafunc_wxLua_wxFileName_DirExists_overload_count, 0 },
 #endif // (wxLUA_USE_wxFileName)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
     { "DirName", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_DirName_overload, s_wxluafunc_wxLua_wxFileName_DirName_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { "DontFollowLink", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_DontFollowLink, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
     { "Exists", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_Exists_overload, s_wxluafunc_wxLua_wxFileName_Exists_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
 #if (wxLUA_USE_wxFileName)
     { "FileExists", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_FileExists_overload, s_wxluafunc_wxLua_wxFileName_FileExists_overload_count, 0 },
 #endif // (wxLUA_USE_wxFileName)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
     { "FileName", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_FileName_overload, s_wxluafunc_wxLua_wxFileName_FileName_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
     { "GetCwd", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetCwd, 1, NULL },
     { "GetDirCount", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_GetDirCount, 1, NULL },
@@ -3643,9 +3643,9 @@ wxLuaBindMethod wxFileName_methods[] = {
     { "GetFullPath", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_GetFullPath, 1, NULL },
     { "GetHomeDir", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetHomeDir, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
     { "GetHumanReadableSize", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize_overload, s_wxluafunc_wxLua_wxFileName_GetHumanReadableSize_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))||((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))||(((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
 
     { "GetLongPath", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_GetLongPath, 1, NULL },
 
@@ -3665,25 +3665,25 @@ wxLuaBindMethod wxFileName_methods[] = {
     { "GetSize", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetSize_overload, s_wxluafunc_wxLua_wxFileName_GetSize_overload_count, 0 },
 #endif // (((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName)) && (wxUSE_LONGLONG))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { "GetTempDir", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetTempDir, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
     { "GetTimes", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_GetTimes, 1, NULL },
     { "GetVolume", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_GetVolume, 1, NULL },
     { "GetVolumeSeparator", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetVolumeSeparator, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
     { "GetVolumeString", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_GetVolumeString, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)
 
     { "HasExt", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_HasExt, 1, NULL },
     { "HasName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_HasName, 1, NULL },
     { "HasVolume", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_HasVolume, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
     { "InsertDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_InsertDir_overload, s_wxluafunc_wxLua_wxFileName_InsertDir_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
     { "IsAbsolute", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_IsAbsolute, 1, NULL },
     { "IsCaseSensitive", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_IsCaseSensitive, 1, NULL },
@@ -3697,15 +3697,15 @@ wxLuaBindMethod wxFileName_methods[] = {
     { "IsFileWritable", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_IsFileWritable_overload, s_wxluafunc_wxLua_wxFileName_IsFileWritable_overload_count, 0 },
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFileName))
 
-#if ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { "IsMSWUniqueVolumeNamePath", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_IsMSWUniqueVolumeNamePath, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_IsOk, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
     { "IsPathSeparator", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_IsPathSeparator_overload, s_wxluafunc_wxLua_wxFileName_IsPathSeparator_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
     { "IsRelative", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_IsRelative, 1, NULL },
     { "MakeAbsolute", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_MakeAbsolute, 1, NULL },
@@ -3718,20 +3718,20 @@ wxLuaBindMethod wxFileName_methods[] = {
     { "Normalize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_Normalize, 1, NULL },
     { "PrependDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_PrependDir, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
     { "RemoveDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_RemoveDir_overload, s_wxluafunc_wxLua_wxFileName_RemoveDir_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
     { "RemoveLastDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_RemoveLastDir, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { "ReplaceEnvVariable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_ReplaceEnvVariable, 1, NULL },
     { "ReplaceHomeDir", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_ReplaceHomeDir, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
     { "Rmdir", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_Rmdir_overload, s_wxluafunc_wxLua_wxFileName_Rmdir_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))
 
     { "SameAs", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SameAs, 1, NULL },
 
@@ -3744,13 +3744,13 @@ wxLuaBindMethod wxFileName_methods[] = {
     { "SetFullName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SetFullName, 1, NULL },
     { "SetName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SetName, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
     { "SetPath", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SetPath, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { "SetPermissions", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SetPermissions, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
 #if (wxLUA_USE_wxDateTime && wxUSE_DATETIME) && (wxLUA_USE_wxFileName)
     { "SetTimes", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SetTimes, 1, NULL },
@@ -3758,36 +3758,36 @@ wxLuaBindMethod wxFileName_methods[] = {
 
     { "SetVolume", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_SetVolume, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { "ShouldFollowLink", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_ShouldFollowLink, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
     { "SplitPath", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_SplitPath, 1, NULL },
     { "SplitPathVolume", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_SplitPathVolume, 1, NULL },
     { "SplitVolume", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_SplitVolume, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
     { "StripExtension", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFileName_StripExtension, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)
 
     { "Touch", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_Touch, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxFileName_delete, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
     { "op_eq", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_op_eq_overload, s_wxluafunc_wxLua_wxFileName_op_eq_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
     { "op_ne", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_op_ne_overload, s_wxluafunc_wxLua_wxFileName_op_ne_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFileName_op_set_overload, s_wxluafunc_wxLua_wxFileName_op_set_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))||(wxLUA_USE_wxFileName)
 
-#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#if (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
     { "wxFileName", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxFileName_constructor_overload, s_wxluafunc_wxLua_wxFileName_constructor_overload_count, 0 },
-#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
+#endif // (wxLUA_USE_wxFileName)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFileName)) && (wxLUA_USE_wxFileName))
 
     { 0, 0, 0, 0 },
 };
@@ -4507,11 +4507,11 @@ int wxTempFile_methodCount = sizeof(wxTempFile_methods)/sizeof(wxLuaBindMethod) 
 // Lua MetaTable Tag for Class 'wxDir'
 int wxluatype_wxDir = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_Close[] = { &wxluatype_wxDir, NULL };
 static int LUACALL wxLua_wxDir_Close(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDir_Close[1] = {{ wxLua_wxDir_Close, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxDir_Close }};
-//     %wxchkver_3_1_1 void Close();
+//     %wxchkver_3_0_0 void Close();
 static int LUACALL wxLua_wxDir_Close(lua_State *L)
 {
     // get this
@@ -4522,7 +4522,7 @@ static int LUACALL wxLua_wxDir_Close(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_Exists[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxDir_Exists(lua_State *L);
@@ -4637,11 +4637,11 @@ static int LUACALL wxLua_wxDir_GetName(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_GetNameWithSep[] = { &wxluatype_wxDir, NULL };
 static int LUACALL wxLua_wxDir_GetNameWithSep(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDir_GetNameWithSep[1] = {{ wxLua_wxDir_GetNameWithSep, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxDir_GetNameWithSep }};
-//     %wxchkver_3_1_1 wxString GetNameWithSep() const;
+//     %wxchkver_3_0_0 wxString GetNameWithSep() const;
 static int LUACALL wxLua_wxDir_GetNameWithSep(lua_State *L)
 {
     // get this
@@ -4654,7 +4654,7 @@ static int LUACALL wxLua_wxDir_GetNameWithSep(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_GetNext[] = { &wxluatype_wxDir, NULL };
 static int LUACALL wxLua_wxDir_GetNext(lua_State *L);
@@ -4757,11 +4757,11 @@ static int LUACALL wxLua_wxDir_IsOpened(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_Make[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxDir_Make(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDir_Make[1] = {{ wxLua_wxDir_Make, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 3, s_wxluatypeArray_wxLua_wxDir_Make }};
-//     %wxchkver_3_1_1 static bool Make(const wxString &dir, int perm = wxS_DIR_DEFAULT, int flags = 0);
+//     %wxchkver_3_0_0 static bool Make(const wxString &dir, int perm = wxS_DIR_DEFAULT, int flags = 0);
 static int LUACALL wxLua_wxDir_Make(lua_State *L)
 {
     // get number of arguments
@@ -4780,7 +4780,7 @@ static int LUACALL wxLua_wxDir_Make(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_Open[] = { &wxluatype_wxDir, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxDir_Open(lua_State *L);
@@ -4801,11 +4801,11 @@ static int LUACALL wxLua_wxDir_Open(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_Remove[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxDir_Remove(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDir_Remove[1] = {{ wxLua_wxDir_Remove, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxDir_Remove }};
-//     %wxchkver_3_1_1 static bool Remove(const wxString &dir, int flags = 0);
+//     %wxchkver_3_0_0 static bool Remove(const wxString &dir, int flags = 0);
 static int LUACALL wxLua_wxDir_Remove(lua_State *L)
 {
     // get number of arguments
@@ -4822,7 +4822,7 @@ static int LUACALL wxLua_wxDir_Remove(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDir_delete[] = { &wxluatype_wxDir, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDir_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxDir_delete }};
@@ -4882,9 +4882,9 @@ void wxLua_wxDir_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxDir_methods[] = {
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
     { "Close", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_Close, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
     { "Exists", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxDir_Exists, 1, NULL },
 
@@ -4896,9 +4896,9 @@ wxLuaBindMethod wxDir_methods[] = {
     { "GetFirst", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_GetFirst, 1, NULL },
     { "GetName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_GetName, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
     { "GetNameWithSep", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_GetNameWithSep, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
     { "GetNext", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_GetNext, 1, NULL },
 
@@ -4910,15 +4910,15 @@ wxLuaBindMethod wxDir_methods[] = {
     { "HasSubDirs", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_HasSubDirs, 1, NULL },
     { "IsOpened", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_IsOpened, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
     { "Make", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxDir_Make, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
     { "Open", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDir_Open, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
     { "Remove", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxDir_Remove, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDir)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDir)
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxDir_delete, 1, NULL },
 

--- a/wxLua/modules/wxbind/src/wxcore_appframe.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_appframe.cpp
@@ -37,11 +37,11 @@
 // Lua MetaTable Tag for Class 'wxAppConsole'
 int wxluatype_wxAppConsole = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_DeletePendingEvents[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_DeletePendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_DeletePendingEvents[1] = {{ wxLua_wxAppConsole_DeletePendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_DeletePendingEvents }};
-//     %wxchkver_3_1_1 void DeletePendingEvents();
+//     %wxchkver_3_0_0 void DeletePendingEvents();
 static int LUACALL wxLua_wxAppConsole_DeletePendingEvents(lua_State *L)
 {
     // get this
@@ -55,7 +55,7 @@ static int LUACALL wxLua_wxAppConsole_DeletePendingEvents(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_ExitMainLoop[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_ExitMainLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_ExitMainLoop[1] = {{ wxLua_wxAppConsole_ExitMainLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_ExitMainLoop }};
-//     %wxchkver_3_1_1 void ExitMainLoop();
+//     %wxchkver_3_0_0 void ExitMainLoop();
 static int LUACALL wxLua_wxAppConsole_ExitMainLoop(lua_State *L)
 {
     // get this
@@ -69,7 +69,7 @@ static int LUACALL wxLua_wxAppConsole_ExitMainLoop(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_FilterEvent[] = { &wxluatype_wxAppConsole, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxAppConsole_FilterEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_FilterEvent[1] = {{ wxLua_wxAppConsole_FilterEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_FilterEvent }};
-//     %wxchkver_3_1_1 int FilterEvent(wxEvent& event);
+//     %wxchkver_3_0_0 int FilterEvent(wxEvent& event);
 static int LUACALL wxLua_wxAppConsole_FilterEvent(lua_State *L)
 {
     // wxEvent event
@@ -87,7 +87,7 @@ static int LUACALL wxLua_wxAppConsole_FilterEvent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_GetAppDisplayName[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_GetAppDisplayName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetAppDisplayName[1] = {{ wxLua_wxAppConsole_GetAppDisplayName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_GetAppDisplayName }};
-//     %wxchkver_3_1_1 wxString GetAppDisplayName() const;
+//     %wxchkver_3_0_0 wxString GetAppDisplayName() const;
 static int LUACALL wxLua_wxAppConsole_GetAppDisplayName(lua_State *L)
 {
     // get this
@@ -103,7 +103,7 @@ static int LUACALL wxLua_wxAppConsole_GetAppDisplayName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_GetAppName[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_GetAppName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetAppName[1] = {{ wxLua_wxAppConsole_GetAppName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_GetAppName }};
-//     %wxchkver_3_1_1 wxString GetAppName() const;
+//     %wxchkver_3_0_0 wxString GetAppName() const;
 static int LUACALL wxLua_wxAppConsole_GetAppName(lua_State *L)
 {
     // get this
@@ -119,7 +119,7 @@ static int LUACALL wxLua_wxAppConsole_GetAppName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_GetClassName[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_GetClassName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetClassName[1] = {{ wxLua_wxAppConsole_GetClassName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_GetClassName }};
-//     %wxchkver_3_1_1 wxString GetClassName() const;
+//     %wxchkver_3_0_0 wxString GetClassName() const;
 static int LUACALL wxLua_wxAppConsole_GetClassName(lua_State *L)
 {
     // get this
@@ -132,12 +132,12 @@ static int LUACALL wxLua_wxAppConsole_GetClassName(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 static int LUACALL wxLua_wxAppConsole_GetInstance(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetInstance[1] = {{ wxLua_wxAppConsole_GetInstance, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 static wxAppConsole* GetInstance();
+//     %wxchkver_3_0_0 static wxAppConsole* GetInstance();
 static int LUACALL wxLua_wxAppConsole_GetInstance(lua_State *L)
 {
     // call GetInstance
@@ -148,13 +148,13 @@ static int LUACALL wxLua_wxAppConsole_GetInstance(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_GetMainLoop[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_GetMainLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetMainLoop[1] = {{ wxLua_wxAppConsole_GetMainLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_GetMainLoop }};
-//     %wxchkver_3_1_1 wxEventLoopBase* GetMainLoop() const;
+//     %wxchkver_3_0_0 wxEventLoopBase* GetMainLoop() const;
 static int LUACALL wxLua_wxAppConsole_GetMainLoop(lua_State *L)
 {
     // get this
@@ -170,7 +170,7 @@ static int LUACALL wxLua_wxAppConsole_GetMainLoop(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_GetVendorDisplayName[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_GetVendorDisplayName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetVendorDisplayName[1] = {{ wxLua_wxAppConsole_GetVendorDisplayName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_GetVendorDisplayName }};
-//     %wxchkver_3_1_1 const wxString& GetVendorDisplayName() const;
+//     %wxchkver_3_0_0 const wxString& GetVendorDisplayName() const;
 static int LUACALL wxLua_wxAppConsole_GetVendorDisplayName(lua_State *L)
 {
     // get this
@@ -186,7 +186,7 @@ static int LUACALL wxLua_wxAppConsole_GetVendorDisplayName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_GetVendorName[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_GetVendorName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_GetVendorName[1] = {{ wxLua_wxAppConsole_GetVendorName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_GetVendorName }};
-//     %wxchkver_3_1_1 const wxString& GetVendorName() const;
+//     %wxchkver_3_0_0 const wxString& GetVendorName() const;
 static int LUACALL wxLua_wxAppConsole_GetVendorName(lua_State *L)
 {
     // get this
@@ -202,7 +202,7 @@ static int LUACALL wxLua_wxAppConsole_GetVendorName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_HasPendingEvents[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_HasPendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_HasPendingEvents[1] = {{ wxLua_wxAppConsole_HasPendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_HasPendingEvents }};
-//     %wxchkver_3_1_1 bool HasPendingEvents() const;
+//     %wxchkver_3_0_0 bool HasPendingEvents() const;
 static int LUACALL wxLua_wxAppConsole_HasPendingEvents(lua_State *L)
 {
     // get this
@@ -217,7 +217,7 @@ static int LUACALL wxLua_wxAppConsole_HasPendingEvents(lua_State *L)
 
 static int LUACALL wxLua_wxAppConsole_IsMainLoopRunning(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_IsMainLoopRunning[1] = {{ wxLua_wxAppConsole_IsMainLoopRunning, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 static bool IsMainLoopRunning();
+//     %wxchkver_3_0_0 static bool IsMainLoopRunning();
 static int LUACALL wxLua_wxAppConsole_IsMainLoopRunning(lua_State *L)
 {
     // call IsMainLoopRunning
@@ -228,13 +228,13 @@ static int LUACALL wxLua_wxAppConsole_IsMainLoopRunning(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_IsScheduledForDestruction[] = { &wxluatype_wxAppConsole, &wxluatype_wxObject, NULL };
 static int LUACALL wxLua_wxAppConsole_IsScheduledForDestruction(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_IsScheduledForDestruction[1] = {{ wxLua_wxAppConsole_IsScheduledForDestruction, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_IsScheduledForDestruction }};
-//     %wxchkver_3_1_1 bool IsScheduledForDestruction(wxObject *object) const;
+//     %wxchkver_3_0_0 bool IsScheduledForDestruction(wxObject *object) const;
 static int LUACALL wxLua_wxAppConsole_IsScheduledForDestruction(lua_State *L)
 {
     // wxObject object
@@ -249,9 +249,9 @@ static int LUACALL wxLua_wxAppConsole_IsScheduledForDestruction(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_MainLoop[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_MainLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_MainLoop[1] = {{ wxLua_wxAppConsole_MainLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_MainLoop }};
@@ -276,7 +276,7 @@ static int LUACALL wxLua_wxAppConsole_MainLoop(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnEventLoopEnter[] = { &wxluatype_wxAppConsole, &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxAppConsole_OnEventLoopEnter(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnEventLoopEnter[1] = {{ wxLua_wxAppConsole_OnEventLoopEnter, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_OnEventLoopEnter }};
-//     %wxchkver_3_1_1 void OnEventLoopEnter(wxEventLoopBase* loop);
+//     %wxchkver_3_0_0 void OnEventLoopEnter(wxEventLoopBase* loop);
 static int LUACALL wxLua_wxAppConsole_OnEventLoopEnter(lua_State *L)
 {
     // wxEventLoopBase loop
@@ -292,7 +292,7 @@ static int LUACALL wxLua_wxAppConsole_OnEventLoopEnter(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnEventLoopExit[] = { &wxluatype_wxAppConsole, &wxluatype_wxEventLoopBase, NULL };
 static int LUACALL wxLua_wxAppConsole_OnEventLoopExit(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnEventLoopExit[1] = {{ wxLua_wxAppConsole_OnEventLoopExit, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_OnEventLoopExit }};
-//     %wxchkver_3_1_1 void OnEventLoopExit(wxEventLoopBase* loop);
+//     %wxchkver_3_0_0 void OnEventLoopExit(wxEventLoopBase* loop);
 static int LUACALL wxLua_wxAppConsole_OnEventLoopExit(lua_State *L)
 {
     // wxEventLoopBase loop
@@ -308,7 +308,7 @@ static int LUACALL wxLua_wxAppConsole_OnEventLoopExit(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnExceptionInMainLoop[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_OnExceptionInMainLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnExceptionInMainLoop[1] = {{ wxLua_wxAppConsole_OnExceptionInMainLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_OnExceptionInMainLoop }};
-//     %wxchkver_3_1_1 bool OnExceptionInMainLoop();
+//     %wxchkver_3_0_0 bool OnExceptionInMainLoop();
 static int LUACALL wxLua_wxAppConsole_OnExceptionInMainLoop(lua_State *L)
 {
     // get this
@@ -324,7 +324,7 @@ static int LUACALL wxLua_wxAppConsole_OnExceptionInMainLoop(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnExit[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_OnExit(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnExit[1] = {{ wxLua_wxAppConsole_OnExit, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_OnExit }};
-//     %wxchkver_3_1_1 int OnExit();
+//     %wxchkver_3_0_0 int OnExit();
 static int LUACALL wxLua_wxAppConsole_OnExit(lua_State *L)
 {
     // get this
@@ -340,7 +340,7 @@ static int LUACALL wxLua_wxAppConsole_OnExit(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnFatalException[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_OnFatalException(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnFatalException[1] = {{ wxLua_wxAppConsole_OnFatalException, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_OnFatalException }};
-//     %wxchkver_3_1_1 void OnFatalException();
+//     %wxchkver_3_0_0 void OnFatalException();
 static int LUACALL wxLua_wxAppConsole_OnFatalException(lua_State *L)
 {
     // get this
@@ -354,7 +354,7 @@ static int LUACALL wxLua_wxAppConsole_OnFatalException(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnInit[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_OnInit(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnInit[1] = {{ wxLua_wxAppConsole_OnInit, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_OnInit }};
-//     %wxchkver_3_1_1 bool OnInit();
+//     %wxchkver_3_0_0 bool OnInit();
 static int LUACALL wxLua_wxAppConsole_OnInit(lua_State *L)
 {
     // get this
@@ -370,7 +370,7 @@ static int LUACALL wxLua_wxAppConsole_OnInit(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnRun[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_OnRun(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnRun[1] = {{ wxLua_wxAppConsole_OnRun, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_OnRun }};
-//     %wxchkver_3_1_1 int OnRun();
+//     %wxchkver_3_0_0 int OnRun();
 static int LUACALL wxLua_wxAppConsole_OnRun(lua_State *L)
 {
     // get this
@@ -386,7 +386,7 @@ static int LUACALL wxLua_wxAppConsole_OnRun(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_OnUnhandledException[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_OnUnhandledException(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_OnUnhandledException[1] = {{ wxLua_wxAppConsole_OnUnhandledException, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_OnUnhandledException }};
-//     %wxchkver_3_1_1 void OnUnhandledException();
+//     %wxchkver_3_0_0 void OnUnhandledException();
 static int LUACALL wxLua_wxAppConsole_OnUnhandledException(lua_State *L)
 {
     // get this
@@ -400,7 +400,7 @@ static int LUACALL wxLua_wxAppConsole_OnUnhandledException(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_ProcessPendingEvents[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_ProcessPendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_ProcessPendingEvents[1] = {{ wxLua_wxAppConsole_ProcessPendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_ProcessPendingEvents }};
-//     %wxchkver_3_1_1 void ProcessPendingEvents();
+//     %wxchkver_3_0_0 void ProcessPendingEvents();
 static int LUACALL wxLua_wxAppConsole_ProcessPendingEvents(lua_State *L)
 {
     // get this
@@ -414,7 +414,7 @@ static int LUACALL wxLua_wxAppConsole_ProcessPendingEvents(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_ResumeProcessingOfPendingEvents[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_ResumeProcessingOfPendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_ResumeProcessingOfPendingEvents[1] = {{ wxLua_wxAppConsole_ResumeProcessingOfPendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_ResumeProcessingOfPendingEvents }};
-//     %wxchkver_3_1_1 void ResumeProcessingOfPendingEvents();
+//     %wxchkver_3_0_0 void ResumeProcessingOfPendingEvents();
 static int LUACALL wxLua_wxAppConsole_ResumeProcessingOfPendingEvents(lua_State *L)
 {
     // get this
@@ -425,10 +425,11 @@ static int LUACALL wxLua_wxAppConsole_ResumeProcessingOfPendingEvents(lua_State 
     return 0;
 }
 
+#if (wxCHECK_VERSION(3,1,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_RethrowStoredException[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_RethrowStoredException(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_RethrowStoredException[1] = {{ wxLua_wxAppConsole_RethrowStoredException, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_RethrowStoredException }};
-//     %wxchkver_3_1_1 void RethrowStoredException();
+//     %wxchkver_3_1_0 void RethrowStoredException();
 static int LUACALL wxLua_wxAppConsole_RethrowStoredException(lua_State *L)
 {
     // get this
@@ -438,14 +439,15 @@ static int LUACALL wxLua_wxAppConsole_RethrowStoredException(lua_State *L)
 
     return 0;
 }
+#endif // (wxCHECK_VERSION(3,1,0))
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_ScheduleForDestruction[] = { &wxluatype_wxAppConsole, &wxluatype_wxObject, NULL };
 static int LUACALL wxLua_wxAppConsole_ScheduleForDestruction(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_ScheduleForDestruction[1] = {{ wxLua_wxAppConsole_ScheduleForDestruction, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_ScheduleForDestruction }};
-//     %wxchkver_3_1_1 void ScheduleForDestruction(wxObject *object);
+//     %wxchkver_3_0_0 void ScheduleForDestruction(wxObject *object);
 static int LUACALL wxLua_wxAppConsole_ScheduleForDestruction(lua_State *L)
 {
     // wxObject object
@@ -458,13 +460,13 @@ static int LUACALL wxLua_wxAppConsole_ScheduleForDestruction(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetAppDisplayName[] = { &wxluatype_wxAppConsole, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxAppConsole_SetAppDisplayName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetAppDisplayName[1] = {{ wxLua_wxAppConsole_SetAppDisplayName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_SetAppDisplayName }};
-//     %wxchkver_3_1_1 void SetAppDisplayName(const wxString& name);
+//     %wxchkver_3_0_0 void SetAppDisplayName(const wxString& name);
 static int LUACALL wxLua_wxAppConsole_SetAppDisplayName(lua_State *L)
 {
     // const wxString name
@@ -480,7 +482,7 @@ static int LUACALL wxLua_wxAppConsole_SetAppDisplayName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetAppName[] = { &wxluatype_wxAppConsole, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxAppConsole_SetAppName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetAppName[1] = {{ wxLua_wxAppConsole_SetAppName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_SetAppName }};
-//     %wxchkver_3_1_1 void SetAppName(const wxString& name);
+//     %wxchkver_3_0_0 void SetAppName(const wxString& name);
 static int LUACALL wxLua_wxAppConsole_SetAppName(lua_State *L)
 {
     // const wxString name
@@ -496,7 +498,7 @@ static int LUACALL wxLua_wxAppConsole_SetAppName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetCLocale[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_SetCLocale(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetCLocale[1] = {{ wxLua_wxAppConsole_SetCLocale, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_SetCLocale }};
-//     %wxchkver_3_1_1 void SetCLocale();
+//     %wxchkver_3_0_0 void SetCLocale();
 static int LUACALL wxLua_wxAppConsole_SetCLocale(lua_State *L)
 {
     // get this
@@ -510,7 +512,7 @@ static int LUACALL wxLua_wxAppConsole_SetCLocale(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetClassName[] = { &wxluatype_wxAppConsole, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxAppConsole_SetClassName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetClassName[1] = {{ wxLua_wxAppConsole_SetClassName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_SetClassName }};
-//     %wxchkver_3_1_1 void SetClassName(const wxString& name);
+//     %wxchkver_3_0_0 void SetClassName(const wxString& name);
 static int LUACALL wxLua_wxAppConsole_SetClassName(lua_State *L)
 {
     // const wxString name
@@ -523,13 +525,13 @@ static int LUACALL wxLua_wxAppConsole_SetClassName(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetInstance[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_SetInstance(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetInstance[1] = {{ wxLua_wxAppConsole_SetInstance, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_SetInstance }};
-//     %wxchkver_3_1_1 static void SetInstance(wxAppConsole* app);
+//     %wxchkver_3_0_0 static void SetInstance(wxAppConsole* app);
 static int LUACALL wxLua_wxAppConsole_SetInstance(lua_State *L)
 {
     // wxAppConsole app
@@ -540,13 +542,13 @@ static int LUACALL wxLua_wxAppConsole_SetInstance(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetVendorDisplayName[] = { &wxluatype_wxAppConsole, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxAppConsole_SetVendorDisplayName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetVendorDisplayName[1] = {{ wxLua_wxAppConsole_SetVendorDisplayName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_SetVendorDisplayName }};
-//     %wxchkver_3_1_1 void SetVendorDisplayName(const wxString& name);
+//     %wxchkver_3_0_0 void SetVendorDisplayName(const wxString& name);
 static int LUACALL wxLua_wxAppConsole_SetVendorDisplayName(lua_State *L)
 {
     // const wxString name
@@ -562,7 +564,7 @@ static int LUACALL wxLua_wxAppConsole_SetVendorDisplayName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SetVendorName[] = { &wxluatype_wxAppConsole, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxAppConsole_SetVendorName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SetVendorName[1] = {{ wxLua_wxAppConsole_SetVendorName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAppConsole_SetVendorName }};
-//     %wxchkver_3_1_1 void SetVendorName(const wxString& name);
+//     %wxchkver_3_0_0 void SetVendorName(const wxString& name);
 static int LUACALL wxLua_wxAppConsole_SetVendorName(lua_State *L)
 {
     // const wxString name
@@ -575,10 +577,11 @@ static int LUACALL wxLua_wxAppConsole_SetVendorName(lua_State *L)
     return 0;
 }
 
+#if (wxCHECK_VERSION(3,1,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_StoreCurrentException[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_StoreCurrentException(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_StoreCurrentException[1] = {{ wxLua_wxAppConsole_StoreCurrentException, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_StoreCurrentException }};
-//     %wxchkver_3_1_1 bool StoreCurrentException();
+//     %wxchkver_3_1_0 bool StoreCurrentException();
 static int LUACALL wxLua_wxAppConsole_StoreCurrentException(lua_State *L)
 {
     // get this
@@ -590,11 +593,12 @@ static int LUACALL wxLua_wxAppConsole_StoreCurrentException(lua_State *L)
 
     return 1;
 }
+#endif // (wxCHECK_VERSION(3,1,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_SuspendProcessingOfPendingEvents[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_SuspendProcessingOfPendingEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_SuspendProcessingOfPendingEvents[1] = {{ wxLua_wxAppConsole_SuspendProcessingOfPendingEvents, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_SuspendProcessingOfPendingEvents }};
-//     %wxchkver_3_1_1 void SuspendProcessingOfPendingEvents();
+//     %wxchkver_3_0_0 void SuspendProcessingOfPendingEvents();
 static int LUACALL wxLua_wxAppConsole_SuspendProcessingOfPendingEvents(lua_State *L)
 {
     // get this
@@ -608,7 +612,7 @@ static int LUACALL wxLua_wxAppConsole_SuspendProcessingOfPendingEvents(lua_State
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_UsesEventLoop[] = { &wxluatype_wxAppConsole, NULL };
 static int LUACALL wxLua_wxAppConsole_UsesEventLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_UsesEventLoop[1] = {{ wxLua_wxAppConsole_UsesEventLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAppConsole_UsesEventLoop }};
-//     %wxchkver_3_1_1 bool UsesEventLoop() const;
+//     %wxchkver_3_0_0 bool UsesEventLoop() const;
 static int LUACALL wxLua_wxAppConsole_UsesEventLoop(lua_State *L)
 {
     // get this
@@ -624,7 +628,7 @@ static int LUACALL wxLua_wxAppConsole_UsesEventLoop(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAppConsole_Yield[] = { &wxluatype_wxAppConsole, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxAppConsole_Yield(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAppConsole_Yield[1] = {{ wxLua_wxAppConsole_Yield, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxAppConsole_Yield }};
-//     %wxchkver_3_1_1 bool Yield(bool onlyIfNeeded = false);
+//     %wxchkver_3_0_0 bool Yield(bool onlyIfNeeded = false);
 static int LUACALL wxLua_wxAppConsole_Yield(lua_State *L)
 {
     // get number of arguments
@@ -641,7 +645,7 @@ static int LUACALL wxLua_wxAppConsole_Yield(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
 
 
@@ -653,32 +657,32 @@ void wxLua_wxAppConsole_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxAppConsole_methods[] = {
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "DeletePendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_DeletePendingEvents, 1, NULL },
     { "ExitMainLoop", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_ExitMainLoop, 1, NULL },
     { "FilterEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_FilterEvent, 1, NULL },
     { "GetAppDisplayName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_GetAppDisplayName, 1, NULL },
     { "GetAppName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_GetAppName, 1, NULL },
     { "GetClassName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_GetClassName, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
     { "GetInstance", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxAppConsole_GetInstance, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "GetMainLoop", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_GetMainLoop, 1, NULL },
     { "GetVendorDisplayName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_GetVendorDisplayName, 1, NULL },
     { "GetVendorName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_GetVendorName, 1, NULL },
     { "HasPendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_HasPendingEvents, 1, NULL },
     { "IsMainLoopRunning", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxAppConsole_IsMainLoopRunning, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
     { "IsScheduledForDestruction", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_IsScheduledForDestruction, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "MainLoop", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_MainLoop, 1, NULL },
     { "OnEventLoopEnter", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_OnEventLoopEnter, 1, NULL },
     { "OnEventLoopExit", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_OnEventLoopExit, 1, NULL },
@@ -690,32 +694,37 @@ wxLuaBindMethod wxAppConsole_methods[] = {
     { "OnUnhandledException", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_OnUnhandledException, 1, NULL },
     { "ProcessPendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_ProcessPendingEvents, 1, NULL },
     { "ResumeProcessingOfPendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_ResumeProcessingOfPendingEvents, 1, NULL },
+#if (wxCHECK_VERSION(3,1,0))
     { "RethrowStoredException", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_RethrowStoredException, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,1,0))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
+
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
     { "ScheduleForDestruction", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_ScheduleForDestruction, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxObject)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "SetAppDisplayName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SetAppDisplayName, 1, NULL },
     { "SetAppName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SetAppName, 1, NULL },
     { "SetCLocale", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SetCLocale, 1, NULL },
     { "SetClassName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SetClassName, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
     { "SetInstance", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxAppConsole_SetInstance, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "SetVendorDisplayName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SetVendorDisplayName, 1, NULL },
     { "SetVendorName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SetVendorName, 1, NULL },
+#if (wxCHECK_VERSION(3,1,0))
     { "StoreCurrentException", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_StoreCurrentException, 1, NULL },
+#endif // (wxCHECK_VERSION(3,1,0))
     { "SuspendProcessingOfPendingEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_SuspendProcessingOfPendingEvents, 1, NULL },
     { "UsesEventLoop", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_UsesEventLoop, 1, NULL },
     { "Yield", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAppConsole_Yield, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
     { 0, 0, 0, 0 },
 };
@@ -733,11 +742,11 @@ int wxAppConsole_methodCount = sizeof(wxAppConsole_methods)/sizeof(wxLuaBindMeth
 // Lua MetaTable Tag for Class 'wxApp'
 int wxluatype_wxApp = WXLUA_TUNKNOWN;
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_Dispatch[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_Dispatch(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_Dispatch[1] = {{ wxLua_wxApp_Dispatch, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_Dispatch }};
-//     !%wxchkver_3_1_1 void Dispatch();
+//     !%wxchkver_3_0_0 void Dispatch();
 static int LUACALL wxLua_wxApp_Dispatch(lua_State *L)
 {
     // get this
@@ -751,7 +760,7 @@ static int LUACALL wxLua_wxApp_Dispatch(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_ExitMainLoop[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_ExitMainLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_ExitMainLoop[1] = {{ wxLua_wxApp_ExitMainLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_ExitMainLoop }};
-//     !%wxchkver_3_1_1 void ExitMainLoop();
+//     !%wxchkver_3_0_0 void ExitMainLoop();
 static int LUACALL wxLua_wxApp_ExitMainLoop(lua_State *L)
 {
     // get this
@@ -765,7 +774,7 @@ static int LUACALL wxLua_wxApp_ExitMainLoop(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetAppName[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetAppName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_GetAppName[1] = {{ wxLua_wxApp_GetAppName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_GetAppName }};
-//     !%wxchkver_3_1_1 wxString GetAppName() const;
+//     !%wxchkver_3_0_0 wxString GetAppName() const;
 static int LUACALL wxLua_wxApp_GetAppName(lua_State *L)
 {
     // get this
@@ -781,7 +790,7 @@ static int LUACALL wxLua_wxApp_GetAppName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetClassName[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetClassName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_GetClassName[1] = {{ wxLua_wxApp_GetClassName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_GetClassName }};
-//     !%wxchkver_3_1_1 wxString GetClassName() const;
+//     !%wxchkver_3_0_0 wxString GetClassName() const;
 static int LUACALL wxLua_wxApp_GetClassName(lua_State *L)
 {
     // get this
@@ -794,13 +803,13 @@ static int LUACALL wxLua_wxApp_GetClassName(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetDisplayMode[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetDisplayMode(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_GetDisplayMode[1] = {{ wxLua_wxApp_GetDisplayMode, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_GetDisplayMode }};
-//     %wxchkver_3_1_1 wxVideoMode GetDisplayMode() const;
+//     %wxchkver_3_0_0 wxVideoMode GetDisplayMode() const;
 static int LUACALL wxLua_wxApp_GetDisplayMode(lua_State *L)
 {
     // get this
@@ -816,7 +825,7 @@ static int LUACALL wxLua_wxApp_GetDisplayMode(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetExitOnFrameDelete[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetExitOnFrameDelete(lua_State *L);
@@ -835,11 +844,11 @@ static int LUACALL wxLua_wxApp_GetExitOnFrameDelete(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetLayoutDirection[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetLayoutDirection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_GetLayoutDirection[1] = {{ wxLua_wxApp_GetLayoutDirection, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_GetLayoutDirection }};
-//     %wxchkver_3_1_1 wxLayoutDirection GetLayoutDirection() const;
+//     %wxchkver_3_0_0 wxLayoutDirection GetLayoutDirection() const;
 static int LUACALL wxLua_wxApp_GetLayoutDirection(lua_State *L)
 {
     // get this
@@ -852,7 +861,7 @@ static int LUACALL wxLua_wxApp_GetLayoutDirection(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetTopWindow[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetTopWindow(lua_State *L);
@@ -887,11 +896,11 @@ static int LUACALL wxLua_wxApp_GetUseBestVisual(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_GetVendorName[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_GetVendorName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_GetVendorName[1] = {{ wxLua_wxApp_GetVendorName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_GetVendorName }};
-//     !%wxchkver_3_1_1 wxString GetVendorName() const;
+//     !%wxchkver_3_0_0 wxString GetVendorName() const;
 static int LUACALL wxLua_wxApp_GetVendorName(lua_State *L)
 {
     // get this
@@ -904,7 +913,7 @@ static int LUACALL wxLua_wxApp_GetVendorName(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_IsActive[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_IsActive(lua_State *L);
@@ -923,10 +932,10 @@ static int LUACALL wxLua_wxApp_IsActive(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static int LUACALL wxLua_wxApp_IsMainLoopRunning(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_IsMainLoopRunning[1] = {{ wxLua_wxApp_IsMainLoopRunning, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     !%wxchkver_3_1_1 static bool IsMainLoopRunning();
+//     !%wxchkver_3_0_0 static bool IsMainLoopRunning();
 static int LUACALL wxLua_wxApp_IsMainLoopRunning(lua_State *L)
 {
     // call IsMainLoopRunning
@@ -937,13 +946,13 @@ static int LUACALL wxLua_wxApp_IsMainLoopRunning(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MacNewFile[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_MacNewFile(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MacNewFile[1] = {{ wxLua_wxApp_MacNewFile, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_MacNewFile }};
-//     %wxchkver_3_1_1 && %mac void MacNewFile();
+//     %wxchkver_3_0_0 && %mac void MacNewFile();
 static int LUACALL wxLua_wxApp_MacNewFile(lua_State *L)
 {
     // get this
@@ -957,7 +966,7 @@ static int LUACALL wxLua_wxApp_MacNewFile(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MacOpenFile[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_MacOpenFile(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MacOpenFile[1] = {{ wxLua_wxApp_MacOpenFile, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_MacOpenFile }};
-//     %wxchkver_3_1_1 && %mac void MacOpenFile(const wxString& fileName);
+//     %wxchkver_3_0_0 && %mac void MacOpenFile(const wxString& fileName);
 static int LUACALL wxLua_wxApp_MacOpenFile(lua_State *L)
 {
     // const wxString fileName
@@ -970,13 +979,13 @@ static int LUACALL wxLua_wxApp_MacOpenFile(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
+#if ((wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MacOpenFiles[] = { &wxluatype_wxApp, &wxluatype_wxArrayString, NULL };
 static int LUACALL wxLua_wxApp_MacOpenFiles(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MacOpenFiles[1] = {{ wxLua_wxApp_MacOpenFiles, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_MacOpenFiles }};
-//     %wxchkver_3_1_1 && %mac void MacOpenFiles(const wxArrayString& fileNames);
+//     %wxchkver_3_0_0 && %mac void MacOpenFiles(const wxArrayString& fileNames);
 static int LUACALL wxLua_wxApp_MacOpenFiles(lua_State *L)
 {
     // const wxArrayString fileNames
@@ -989,13 +998,13 @@ static int LUACALL wxLua_wxApp_MacOpenFiles(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
+#endif // ((wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MacOpenURL[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_MacOpenURL(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MacOpenURL[1] = {{ wxLua_wxApp_MacOpenURL, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_MacOpenURL }};
-//     %wxchkver_3_1_1 && %mac void MacOpenURL(const wxString& url);
+//     %wxchkver_3_0_0 && %mac void MacOpenURL(const wxString& url);
 static int LUACALL wxLua_wxApp_MacOpenURL(lua_State *L)
 {
     // const wxString url
@@ -1011,7 +1020,7 @@ static int LUACALL wxLua_wxApp_MacOpenURL(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MacPrintFile[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_MacPrintFile(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MacPrintFile[1] = {{ wxLua_wxApp_MacPrintFile, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_MacPrintFile }};
-//     %wxchkver_3_1_1 && %mac void MacPrintFile(const wxString& fileName);
+//     %wxchkver_3_0_0 && %mac void MacPrintFile(const wxString& fileName);
 static int LUACALL wxLua_wxApp_MacPrintFile(lua_State *L)
 {
     // const wxString fileName
@@ -1027,7 +1036,7 @@ static int LUACALL wxLua_wxApp_MacPrintFile(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MacReopenApp[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_MacReopenApp(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MacReopenApp[1] = {{ wxLua_wxApp_MacReopenApp, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_MacReopenApp }};
-//     %wxchkver_3_1_1 && %mac void MacReopenApp();
+//     %wxchkver_3_0_0 && %mac void MacReopenApp();
 static int LUACALL wxLua_wxApp_MacReopenApp(lua_State *L)
 {
     // get this
@@ -1038,9 +1047,9 @@ static int LUACALL wxLua_wxApp_MacReopenApp(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_MainLoop[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_MainLoop(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_MainLoop[1] = {{ wxLua_wxApp_MainLoop, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_MainLoop }};
@@ -1062,13 +1071,13 @@ static int LUACALL wxLua_wxApp_MainLoop(lua_State *L)
 }
 
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_OSXIsGUIApplication[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_OSXIsGUIApplication(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_OSXIsGUIApplication[1] = {{ wxLua_wxApp_OSXIsGUIApplication, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_OSXIsGUIApplication }};
-//     %wxchkver_3_1_1 && %mac bool OSXIsGUIApplication();
+//     %wxchkver_3_0_0 && %mac bool OSXIsGUIApplication();
 static int LUACALL wxLua_wxApp_OSXIsGUIApplication(lua_State *L)
 {
     // get this
@@ -1081,13 +1090,13 @@ static int LUACALL wxLua_wxApp_OSXIsGUIApplication(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_Pending[] = { &wxluatype_wxApp, NULL };
 static int LUACALL wxLua_wxApp_Pending(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_Pending[1] = {{ wxLua_wxApp_Pending, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxApp_Pending }};
-//     !%wxchkver_3_1_1 bool Pending();
+//     !%wxchkver_3_0_0 bool Pending();
 static int LUACALL wxLua_wxApp_Pending(lua_State *L)
 {
     // get this
@@ -1100,13 +1109,13 @@ static int LUACALL wxLua_wxApp_Pending(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SafeYield[] = { &wxluatype_wxApp, &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxApp_SafeYield(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SafeYield[1] = {{ wxLua_wxApp_SafeYield, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxApp_SafeYield }};
-//     %wxchkver_3_1_1 bool SafeYield(wxWindow *win, bool onlyIfNeeded);
+//     %wxchkver_3_0_0 bool SafeYield(wxWindow *win, bool onlyIfNeeded);
 static int LUACALL wxLua_wxApp_SafeYield(lua_State *L)
 {
     // bool onlyIfNeeded
@@ -1126,7 +1135,7 @@ static int LUACALL wxLua_wxApp_SafeYield(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SafeYieldFor[] = { &wxluatype_wxApp, &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxApp_SafeYieldFor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SafeYieldFor[1] = {{ wxLua_wxApp_SafeYieldFor, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxApp_SafeYieldFor }};
-//     %wxchkver_3_1_1 bool SafeYieldFor(wxWindow *win, long eventsToProcess);
+//     %wxchkver_3_0_0 bool SafeYieldFor(wxWindow *win, long eventsToProcess);
 static int LUACALL wxLua_wxApp_SafeYieldFor(lua_State *L)
 {
     // long eventsToProcess
@@ -1143,7 +1152,7 @@ static int LUACALL wxLua_wxApp_SafeYieldFor(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
 #if (wxCHECK_VERSION(2,6,0) && !wxCHECK_VERSION(2,9,2)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SendIdleEvents[] = { &wxluatype_wxApp, &wxluatype_wxWindow, &wxluatype_wxIdleEvent, NULL };
@@ -1168,11 +1177,11 @@ static int LUACALL wxLua_wxApp_SendIdleEvents(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,6,0) && !wxCHECK_VERSION(2,9,2)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetAppName[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_SetAppName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetAppName[1] = {{ wxLua_wxApp_SetAppName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetAppName }};
-//     !%wxchkver_3_1_1 void SetAppName(const wxString& name);
+//     !%wxchkver_3_0_0 void SetAppName(const wxString& name);
 static int LUACALL wxLua_wxApp_SetAppName(lua_State *L)
 {
     // const wxString name
@@ -1188,7 +1197,7 @@ static int LUACALL wxLua_wxApp_SetAppName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetClassName[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_SetClassName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetClassName[1] = {{ wxLua_wxApp_SetClassName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetClassName }};
-//     !%wxchkver_3_1_1 void SetClassName(const wxString& name);
+//     !%wxchkver_3_0_0 void SetClassName(const wxString& name);
 static int LUACALL wxLua_wxApp_SetClassName(lua_State *L)
 {
     // const wxString name
@@ -1201,13 +1210,13 @@ static int LUACALL wxLua_wxApp_SetClassName(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetDisplayMode[] = { &wxluatype_wxApp, &wxluatype_wxVideoMode, NULL };
 static int LUACALL wxLua_wxApp_SetDisplayMode(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetDisplayMode[1] = {{ wxLua_wxApp_SetDisplayMode, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetDisplayMode }};
-//     %wxchkver_3_1_1 bool SetDisplayMode(const wxVideoMode& info);
+//     %wxchkver_3_0_0 bool SetDisplayMode(const wxVideoMode& info);
 static int LUACALL wxLua_wxApp_SetDisplayMode(lua_State *L)
 {
     // const wxVideoMode info
@@ -1222,7 +1231,7 @@ static int LUACALL wxLua_wxApp_SetDisplayMode(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetExitOnFrameDelete[] = { &wxluatype_wxApp, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxApp_SetExitOnFrameDelete(lua_State *L);
@@ -1241,11 +1250,11 @@ static int LUACALL wxLua_wxApp_SetExitOnFrameDelete(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetNativeTheme[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_SetNativeTheme(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetNativeTheme[1] = {{ wxLua_wxApp_SetNativeTheme, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetNativeTheme }};
-//     %wxchkver_3_1_1 bool SetNativeTheme(const wxString& theme);
+//     %wxchkver_3_0_0 bool SetNativeTheme(const wxString& theme);
 static int LUACALL wxLua_wxApp_SetNativeTheme(lua_State *L)
 {
     // const wxString theme
@@ -1260,7 +1269,7 @@ static int LUACALL wxLua_wxApp_SetNativeTheme(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetTopWindow[] = { &wxluatype_wxApp, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxApp_SetTopWindow(lua_State *L);
@@ -1279,11 +1288,11 @@ static int LUACALL wxLua_wxApp_SetTopWindow(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetUseBestVisual1[] = { &wxluatype_wxApp, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxApp_SetUseBestVisual1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetUseBestVisual1[1] = {{ wxLua_wxApp_SetUseBestVisual1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetUseBestVisual1 }};
-//     !%wxchkver_3_1_1 void SetUseBestVisual(bool flag);
+//     !%wxchkver_3_0_0 void SetUseBestVisual(bool flag);
 static int LUACALL wxLua_wxApp_SetUseBestVisual1(lua_State *L)
 {
     // bool flag
@@ -1296,13 +1305,13 @@ static int LUACALL wxLua_wxApp_SetUseBestVisual1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetUseBestVisual[] = { &wxluatype_wxApp, &wxluatype_TBOOLEAN, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxApp_SetUseBestVisual(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetUseBestVisual[1] = {{ wxLua_wxApp_SetUseBestVisual, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxApp_SetUseBestVisual }};
-//     %wxchkver_3_1_1 void SetUseBestVisual(bool flag, bool forceTrueColour = false);
+//     %wxchkver_3_0_0 void SetUseBestVisual(bool flag, bool forceTrueColour = false);
 static int LUACALL wxLua_wxApp_SetUseBestVisual(lua_State *L)
 {
     // get number of arguments
@@ -1319,13 +1328,13 @@ static int LUACALL wxLua_wxApp_SetUseBestVisual(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxApp_SetVendorName[] = { &wxluatype_wxApp, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxApp_SetVendorName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetVendorName[1] = {{ wxLua_wxApp_SetVendorName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetVendorName }};
-//     !%wxchkver_3_1_1 void SetVendorName(const wxString& name);
+//     !%wxchkver_3_0_0 void SetVendorName(const wxString& name);
 static int LUACALL wxLua_wxApp_SetVendorName(lua_State *L)
 {
     // const wxString name
@@ -1338,12 +1347,12 @@ static int LUACALL wxLua_wxApp_SetVendorName(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 static int LUACALL wxLua_wxApp_constructor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_constructor[1] = {{ wxLua_wxApp_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxApp();
+//     %wxchkver_3_0_0 wxApp();
 static int LUACALL wxLua_wxApp_constructor(lua_State *L)
 {
     // call constructor
@@ -1354,26 +1363,26 @@ static int LUACALL wxLua_wxApp_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxApp_SetUseBestVisual_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { wxLua_wxApp_SetUseBestVisual1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxApp_SetUseBestVisual1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { wxLua_wxApp_SetUseBestVisual, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxApp_SetUseBestVisual },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 };
 static int s_wxluafunc_wxLua_wxApp_SetUseBestVisual_overload_count = sizeof(s_wxluafunc_wxLua_wxApp_SetUseBestVisual_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
 
 void wxLua_wxApp_delete_function(void** p)
 {
@@ -1383,100 +1392,100 @@ void wxLua_wxApp_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxApp_methods[] = {
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "Dispatch", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_Dispatch, 1, NULL },
     { "ExitMainLoop", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_ExitMainLoop, 1, NULL },
     { "GetAppName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetAppName, 1, NULL },
     { "GetClassName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetClassName, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
     { "GetDisplayMode", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetDisplayMode, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
     { "GetExitOnFrameDelete", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetExitOnFrameDelete, 1, NULL },
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
     { "GetLayoutDirection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetLayoutDirection, 1, NULL },
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
 
     { "GetTopWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetTopWindow, 1, NULL },
     { "GetUseBestVisual", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetUseBestVisual, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "GetVendorName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_GetVendorName, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
     { "IsActive", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_IsActive, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "IsMainLoopRunning", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxApp_IsMainLoopRunning, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
     { "MacNewFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MacNewFile, 1, NULL },
     { "MacOpenFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MacOpenFile, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
+#if ((wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
     { "MacOpenFiles", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MacOpenFiles, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
+#endif // ((wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxArrayString)
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
     { "MacOpenURL", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MacOpenURL, 1, NULL },
     { "MacPrintFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MacPrintFile, 1, NULL },
     { "MacReopenApp", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MacReopenApp, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "MainLoop", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_MainLoop, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
     { "OSXIsGUIApplication", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_OSXIsGUIApplication, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "Pending", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_Pending, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "SafeYield", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SafeYield, 1, NULL },
     { "SafeYieldFor", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SafeYieldFor, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
 #if (wxCHECK_VERSION(2,6,0) && !wxCHECK_VERSION(2,9,2)) && (wxLUA_USE_wxApp)
     { "SendIdleEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SendIdleEvents, 1, NULL },
 #endif // (wxCHECK_VERSION(2,6,0) && !wxCHECK_VERSION(2,9,2)) && (wxLUA_USE_wxApp)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "SetAppName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetAppName, 1, NULL },
     { "SetClassName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetClassName, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
     { "SetDisplayMode", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetDisplayMode, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
     { "SetExitOnFrameDelete", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetExitOnFrameDelete, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "SetNativeTheme", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetNativeTheme, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
     { "SetTopWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetTopWindow, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
     { "SetUseBestVisual", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetUseBestVisual_overload, s_wxluafunc_wxLua_wxApp_SetUseBestVisual_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
     { "SetVendorName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxApp_SetVendorName, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
     { "wxApp", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxApp_constructor, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxApp)) && (wxLUA_USE_wxApp)
 
     { 0, 0, 0, 0 },
 };
@@ -1494,11 +1503,11 @@ int wxApp_methodCount = sizeof(wxApp_methods)/sizeof(wxLuaBindMethod) - 1;
 // Lua MetaTable Tag for Class 'wxNonOwnedWindow'
 int wxluatype_wxNonOwnedWindow = WXLUA_TUNKNOWN;
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxNonOwnedWindow_SetShape[] = { &wxluatype_wxNonOwnedWindow, &wxluatype_wxRegion, NULL };
 static int LUACALL wxLua_wxNonOwnedWindow_SetShape(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxNonOwnedWindow_SetShape[1] = {{ wxLua_wxNonOwnedWindow_SetShape, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxNonOwnedWindow_SetShape }};
-//     %wxchkver_3_1_1 bool SetShape(const wxRegion& region);
+//     %wxchkver_3_0_0 bool SetShape(const wxRegion& region);
 static int LUACALL wxLua_wxNonOwnedWindow_SetShape(lua_State *L)
 {
     // const wxRegion region
@@ -1513,7 +1522,7 @@ static int LUACALL wxLua_wxNonOwnedWindow_SetShape(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
 
 
 
@@ -1525,9 +1534,9 @@ void wxLua_wxNonOwnedWindow_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxNonOwnedWindow_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
     { "SetShape", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxNonOwnedWindow_SetShape, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
 
     { 0, 0, 0, 0 },
 };
@@ -1562,11 +1571,11 @@ static int LUACALL wxLua_wxTopLevelWindow_CanSetTransparent(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_CenterOnScreen[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_CenterOnScreen(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_CenterOnScreen[1] = {{ wxLua_wxTopLevelWindow_CenterOnScreen, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_CenterOnScreen }};
-//     %wxchkver_3_1_1 void CenterOnScreen(int direction = wxBOTH);
+//     %wxchkver_3_0_0 void CenterOnScreen(int direction = wxBOTH);
 static int LUACALL wxLua_wxTopLevelWindow_CenterOnScreen(lua_State *L)
 {
     // get number of arguments
@@ -1584,7 +1593,7 @@ static int LUACALL wxLua_wxTopLevelWindow_CenterOnScreen(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_CentreOnScreen[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_CentreOnScreen(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_CentreOnScreen[1] = {{ wxLua_wxTopLevelWindow_CentreOnScreen, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_CentreOnScreen }};
-//     %wxchkver_3_1_1 void CentreOnScreen(int direction = wxBOTH);
+//     %wxchkver_3_0_0 void CentreOnScreen(int direction = wxBOTH);
 static int LUACALL wxLua_wxTopLevelWindow_CentreOnScreen(lua_State *L)
 {
     // get number of arguments
@@ -1599,13 +1608,13 @@ static int LUACALL wxLua_wxTopLevelWindow_CentreOnScreen(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_Create[] = { &wxluatype_wxTopLevelWindow, &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_Create(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_Create[1] = {{ wxLua_wxTopLevelWindow_Create, WXLUAMETHOD_METHOD, 4, 8, s_wxluatypeArray_wxLua_wxTopLevelWindow_Create }};
-//     %wxchkver_3_1_1 bool Create(wxWindow *parent, wxWindowID id, const wxString& title, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
+//     %wxchkver_3_0_0 bool Create(wxWindow *parent, wxWindowID id, const wxString& title, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
 static int LUACALL wxLua_wxTopLevelWindow_Create(lua_State *L)
 {
     // get number of arguments
@@ -1634,7 +1643,7 @@ static int LUACALL wxLua_wxTopLevelWindow_Create(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableCloseButton[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_EnableCloseButton(lua_State *L);
@@ -1657,11 +1666,11 @@ static int LUACALL wxLua_wxTopLevelWindow_EnableCloseButton(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableFullScreenView[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_EnableFullScreenView(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_EnableFullScreenView[1] = {{ wxLua_wxTopLevelWindow_EnableFullScreenView, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableFullScreenView }};
-//     %wxchkver_3_1_1 bool EnableFullScreenView(bool enable = true);
+//     %wxchkver_3_1_0 bool EnableFullScreenView(bool enable = true);
 static int LUACALL wxLua_wxTopLevelWindow_EnableFullScreenView(lua_State *L)
 {
     // get number of arguments
@@ -1681,7 +1690,7 @@ static int LUACALL wxLua_wxTopLevelWindow_EnableFullScreenView(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableMaximizeButton[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_EnableMaximizeButton(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_EnableMaximizeButton[1] = {{ wxLua_wxTopLevelWindow_EnableMaximizeButton, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableMaximizeButton }};
-//     %wxchkver_3_1_1 bool EnableMaximizeButton(bool enable = true);
+//     %wxchkver_3_1_0 bool EnableMaximizeButton(bool enable = true);
 static int LUACALL wxLua_wxTopLevelWindow_EnableMaximizeButton(lua_State *L)
 {
     // get number of arguments
@@ -1701,7 +1710,7 @@ static int LUACALL wxLua_wxTopLevelWindow_EnableMaximizeButton(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableMinimizeButton[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_EnableMinimizeButton(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_EnableMinimizeButton[1] = {{ wxLua_wxTopLevelWindow_EnableMinimizeButton, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_EnableMinimizeButton }};
-//     %wxchkver_3_1_1 bool EnableMinimizeButton(bool enable = true);
+//     %wxchkver_3_1_0 bool EnableMinimizeButton(bool enable = true);
 static int LUACALL wxLua_wxTopLevelWindow_EnableMinimizeButton(lua_State *L)
 {
     // get number of arguments
@@ -1718,7 +1727,7 @@ static int LUACALL wxLua_wxTopLevelWindow_EnableMinimizeButton(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_GetDefaultItem[] = { &wxluatype_wxTopLevelWindow, NULL };
@@ -1739,10 +1748,10 @@ static int LUACALL wxLua_wxTopLevelWindow_GetDefaultItem(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 static int LUACALL wxLua_wxTopLevelWindow_GetDefaultSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_GetDefaultSize[1] = {{ wxLua_wxTopLevelWindow_GetDefaultSize, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 static wxSize GetDefaultSize();
+//     %wxchkver_3_0_0 static wxSize GetDefaultSize();
 static int LUACALL wxLua_wxTopLevelWindow_GetDefaultSize(lua_State *L)
 {
     // call GetDefaultSize
@@ -1756,7 +1765,7 @@ static int LUACALL wxLua_wxTopLevelWindow_GetDefaultSize(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_GetIcon[] = { &wxluatype_wxTopLevelWindow, NULL };
@@ -1780,11 +1789,11 @@ static int LUACALL wxLua_wxTopLevelWindow_GetIcon(lua_State *L)
 
 #endif // (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxIcon)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_GetIcons[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_GetIcons(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_GetIcons[1] = {{ wxLua_wxTopLevelWindow_GetIcons, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTopLevelWindow_GetIcons }};
-//     %wxchkver_3_1_1 const wxIconBundle& GetIcons() const;
+//     %wxchkver_3_0_0 const wxIconBundle& GetIcons() const;
 static int LUACALL wxLua_wxTopLevelWindow_GetIcons(lua_State *L)
 {
     // get this
@@ -1797,7 +1806,7 @@ static int LUACALL wxLua_wxTopLevelWindow_GetIcons(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_GetTitle[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_GetTitle(lua_State *L);
@@ -1932,11 +1941,11 @@ static int LUACALL wxLua_wxTopLevelWindow_IsMaximized(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_Layout[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_Layout(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_Layout[1] = {{ wxLua_wxTopLevelWindow_Layout, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTopLevelWindow_Layout }};
-//     %wxchkver_3_1_1 bool Layout();
+//     %wxchkver_3_0_0 bool Layout();
 static int LUACALL wxLua_wxTopLevelWindow_Layout(lua_State *L)
 {
     // get this
@@ -1949,13 +1958,13 @@ static int LUACALL wxLua_wxTopLevelWindow_Layout(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_MSWGetSystemMenu[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_MSWGetSystemMenu(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_MSWGetSystemMenu[1] = {{ wxLua_wxTopLevelWindow_MSWGetSystemMenu, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTopLevelWindow_MSWGetSystemMenu }};
-//     %wxchkver_3_1_1 && %win wxMenu *MSWGetSystemMenu() const;
+//     %wxchkver_3_0_0 && %win wxMenu *MSWGetSystemMenu() const;
 static int LUACALL wxLua_wxTopLevelWindow_MSWGetSystemMenu(lua_State *L)
 {
     // get this
@@ -1968,7 +1977,7 @@ static int LUACALL wxLua_wxTopLevelWindow_MSWGetSystemMenu(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_Maximize[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_Maximize(lua_State *L);
@@ -1987,11 +1996,11 @@ static int LUACALL wxLua_wxTopLevelWindow_Maximize(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_OSXIsModified[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_OSXIsModified(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_OSXIsModified[1] = {{ wxLua_wxTopLevelWindow_OSXIsModified, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTopLevelWindow_OSXIsModified }};
-//     %wxchkver_3_1_1 && %mac bool OSXIsModified() const;
+//     %wxchkver_3_0_0 && %mac bool OSXIsModified() const;
 static int LUACALL wxLua_wxTopLevelWindow_OSXIsModified(lua_State *L)
 {
     // get this
@@ -2007,7 +2016,7 @@ static int LUACALL wxLua_wxTopLevelWindow_OSXIsModified(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_OSXSetModified[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_OSXSetModified(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_OSXSetModified[1] = {{ wxLua_wxTopLevelWindow_OSXSetModified, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_OSXSetModified }};
-//     %wxchkver_3_1_1 && %mac void OSXSetModified(bool modified);
+//     %wxchkver_3_0_0 && %mac void OSXSetModified(bool modified);
 static int LUACALL wxLua_wxTopLevelWindow_OSXSetModified(lua_State *L)
 {
     // bool modified
@@ -2020,7 +2029,7 @@ static int LUACALL wxLua_wxTopLevelWindow_OSXSetModified(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_RequestUserAttention[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_RequestUserAttention(lua_State *L);
@@ -2041,11 +2050,11 @@ static int LUACALL wxLua_wxTopLevelWindow_RequestUserAttention(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_Restore[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_Restore(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_Restore[1] = {{ wxLua_wxTopLevelWindow_Restore, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTopLevelWindow_Restore }};
-//     %wxchkver_3_1_1 void Restore();
+//     %wxchkver_3_0_0 void Restore();
 static int LUACALL wxLua_wxTopLevelWindow_Restore(lua_State *L)
 {
     // get this
@@ -2056,7 +2065,7 @@ static int LUACALL wxLua_wxTopLevelWindow_Restore(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_SetDefaultItem[] = { &wxluatype_wxTopLevelWindow, &wxluatype_wxWindow, NULL };
@@ -2149,11 +2158,11 @@ static int LUACALL wxLua_wxTopLevelWindow_SetMinSize(lua_State *L)
 
 #endif // (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_SetRepresentedFilename[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_SetRepresentedFilename(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_SetRepresentedFilename[1] = {{ wxLua_wxTopLevelWindow_SetRepresentedFilename, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_SetRepresentedFilename }};
-//     %wxchkver_3_1_1 void SetRepresentedFilename(const wxString& filename);
+//     %wxchkver_3_0_0 void SetRepresentedFilename(const wxString& filename);
 static int LUACALL wxLua_wxTopLevelWindow_SetRepresentedFilename(lua_State *L)
 {
     // const wxString filename
@@ -2166,13 +2175,13 @@ static int LUACALL wxLua_wxTopLevelWindow_SetRepresentedFilename(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_SetShape[] = { &wxluatype_wxTopLevelWindow, &wxluatype_wxRegion, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_SetShape(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_SetShape[1] = {{ wxLua_wxTopLevelWindow_SetShape, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_SetShape }};
-//     !%wxchkver_3_1_1 bool SetShape(const wxRegion& region);
+//     !%wxchkver_3_0_0 bool SetShape(const wxRegion& region);
 static int LUACALL wxLua_wxTopLevelWindow_SetShape(lua_State *L)
 {
     // const wxRegion region
@@ -2187,7 +2196,7 @@ static int LUACALL wxLua_wxTopLevelWindow_SetShape(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
 
 #if (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_SetSizeHints1[] = { &wxluatype_wxTopLevelWindow, &wxluatype_wxSize, &wxluatype_wxSize, &wxluatype_wxSize, NULL };
@@ -2280,11 +2289,11 @@ static int LUACALL wxLua_wxTopLevelWindow_SetTmpDefaultItem(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_SetTransparent1[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_SetTransparent1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent1[1] = {{ wxLua_wxTopLevelWindow_SetTransparent1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_SetTransparent1 }};
-//     !%wxchkver_3_1_1 virtual bool SetTransparent(int alpha);
+//     !%wxchkver_3_0_0 virtual bool SetTransparent(int alpha);
 static int LUACALL wxLua_wxTopLevelWindow_SetTransparent1(lua_State *L)
 {
     // int alpha
@@ -2299,13 +2308,13 @@ static int LUACALL wxLua_wxTopLevelWindow_SetTransparent1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_SetTransparent[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_SetTransparent(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent[1] = {{ wxLua_wxTopLevelWindow_SetTransparent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_SetTransparent }};
-//     %wxchkver_3_1_1 bool SetTransparent(wxByte alpha);
+//     %wxchkver_3_0_0 bool SetTransparent(wxByte alpha);
 static int LUACALL wxLua_wxTopLevelWindow_SetTransparent(lua_State *L)
 {
     // wxByte alpha
@@ -2320,7 +2329,7 @@ static int LUACALL wxLua_wxTopLevelWindow_SetTransparent(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_ShowFullScreen[] = { &wxluatype_wxTopLevelWindow, &wxluatype_TBOOLEAN, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_ShowFullScreen(lua_State *L);
@@ -2345,11 +2354,11 @@ static int LUACALL wxLua_wxTopLevelWindow_ShowFullScreen(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_ShowWithoutActivating[] = { &wxluatype_wxTopLevelWindow, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_ShowWithoutActivating(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_ShowWithoutActivating[1] = {{ wxLua_wxTopLevelWindow_ShowWithoutActivating, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTopLevelWindow_ShowWithoutActivating }};
-//     %wxchkver_3_1_1 void ShowWithoutActivating();
+//     %wxchkver_3_0_0 void ShowWithoutActivating();
 static int LUACALL wxLua_wxTopLevelWindow_ShowWithoutActivating(lua_State *L)
 {
     // get this
@@ -2360,13 +2369,13 @@ static int LUACALL wxLua_wxTopLevelWindow_ShowWithoutActivating(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTopLevelWindow_constructor1[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTopLevelWindow_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_constructor1[1] = {{ wxLua_wxTopLevelWindow_constructor1, WXLUAMETHOD_CONSTRUCTOR, 3, 7, s_wxluatypeArray_wxLua_wxTopLevelWindow_constructor1 }};
-//     %wxchkver_3_1_1 wxTopLevelWindow(wxWindow *parent, wxWindowID id, const wxString& title, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
+//     %wxchkver_3_0_0 wxTopLevelWindow(wxWindow *parent, wxWindowID id, const wxString& title, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_FRAME_STYLE, const wxString& name = wxFrameNameStr);
 static int LUACALL wxLua_wxTopLevelWindow_constructor1(lua_State *L)
 {
     // get number of arguments
@@ -2395,12 +2404,12 @@ static int LUACALL wxLua_wxTopLevelWindow_constructor1(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 static int LUACALL wxLua_wxTopLevelWindow_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_constructor[1] = {{ wxLua_wxTopLevelWindow_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxTopLevelWindow();
+//     %wxchkver_3_0_0 wxTopLevelWindow();
 static int LUACALL wxLua_wxTopLevelWindow_constructor(lua_State *L)
 {
     // call constructor
@@ -2413,7 +2422,7 @@ static int LUACALL wxLua_wxTopLevelWindow_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 
 
@@ -2431,39 +2440,39 @@ static int s_wxluafunc_wxLua_wxTopLevelWindow_SetSizeHints_overload_count = size
 
 #endif // ((wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { wxLua_wxTopLevelWindow_SetTransparent1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_SetTransparent1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { wxLua_wxTopLevelWindow_SetTransparent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTopLevelWindow_SetTransparent },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 };
 static int s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent_overload_count = sizeof(s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTopLevelWindow_constructor_overload[] =
 {
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxTopLevelWindow_constructor1, WXLUAMETHOD_CONSTRUCTOR, 3, 7, s_wxluatypeArray_wxLua_wxTopLevelWindow_constructor1 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { wxLua_wxTopLevelWindow_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 };
 static int s_wxluafunc_wxLua_wxTopLevelWindow_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxTopLevelWindow_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
 
 void wxLua_wxTopLevelWindow_delete_function(void** p)
 {
@@ -2475,38 +2484,38 @@ void wxLua_wxTopLevelWindow_delete_function(void** p)
 wxLuaBindMethod wxTopLevelWindow_methods[] = {
     { "CanSetTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_CanSetTransparent, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "CenterOnScreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_CenterOnScreen, 1, NULL },
     { "CentreOnScreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_CentreOnScreen, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_Create, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 
     { "EnableCloseButton", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_EnableCloseButton, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "EnableFullScreenView", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_EnableFullScreenView, 1, NULL },
     { "EnableMaximizeButton", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_EnableMaximizeButton, 1, NULL },
     { "EnableMinimizeButton", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_EnableMinimizeButton, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "GetDefaultItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_GetDefaultItem, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
     { "GetDefaultSize", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxTopLevelWindow_GetDefaultSize, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxIcon)
     { "GetIcon", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_GetIcon, 1, NULL },
 #endif // (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxIcon)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
     { "GetIcons", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_GetIcons, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxIcon)
 
     { "GetTitle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_GetTitle, 1, NULL },
 
@@ -2521,26 +2530,26 @@ wxLuaBindMethod wxTopLevelWindow_methods[] = {
     { "IsIconized", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_IsIconized, 1, NULL },
     { "IsMaximized", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_IsMaximized, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "Layout", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_Layout, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "MSWGetSystemMenu", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_MSWGetSystemMenu, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "Maximize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_Maximize, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "OSXIsModified", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_OSXIsModified, 1, NULL },
     { "OSXSetModified", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_OSXSetModified, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMAC__)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
     { "RequestUserAttention", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_RequestUserAttention, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "Restore", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_Restore, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "SetDefaultItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetDefaultItem, 1, NULL },
@@ -2556,13 +2565,13 @@ wxLuaBindMethod wxTopLevelWindow_methods[] = {
     { "SetMinSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetMinSize, 1, NULL },
 #endif // (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "SetRepresentedFilename", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetRepresentedFilename, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
     { "SetShape", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetShape, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxRegion)
 
 #if ((wxLUA_USE_wxFrame || wxLUA_USE_wxDialog) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "SetSizeHints", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetSizeHints_overload, s_wxluafunc_wxLua_wxTopLevelWindow_SetSizeHints_overload_count, 0 },
@@ -2574,19 +2583,19 @@ wxLuaBindMethod wxTopLevelWindow_methods[] = {
     { "SetTmpDefaultItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetTmpDefaultItem, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
     { "SetTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent_overload, s_wxluafunc_wxLua_wxTopLevelWindow_SetTransparent_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
 
     { "ShowFullScreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_ShowFullScreen, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
     { "ShowWithoutActivating", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTopLevelWindow_ShowWithoutActivating, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
     { "wxTopLevelWindow", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxTopLevelWindow_constructor_overload, s_wxluafunc_wxLua_wxTopLevelWindow_constructor_overload_count, 0 },
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog)) && (wxLUA_USE_wxFrame || wxLUA_USE_wxDialog))
 
     { 0, 0, 0, 0 },
 };
@@ -2604,11 +2613,11 @@ int wxTopLevelWindow_methodCount = sizeof(wxTopLevelWindow_methods)/sizeof(wxLua
 // Lua MetaTable Tag for Class 'wxFrame'
 int wxluatype_wxFrame = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_Centre[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFrame_Centre(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_Centre[1] = {{ wxLua_wxFrame_Centre, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFrame_Centre }};
-//     %wxchkver_3_1_1 void Centre(int direction = wxBOTH);
+//     %wxchkver_3_0_0 void Centre(int direction = wxBOTH);
 static int LUACALL wxLua_wxFrame_Centre(lua_State *L)
 {
     // get number of arguments
@@ -2623,7 +2632,7 @@ static int LUACALL wxLua_wxFrame_Centre(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxLUA_USE_wxFrame) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_Create[] = { &wxluatype_wxFrame, &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
@@ -2689,11 +2698,11 @@ static int LUACALL wxLua_wxFrame_CreateStatusBar(lua_State *L)
 
 #endif // (wxLUA_USE_wxFrame) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_CreateToolBar1[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFrame_CreateToolBar1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_CreateToolBar1[1] = {{ wxLua_wxFrame_CreateToolBar1, WXLUAMETHOD_METHOD, 1, 4, s_wxluatypeArray_wxLua_wxFrame_CreateToolBar1 }};
-//     !%wxchkver_3_1_1 virtual wxToolBar* CreateToolBar(long style = wxNO_BORDER|wxTB_HORIZONTAL, wxWindowID id = wxID_ANY, const wxString& name = "wxToolBar");
+//     !%wxchkver_3_0_0 virtual wxToolBar* CreateToolBar(long style = wxNO_BORDER|wxTB_HORIZONTAL, wxWindowID id = wxID_ANY, const wxString& name = "wxToolBar");
 static int LUACALL wxLua_wxFrame_CreateToolBar1(lua_State *L)
 {
     // get number of arguments
@@ -2714,13 +2723,13 @@ static int LUACALL wxLua_wxFrame_CreateToolBar1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_CreateToolBar[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFrame_CreateToolBar(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_CreateToolBar[1] = {{ wxLua_wxFrame_CreateToolBar, WXLUAMETHOD_METHOD, 1, 4, s_wxluatypeArray_wxLua_wxFrame_CreateToolBar }};
-//     %wxchkver_3_1_1 wxToolBar* CreateToolBar(long style = wxTB_DEFAULT_STYLE, wxWindowID id = wxID_ANY, const wxString& name = wxToolBarNameStr);
+//     %wxchkver_3_0_0 wxToolBar* CreateToolBar(long style = wxTB_DEFAULT_STYLE, wxWindowID id = wxID_ANY, const wxString& name = wxToolBarNameStr);
 static int LUACALL wxLua_wxFrame_CreateToolBar(lua_State *L)
 {
     // get number of arguments
@@ -2741,13 +2750,13 @@ static int LUACALL wxLua_wxFrame_CreateToolBar(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_DoGiveHelp[] = { &wxluatype_wxFrame, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFrame_DoGiveHelp(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_DoGiveHelp[1] = {{ wxLua_wxFrame_DoGiveHelp, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxFrame_DoGiveHelp }};
-//     %wxchkver_3_1_1 void DoGiveHelp(const wxString& text, bool show);
+//     %wxchkver_3_0_0 void DoGiveHelp(const wxString& text, bool show);
 static int LUACALL wxLua_wxFrame_DoGiveHelp(lua_State *L)
 {
     // bool show
@@ -2762,7 +2771,7 @@ static int LUACALL wxLua_wxFrame_DoGiveHelp(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxLUA_USE_wxFrame) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_GetClientAreaOrigin[] = { &wxluatype_wxFrame, NULL };
@@ -2860,11 +2869,11 @@ static int LUACALL wxLua_wxFrame_GetToolBar(lua_State *L)
 
 #endif // (wxLUA_USE_wxFrame) && (wxLUA_USE_wxToolbar)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_OnCreateStatusBar[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFrame_OnCreateStatusBar(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_OnCreateStatusBar[1] = {{ wxLua_wxFrame_OnCreateStatusBar, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxFrame_OnCreateStatusBar }};
-//     %wxchkver_3_1_1 wxStatusBar* OnCreateStatusBar(int number, long style, wxWindowID id, const wxString& name);
+//     %wxchkver_3_0_0 wxStatusBar* OnCreateStatusBar(int number, long style, wxWindowID id, const wxString& name);
 static int LUACALL wxLua_wxFrame_OnCreateStatusBar(lua_State *L)
 {
     // const wxString name
@@ -2885,13 +2894,13 @@ static int LUACALL wxLua_wxFrame_OnCreateStatusBar(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_OnCreateToolBar[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFrame_OnCreateToolBar(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_OnCreateToolBar[1] = {{ wxLua_wxFrame_OnCreateToolBar, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxFrame_OnCreateToolBar }};
-//     %wxchkver_3_1_1 wxToolBar* OnCreateToolBar(long style, wxWindowID id, const wxString& name);
+//     %wxchkver_3_0_0 wxToolBar* OnCreateToolBar(long style, wxWindowID id, const wxString& name);
 static int LUACALL wxLua_wxFrame_OnCreateToolBar(lua_State *L)
 {
     // const wxString name
@@ -2910,13 +2919,13 @@ static int LUACALL wxLua_wxFrame_OnCreateToolBar(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_PopStatusText[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFrame_PopStatusText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_PopStatusText[1] = {{ wxLua_wxFrame_PopStatusText, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFrame_PopStatusText }};
-//     %wxchkver_3_1_1 void PopStatusText(int number = 0);
+//     %wxchkver_3_0_0 void PopStatusText(int number = 0);
 static int LUACALL wxLua_wxFrame_PopStatusText(lua_State *L)
 {
     // get number of arguments
@@ -2931,7 +2940,7 @@ static int LUACALL wxLua_wxFrame_PopStatusText(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxCHECK_VERSION(2,4,0)) && (wxLUA_USE_wxFrame)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_ProcessCommand[] = { &wxluatype_wxFrame, &wxluatype_TNUMBER, NULL };
@@ -2952,11 +2961,11 @@ static int LUACALL wxLua_wxFrame_ProcessCommand(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,4,0)) && (wxLUA_USE_wxFrame)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_PushStatusText[] = { &wxluatype_wxFrame, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFrame_PushStatusText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_PushStatusText[1] = {{ wxLua_wxFrame_PushStatusText, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxFrame_PushStatusText }};
-//     %wxchkver_3_1_1 void PushStatusText(const wxString &text, int number = 0);
+//     %wxchkver_3_0_0 void PushStatusText(const wxString &text, int number = 0);
 static int LUACALL wxLua_wxFrame_PushStatusText(lua_State *L)
 {
     // get number of arguments
@@ -2973,13 +2982,13 @@ static int LUACALL wxLua_wxFrame_PushStatusText(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_SendSizeEvent[] = { &wxluatype_wxFrame, NULL };
 static int LUACALL wxLua_wxFrame_SendSizeEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_SendSizeEvent[1] = {{ wxLua_wxFrame_SendSizeEvent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFrame_SendSizeEvent }};
-//     !%wxchkver_3_1_1 void SendSizeEvent();
+//     !%wxchkver_3_0_0 void SendSizeEvent();
 static int LUACALL wxLua_wxFrame_SendSizeEvent(lua_State *L)
 {
     // get this
@@ -2990,7 +2999,7 @@ static int LUACALL wxLua_wxFrame_SendSizeEvent(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxLUA_USE_wxFrame) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFrame_SetMenuBar[] = { &wxluatype_wxFrame, &wxluatype_wxMenuBar, NULL };
@@ -3155,22 +3164,22 @@ static int LUACALL wxLua_wxFrame_constructor(lua_State *L)
 
 
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFrame_CreateToolBar_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
     { wxLua_wxFrame_CreateToolBar1, WXLUAMETHOD_METHOD, 1, 4, s_wxluatypeArray_wxLua_wxFrame_CreateToolBar1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
     { wxLua_wxFrame_CreateToolBar, WXLUAMETHOD_METHOD, 1, 4, s_wxluatypeArray_wxLua_wxFrame_CreateToolBar },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 };
 static int s_wxluafunc_wxLua_wxFrame_CreateToolBar_overload_count = sizeof(s_wxluafunc_wxLua_wxFrame_CreateToolBar_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
 
 #if ((wxLUA_USE_wxFrame) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxFrame)
 // function overload table
@@ -3194,9 +3203,9 @@ void wxLua_wxFrame_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxFrame_methods[] = {
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
     { "Centre", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_Centre, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxLUA_USE_wxFrame) && (wxLUA_USE_wxPointSizeRect)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_Create, 1, NULL },
@@ -3206,13 +3215,13 @@ wxLuaBindMethod wxFrame_methods[] = {
     { "CreateStatusBar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_CreateStatusBar, 1, NULL },
 #endif // (wxLUA_USE_wxFrame) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
     { "CreateToolBar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_CreateToolBar_overload, s_wxluafunc_wxLua_wxFrame_CreateToolBar_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
     { "DoGiveHelp", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_DoGiveHelp, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxLUA_USE_wxFrame) && (wxLUA_USE_wxPointSizeRect)
     { "GetClientAreaOrigin", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_GetClientAreaOrigin, 1, NULL },
@@ -3232,29 +3241,29 @@ wxLuaBindMethod wxFrame_methods[] = {
     { "GetToolBar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_GetToolBar, 1, NULL },
 #endif // (wxLUA_USE_wxFrame) && (wxLUA_USE_wxToolbar)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "OnCreateStatusBar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_OnCreateStatusBar, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
     { "OnCreateToolBar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_OnCreateToolBar, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)) && (wxLUA_USE_wxToolbar)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
     { "PopStatusText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_PopStatusText, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxCHECK_VERSION(2,4,0)) && (wxLUA_USE_wxFrame)
     { "ProcessCommand", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_ProcessCommand, 1, NULL },
 #endif // (wxCHECK_VERSION(2,4,0)) && (wxLUA_USE_wxFrame)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
     { "PushStatusText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_PushStatusText, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
     { "SendSizeEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_SendSizeEvent, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFrame)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFrame)
 
 #if (wxLUA_USE_wxFrame) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "SetMenuBar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFrame_SetMenuBar, 1, NULL },
@@ -3423,11 +3432,11 @@ int wxMiniFrame_methodCount = sizeof(wxMiniFrame_methods)/sizeof(wxLuaBindMethod
 // Lua MetaTable Tag for Class 'wxStatusBarPane'
 int wxluatype_wxStatusBarPane = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBarPane_GetStyle[] = { &wxluatype_wxStatusBarPane, NULL };
 static int LUACALL wxLua_wxStatusBarPane_GetStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBarPane_GetStyle[1] = {{ wxLua_wxStatusBarPane_GetStyle, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStatusBarPane_GetStyle }};
-//     %wxchkver_3_1_1 int GetStyle() const;
+//     %wxchkver_3_0_0 int GetStyle() const;
 static int LUACALL wxLua_wxStatusBarPane_GetStyle(lua_State *L)
 {
     // get this
@@ -3443,7 +3452,7 @@ static int LUACALL wxLua_wxStatusBarPane_GetStyle(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBarPane_GetText[] = { &wxluatype_wxStatusBarPane, NULL };
 static int LUACALL wxLua_wxStatusBarPane_GetText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBarPane_GetText[1] = {{ wxLua_wxStatusBarPane_GetText, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStatusBarPane_GetText }};
-//     %wxchkver_3_1_1 wxString GetText() const;
+//     %wxchkver_3_0_0 wxString GetText() const;
 static int LUACALL wxLua_wxStatusBarPane_GetText(lua_State *L)
 {
     // get this
@@ -3459,7 +3468,7 @@ static int LUACALL wxLua_wxStatusBarPane_GetText(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBarPane_GetWidth[] = { &wxluatype_wxStatusBarPane, NULL };
 static int LUACALL wxLua_wxStatusBarPane_GetWidth(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBarPane_GetWidth[1] = {{ wxLua_wxStatusBarPane_GetWidth, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStatusBarPane_GetWidth }};
-//     %wxchkver_3_1_1 int GetWidth() const;
+//     %wxchkver_3_0_0 int GetWidth() const;
 static int LUACALL wxLua_wxStatusBarPane_GetWidth(lua_State *L)
 {
     // get this
@@ -3472,13 +3481,13 @@ static int LUACALL wxLua_wxStatusBarPane_GetWidth(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBarPane_constructor[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStatusBarPane_constructor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBarPane_constructor[1] = {{ wxLua_wxStatusBarPane_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 2, s_wxluatypeArray_wxLua_wxStatusBarPane_constructor }};
-//     %wxchkver_3_1_1 wxStatusBarPane(int style = wxSB_NORMAL, int width = 0);
+//     %wxchkver_3_0_0 wxStatusBarPane(int style = wxSB_NORMAL, int width = 0);
 static int LUACALL wxLua_wxStatusBarPane_constructor(lua_State *L)
 {
     // get number of arguments
@@ -3495,7 +3504,7 @@ static int LUACALL wxLua_wxStatusBarPane_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
 
 
@@ -3507,15 +3516,15 @@ void wxLua_wxStatusBarPane_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxStatusBarPane_methods[] = {
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "GetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBarPane_GetStyle, 1, NULL },
     { "GetText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBarPane_GetText, 1, NULL },
     { "GetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBarPane_GetWidth, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "wxStatusBarPane", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxStatusBarPane_constructor, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
     { 0, 0, 0, 0 },
 };
@@ -3560,11 +3569,11 @@ static int LUACALL wxLua_wxStatusBar_Create(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_GetBorders[] = { &wxluatype_wxStatusBar, NULL };
 static int LUACALL wxLua_wxStatusBar_GetBorders(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBar_GetBorders[1] = {{ wxLua_wxStatusBar_GetBorders, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStatusBar_GetBorders }};
-//     %wxchkver_3_1_1 wxSize GetBorders() const;
+//     %wxchkver_3_0_0 wxSize GetBorders() const;
 static int LUACALL wxLua_wxStatusBar_GetBorders(lua_State *L)
 {
     // get this
@@ -3580,13 +3589,13 @@ static int LUACALL wxLua_wxStatusBar_GetBorders(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_GetField[] = { &wxluatype_wxStatusBar, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStatusBar_GetField(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBar_GetField[1] = {{ wxLua_wxStatusBar_GetField, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStatusBar_GetField }};
-//     %wxchkver_3_1_1 const wxStatusBarPane& GetField(int n) const;
+//     %wxchkver_3_0_0 const wxStatusBarPane& GetField(int n) const;
 static int LUACALL wxLua_wxStatusBar_GetField(lua_State *L)
 {
     // int n
@@ -3601,7 +3610,7 @@ static int LUACALL wxLua_wxStatusBar_GetField(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
 #if (wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_GetFieldRect[] = { &wxluatype_wxStatusBar, &wxluatype_TNUMBER, &wxluatype_wxRect, NULL };
@@ -3643,11 +3652,11 @@ static int LUACALL wxLua_wxStatusBar_GetFieldsCount(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_GetStatusStyle[] = { &wxluatype_wxStatusBar, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStatusBar_GetStatusStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBar_GetStatusStyle[1] = {{ wxLua_wxStatusBar_GetStatusStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStatusBar_GetStatusStyle }};
-//     %wxchkver_3_1_1 int GetStatusStyle(int n) const;
+//     %wxchkver_3_0_0 int GetStatusStyle(int n) const;
 static int LUACALL wxLua_wxStatusBar_GetStatusStyle(lua_State *L)
 {
     // int n
@@ -3662,7 +3671,7 @@ static int LUACALL wxLua_wxStatusBar_GetStatusStyle(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_GetStatusText[] = { &wxluatype_wxStatusBar, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStatusBar_GetStatusText(lua_State *L);
@@ -3685,11 +3694,11 @@ static int LUACALL wxLua_wxStatusBar_GetStatusText(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_GetStatusWidth[] = { &wxluatype_wxStatusBar, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStatusBar_GetStatusWidth(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStatusBar_GetStatusWidth[1] = {{ wxLua_wxStatusBar_GetStatusWidth, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStatusBar_GetStatusWidth }};
-//     %wxchkver_3_1_1 int GetStatusWidth(int n) const;
+//     %wxchkver_3_0_0 int GetStatusWidth(int n) const;
 static int LUACALL wxLua_wxStatusBar_GetStatusWidth(lua_State *L)
 {
     // int n
@@ -3704,7 +3713,7 @@ static int LUACALL wxLua_wxStatusBar_GetStatusWidth(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStatusBar_PopStatusText[] = { &wxluatype_wxStatusBar, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStatusBar_PopStatusText(lua_State *L);
@@ -3903,13 +3912,13 @@ void wxLua_wxStatusBar_delete_function(void** p)
 wxLuaBindMethod wxStatusBar_methods[] = {
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_Create, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
     { "GetBorders", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetBorders, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "GetField", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetField, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
 #if (wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "GetFieldRect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetFieldRect, 1, NULL },
@@ -3917,15 +3926,15 @@ wxLuaBindMethod wxStatusBar_methods[] = {
 
     { "GetFieldsCount", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetFieldsCount, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "GetStatusStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetStatusStyle, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
     { "GetStatusText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetStatusText, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
     { "GetStatusWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_GetStatusWidth, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxStatusBar && wxUSE_STATUSBAR)
 
     { "PopStatusText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_PopStatusText, 1, NULL },
     { "PushStatusText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStatusBar_PushStatusText, 1, NULL },

--- a/wxLua/modules/wxbind/src/wxcore_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_bind.cpp
@@ -63,7 +63,7 @@ wxCursor* wxLua_wxSTANDARD_CURSOR = NULL;
 wxCursor* wxLua_wxHOURGLASS_CURSOR = NULL;
 wxCursor* wxLua_wxCROSS_CURSOR = NULL;
 
-#if defined(__MINGW32__) || defined(__GNUWIN32__)
+#if (defined(__MINGW32__) || defined(__GNUWIN32__)) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
     // FIX: "internal compiler error: output_operand: invalid expression as operand"
     // We set their value again later since some compilers (gcc) won't set their value yet
     static wxPoint wxLua_wxDefaultPosition = wxDefaultPosition;
@@ -7751,7 +7751,7 @@ wxLuaBinding_wxcore::wxLuaBinding_wxcore() : wxLuaBinding()
 
 bool wxLuaBinding_wxcore::RegisterBinding(const wxLuaState& wxlState)
 {
-#if defined(__MINGW32__) || defined(__GNUWIN32__)
+#if (defined(__MINGW32__) || defined(__GNUWIN32__)) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 9))
     #undef wxDefaultPosition
     #undef wxDefaultSize
     #undef wxEVT_COMMAND_DIRPICKER_CHANGED

--- a/wxLua/modules/wxbind/src/wxcore_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_bind.cpp
@@ -696,7 +696,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxBOTH", wxBOTH },
         { "wxBOTTOM", wxBOTTOM },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
         { "wxBRUSHSTYLE_BDIAGONAL_HATCH", wxBRUSHSTYLE_BDIAGONAL_HATCH },
         { "wxBRUSHSTYLE_CROSSDIAG_HATCH", wxBRUSHSTYLE_CROSSDIAG_HATCH },
         { "wxBRUSHSTYLE_CROSS_HATCH", wxBRUSHSTYLE_CROSS_HATCH },
@@ -711,7 +711,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE", wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE },
         { "wxBRUSHSTYLE_TRANSPARENT", wxBRUSHSTYLE_TRANSPARENT },
         { "wxBRUSHSTYLE_VERTICAL_HATCH", wxBRUSHSTYLE_VERTICAL_HATCH },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 #if wxLUA_USE_wxButton && wxUSE_BUTTON
         { "wxBU_ALIGN_MASK", wxBU_ALIGN_MASK },
@@ -1158,7 +1158,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxFONTFLAG_UNDERLINED", wxFONTFLAG_UNDERLINED },
 #endif // wxLUA_USE_wxFont
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
         { "wxFONTSIZE_LARGE", wxFONTSIZE_LARGE },
         { "wxFONTSIZE_MEDIUM", wxFONTSIZE_MEDIUM },
         { "wxFONTSIZE_SMALL", wxFONTSIZE_SMALL },
@@ -1166,7 +1166,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxFONTSIZE_XX_SMALL", wxFONTSIZE_XX_SMALL },
         { "wxFONTSIZE_X_LARGE", wxFONTSIZE_X_LARGE },
         { "wxFONTSIZE_X_SMALL", wxFONTSIZE_X_SMALL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
 #if wxLUA_USE_wxFont
         { "wxFONTSTYLE_ITALIC", wxFONTSTYLE_ITALIC },
@@ -1272,7 +1272,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
 
         { "wxHSCROLL", wxHSCROLL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
         { "wxHT_MAX", wxHT_MAX },
         { "wxHT_NOWHERE", wxHT_NOWHERE },
         { "wxHT_SCROLLBAR_ARROW_LINE_1", wxHT_SCROLLBAR_ARROW_LINE_1 },
@@ -1289,7 +1289,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxHT_WINDOW_INSIDE", wxHT_WINDOW_INSIDE },
         { "wxHT_WINDOW_OUTSIDE", wxHT_WINDOW_OUTSIDE },
         { "wxHT_WINDOW_VERT_SCROLLBAR", wxHT_WINDOW_VERT_SCROLLBAR },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if (wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)
         { "wxHeight", wxHeight },
@@ -2174,7 +2174,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxSHORT_DASH", wxSHORT_DASH },
 #endif // wxLUA_USE_wxColourPenBrush
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
         { "wxSHOW_EFFECT_BLEND", wxSHOW_EFFECT_BLEND },
         { "wxSHOW_EFFECT_EXPAND", wxSHOW_EFFECT_EXPAND },
         { "wxSHOW_EFFECT_MAX", wxSHOW_EFFECT_MAX },
@@ -2187,7 +2187,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxcore(size_t &count)
         { "wxSHOW_EFFECT_SLIDE_TO_LEFT", wxSHOW_EFFECT_SLIDE_TO_LEFT },
         { "wxSHOW_EFFECT_SLIDE_TO_RIGHT", wxSHOW_EFFECT_SLIDE_TO_RIGHT },
         { "wxSHOW_EFFECT_SLIDE_TO_TOP", wxSHOW_EFFECT_SLIDE_TO_TOP },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
         { "wxSHRINK", wxSHRINK },
         { "wxSHUTDOWN_POWEROFF", wxSHUTDOWN_POWEROFF },

--- a/wxLua/modules/wxbind/src/wxcore_controls.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_controls.cpp
@@ -37,11 +37,11 @@
 // Lua MetaTable Tag for Class 'wxAnyButton'
 int wxluatype_wxAnyButton = WXLUA_TUNKNOWN;
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmap[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmap(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmap[1] = {{ wxLua_wxAnyButton_GetBitmap, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmap }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmap() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmap() const;
 static int LUACALL wxLua_wxAnyButton_GetBitmap(lua_State *L)
 {
     // get this
@@ -60,7 +60,7 @@ static int LUACALL wxLua_wxAnyButton_GetBitmap(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapCurrent[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmapCurrent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmapCurrent[1] = {{ wxLua_wxAnyButton_GetBitmapCurrent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapCurrent }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmapCurrent() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmapCurrent() const;
 static int LUACALL wxLua_wxAnyButton_GetBitmapCurrent(lua_State *L)
 {
     // get this
@@ -79,7 +79,7 @@ static int LUACALL wxLua_wxAnyButton_GetBitmapCurrent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapDisabled[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmapDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmapDisabled[1] = {{ wxLua_wxAnyButton_GetBitmapDisabled, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapDisabled }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmapDisabled() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmapDisabled() const;
 static int LUACALL wxLua_wxAnyButton_GetBitmapDisabled(lua_State *L)
 {
     // get this
@@ -98,7 +98,7 @@ static int LUACALL wxLua_wxAnyButton_GetBitmapDisabled(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapFocus[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmapFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmapFocus[1] = {{ wxLua_wxAnyButton_GetBitmapFocus, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapFocus }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmapFocus() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmapFocus() const;
 static int LUACALL wxLua_wxAnyButton_GetBitmapFocus(lua_State *L)
 {
     // get this
@@ -117,7 +117,7 @@ static int LUACALL wxLua_wxAnyButton_GetBitmapFocus(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapLabel[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmapLabel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmapLabel[1] = {{ wxLua_wxAnyButton_GetBitmapLabel, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapLabel }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmapLabel() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmapLabel() const;
 static int LUACALL wxLua_wxAnyButton_GetBitmapLabel(lua_State *L)
 {
     // get this
@@ -133,13 +133,13 @@ static int LUACALL wxLua_wxAnyButton_GetBitmapLabel(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapMargins[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmapMargins(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmapMargins[1] = {{ wxLua_wxAnyButton_GetBitmapMargins, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapMargins }};
-//     %wxchkver_3_1_1 wxSize GetBitmapMargins();
+//     %wxchkver_3_0_0 wxSize GetBitmapMargins();
 static int LUACALL wxLua_wxAnyButton_GetBitmapMargins(lua_State *L)
 {
     // get this
@@ -155,13 +155,13 @@ static int LUACALL wxLua_wxAnyButton_GetBitmapMargins(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapPressed[] = { &wxluatype_wxAnyButton, NULL };
 static int LUACALL wxLua_wxAnyButton_GetBitmapPressed(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_GetBitmapPressed[1] = {{ wxLua_wxAnyButton_GetBitmapPressed, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxAnyButton_GetBitmapPressed }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmapPressed() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmapPressed() const;
 static int LUACALL wxLua_wxAnyButton_GetBitmapPressed(lua_State *L)
 {
     // get this
@@ -180,7 +180,7 @@ static int LUACALL wxLua_wxAnyButton_GetBitmapPressed(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmap[] = { &wxluatype_wxAnyButton, &wxluatype_wxBitmap, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmap(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmap[1] = {{ wxLua_wxAnyButton_SetBitmap, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmap }};
-//     %wxchkver_3_1_1 void SetBitmap(const wxBitmap& bitmap, wxDirection dir = wxLEFT);
+//     %wxchkver_3_0_0 void SetBitmap(const wxBitmap& bitmap, wxDirection dir = wxLEFT);
 static int LUACALL wxLua_wxAnyButton_SetBitmap(lua_State *L)
 {
     // get number of arguments
@@ -200,7 +200,7 @@ static int LUACALL wxLua_wxAnyButton_SetBitmap(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapCurrent[] = { &wxluatype_wxAnyButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapCurrent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapCurrent[1] = {{ wxLua_wxAnyButton_SetBitmapCurrent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapCurrent }};
-//     %wxchkver_3_1_1 void SetBitmapCurrent(const wxBitmap& bitmap);
+//     %wxchkver_3_0_0 void SetBitmapCurrent(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxAnyButton_SetBitmapCurrent(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -216,7 +216,7 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapCurrent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapDisabled[] = { &wxluatype_wxAnyButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapDisabled[1] = {{ wxLua_wxAnyButton_SetBitmapDisabled, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapDisabled }};
-//     %wxchkver_3_1_1 void SetBitmapDisabled(const wxBitmap& bitmap);
+//     %wxchkver_3_0_0 void SetBitmapDisabled(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxAnyButton_SetBitmapDisabled(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -232,7 +232,7 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapDisabled(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapFocus[] = { &wxluatype_wxAnyButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapFocus[1] = {{ wxLua_wxAnyButton_SetBitmapFocus, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapFocus }};
-//     %wxchkver_3_1_1 void SetBitmapFocus(const wxBitmap& bitmap);
+//     %wxchkver_3_0_0 void SetBitmapFocus(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxAnyButton_SetBitmapFocus(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -248,7 +248,7 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapFocus(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapLabel[] = { &wxluatype_wxAnyButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapLabel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapLabel[1] = {{ wxLua_wxAnyButton_SetBitmapLabel, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapLabel }};
-//     %wxchkver_3_1_1 void SetBitmapLabel(const wxBitmap& bitmap);
+//     %wxchkver_3_0_0 void SetBitmapLabel(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxAnyButton_SetBitmapLabel(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -261,13 +261,13 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapLabel(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapMargins1[] = { &wxluatype_wxAnyButton, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapMargins1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins1[1] = {{ wxLua_wxAnyButton_SetBitmapMargins1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapMargins1 }};
-//     %wxchkver_3_1_1 void SetBitmapMargins(const wxSize& sz);
+//     %wxchkver_3_0_0 void SetBitmapMargins(const wxSize& sz);
 static int LUACALL wxLua_wxAnyButton_SetBitmapMargins1(lua_State *L)
 {
     // const wxSize sz
@@ -280,13 +280,13 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapMargins1(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapMargins[] = { &wxluatype_wxAnyButton, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapMargins(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins[1] = {{ wxLua_wxAnyButton_SetBitmapMargins, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapMargins }};
-//     %wxchkver_3_1_1 void SetBitmapMargins(wxCoord x, wxCoord y);
+//     %wxchkver_3_0_0 void SetBitmapMargins(wxCoord x, wxCoord y);
 static int LUACALL wxLua_wxAnyButton_SetBitmapMargins(lua_State *L)
 {
     // wxCoord y
@@ -304,7 +304,7 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapMargins(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapPosition[] = { &wxluatype_wxAnyButton, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapPosition(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapPosition[1] = {{ wxLua_wxAnyButton_SetBitmapPosition, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapPosition }};
-//     %wxchkver_3_1_1 void SetBitmapPosition(wxDirection dir);
+//     %wxchkver_3_0_0 void SetBitmapPosition(wxDirection dir);
 static int LUACALL wxLua_wxAnyButton_SetBitmapPosition(lua_State *L)
 {
     // wxDirection dir
@@ -317,13 +317,13 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapPosition(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapPressed[] = { &wxluatype_wxAnyButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxAnyButton_SetBitmapPressed(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapPressed[1] = {{ wxLua_wxAnyButton_SetBitmapPressed, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapPressed }};
-//     %wxchkver_3_1_1 void SetBitmapPressed(const wxBitmap& bitmap);
+//     %wxchkver_3_0_0 void SetBitmapPressed(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxAnyButton_SetBitmapPressed(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -336,12 +336,12 @@ static int LUACALL wxLua_wxAnyButton_SetBitmapPressed(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 static int LUACALL wxLua_wxAnyButton_constructor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_constructor[1] = {{ wxLua_wxAnyButton_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxAnyButton();
+//     %wxchkver_3_0_0 wxAnyButton();
 static int LUACALL wxLua_wxAnyButton_constructor(lua_State *L)
 {
     // call constructor
@@ -354,26 +354,26 @@ static int LUACALL wxLua_wxAnyButton_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
 
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxAnyButton_SetBitmapMargins1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapMargins1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
     { wxLua_wxAnyButton_SetBitmapMargins, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxAnyButton_SetBitmapMargins },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 };
 static int s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins_overload_count = sizeof(s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
 
 void wxLua_wxAnyButton_delete_function(void** p)
 {
@@ -383,42 +383,42 @@ void wxLua_wxAnyButton_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxAnyButton_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
     { "GetBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmap, 1, NULL },
     { "GetBitmapCurrent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmapCurrent, 1, NULL },
     { "GetBitmapDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmapDisabled, 1, NULL },
     { "GetBitmapFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmapFocus, 1, NULL },
     { "GetBitmapLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmapLabel, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
     { "GetBitmapMargins", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmapMargins, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
     { "GetBitmapPressed", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_GetBitmapPressed, 1, NULL },
     { "SetBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmap, 1, NULL },
     { "SetBitmapCurrent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapCurrent, 1, NULL },
     { "SetBitmapDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapDisabled, 1, NULL },
     { "SetBitmapFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapFocus, 1, NULL },
     { "SetBitmapLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapLabel, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
     { "SetBitmapMargins", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins_overload, s_wxluafunc_wxLua_wxAnyButton_SetBitmapMargins_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
     { "SetBitmapPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapPosition, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
     { "SetBitmapPressed", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxAnyButton_SetBitmapPressed, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
     { "wxAnyButton", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxAnyButton_constructor, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
     { 0, 0, 0, 0 },
 };
@@ -473,11 +473,11 @@ static int LUACALL wxLua_wxButton_Create(lua_State *L)
 
 #endif // ((wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxButton_GetAuthNeeded[] = { &wxluatype_wxButton, NULL };
 static int LUACALL wxLua_wxButton_GetAuthNeeded(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxButton_GetAuthNeeded[1] = {{ wxLua_wxButton_GetAuthNeeded, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxButton_GetAuthNeeded }};
-//     %wxchkver_3_1_1 bool GetAuthNeeded() const;
+//     %wxchkver_3_0_0 bool GetAuthNeeded() const;
 static int LUACALL wxLua_wxButton_GetAuthNeeded(lua_State *L)
 {
     // get this
@@ -490,7 +490,7 @@ static int LUACALL wxLua_wxButton_GetAuthNeeded(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
 #if (wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)
 static int LUACALL wxLua_wxButton_GetDefaultSize(lua_State *L);
@@ -511,11 +511,11 @@ static int LUACALL wxLua_wxButton_GetDefaultSize(lua_State *L)
 
 #endif // (wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxButton_GetLabel[] = { &wxluatype_wxButton, NULL };
 static int LUACALL wxLua_wxButton_GetLabel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxButton_GetLabel[1] = {{ wxLua_wxButton_GetLabel, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxButton_GetLabel }};
-//     %wxchkver_3_1_1 wxString GetLabel() const;
+//     %wxchkver_3_0_0 wxString GetLabel() const;
 static int LUACALL wxLua_wxButton_GetLabel(lua_State *L)
 {
     // get this
@@ -531,7 +531,7 @@ static int LUACALL wxLua_wxButton_GetLabel(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxButton_SetAuthNeeded[] = { &wxluatype_wxButton, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxButton_SetAuthNeeded(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxButton_SetAuthNeeded[1] = {{ wxLua_wxButton_SetAuthNeeded, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxButton_SetAuthNeeded }};
-//     %wxchkver_3_1_1 void SetAuthNeeded(bool needed = true);
+//     %wxchkver_3_0_0 void SetAuthNeeded(bool needed = true);
 static int LUACALL wxLua_wxButton_SetAuthNeeded(lua_State *L)
 {
     // get number of arguments
@@ -546,7 +546,7 @@ static int LUACALL wxLua_wxButton_SetAuthNeeded(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxButton_SetDefault[] = { &wxluatype_wxButton, NULL };
 static int LUACALL wxLua_wxButton_SetDefault(lua_State *L);
@@ -563,11 +563,11 @@ static int LUACALL wxLua_wxButton_SetDefault(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxButton_SetLabel[] = { &wxluatype_wxButton, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxButton_SetLabel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxButton_SetLabel[1] = {{ wxLua_wxButton_SetLabel, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxButton_SetLabel }};
-//     %wxchkver_3_1_1 void SetLabel(const wxString& label);
+//     %wxchkver_3_0_0 void SetLabel(const wxString& label);
 static int LUACALL wxLua_wxButton_SetLabel(lua_State *L)
 {
     // const wxString label
@@ -580,7 +580,7 @@ static int LUACALL wxLua_wxButton_SetLabel(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
 #if ((wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxButton_constructor1[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_wxValidator, &wxluatype_TSTRING, NULL };
@@ -663,24 +663,24 @@ wxLuaBindMethod wxButton_methods[] = {
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxButton_Create, 1, NULL },
 #endif // ((wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
     { "GetAuthNeeded", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxButton_GetAuthNeeded, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
 #if (wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)
     { "GetDefaultSize", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxButton_GetDefaultSize, 1, NULL },
 #endif // (wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
     { "GetLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxButton_GetLabel, 1, NULL },
     { "SetAuthNeeded", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxButton_SetAuthNeeded, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
     { "SetDefault", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxButton_SetDefault, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
     { "SetLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxButton_SetLabel, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxButton && wxUSE_BUTTON)
 
 #if (((wxLUA_USE_wxButton && wxUSE_BUTTON) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(wxLUA_USE_wxButton && wxUSE_BUTTON)
     { "wxButton", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxButton_constructor_overload, s_wxluafunc_wxLua_wxButton_constructor_overload_count, 0 },
@@ -739,11 +739,11 @@ static int LUACALL wxLua_wxBitmapButton_Create(lua_State *L)
 
 #endif // ((((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapDisabled[] = { &wxluatype_wxBitmapButton, NULL };
 static int LUACALL wxLua_wxBitmapButton_GetBitmapDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_GetBitmapDisabled[1] = {{ wxLua_wxBitmapButton_GetBitmapDisabled, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapDisabled }};
-//     !%wxchkver_3_1_1 wxBitmap GetBitmapDisabled() const;
+//     !%wxchkver_3_0_0 wxBitmap GetBitmapDisabled() const;
 static int LUACALL wxLua_wxBitmapButton_GetBitmapDisabled(lua_State *L)
 {
     // get this
@@ -762,7 +762,7 @@ static int LUACALL wxLua_wxBitmapButton_GetBitmapDisabled(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapFocus[] = { &wxluatype_wxBitmapButton, NULL };
 static int LUACALL wxLua_wxBitmapButton_GetBitmapFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_GetBitmapFocus[1] = {{ wxLua_wxBitmapButton_GetBitmapFocus, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapFocus }};
-//     !%wxchkver_3_1_1 wxBitmap GetBitmapFocus() const;
+//     !%wxchkver_3_0_0 wxBitmap GetBitmapFocus() const;
 static int LUACALL wxLua_wxBitmapButton_GetBitmapFocus(lua_State *L)
 {
     // get this
@@ -778,13 +778,13 @@ static int LUACALL wxLua_wxBitmapButton_GetBitmapFocus(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapHover[] = { &wxluatype_wxBitmapButton, NULL };
 static int LUACALL wxLua_wxBitmapButton_GetBitmapHover(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_GetBitmapHover[1] = {{ wxLua_wxBitmapButton_GetBitmapHover, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapHover }};
-//     !%wxchkver_3_1_1 && %wxchkver_2_8 wxBitmap GetBitmapHover() const;
+//     !%wxchkver_3_0_0 && %wxchkver_2_8 wxBitmap GetBitmapHover() const;
 static int LUACALL wxLua_wxBitmapButton_GetBitmapHover(lua_State *L)
 {
     // get this
@@ -800,13 +800,13 @@ static int LUACALL wxLua_wxBitmapButton_GetBitmapHover(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapLabel[] = { &wxluatype_wxBitmapButton, NULL };
 static int LUACALL wxLua_wxBitmapButton_GetBitmapLabel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_GetBitmapLabel[1] = {{ wxLua_wxBitmapButton_GetBitmapLabel, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapLabel }};
-//     !%wxchkver_3_1_1 wxBitmap GetBitmapLabel() const;
+//     !%wxchkver_3_0_0 wxBitmap GetBitmapLabel() const;
 static int LUACALL wxLua_wxBitmapButton_GetBitmapLabel(lua_State *L)
 {
     // get this
@@ -825,7 +825,7 @@ static int LUACALL wxLua_wxBitmapButton_GetBitmapLabel(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapSelected[] = { &wxluatype_wxBitmapButton, NULL };
 static int LUACALL wxLua_wxBitmapButton_GetBitmapSelected(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_GetBitmapSelected[1] = {{ wxLua_wxBitmapButton_GetBitmapSelected, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmapButton_GetBitmapSelected }};
-//     !%wxchkver_3_1_1 wxBitmap GetBitmapSelected() const;
+//     !%wxchkver_3_0_0 wxBitmap GetBitmapSelected() const;
 static int LUACALL wxLua_wxBitmapButton_GetBitmapSelected(lua_State *L)
 {
     // get this
@@ -841,13 +841,13 @@ static int LUACALL wxLua_wxBitmapButton_GetBitmapSelected(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,1,1))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#if (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,0,0))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_NewCloseButton[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmapButton_NewCloseButton(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_NewCloseButton[1] = {{ wxLua_wxBitmapButton_NewCloseButton, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxBitmapButton_NewCloseButton }};
-//     %wxchkver_3_1_1 static wxBitmapButton* NewCloseButton(wxWindow* parent, wxWindowID winid);
+//     %wxchkver_3_0_0 static wxBitmapButton* NewCloseButton(wxWindow* parent, wxWindowID winid);
 static int LUACALL wxLua_wxBitmapButton_NewCloseButton(lua_State *L)
 {
     // wxWindowID winid
@@ -862,13 +862,13 @@ static int LUACALL wxLua_wxBitmapButton_NewCloseButton(lua_State *L)
     return 1;
 }
 
-#endif // (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,1,1))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#endif // (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,0,0))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapDisabled[] = { &wxluatype_wxBitmapButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmapButton_SetBitmapDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_SetBitmapDisabled[1] = {{ wxLua_wxBitmapButton_SetBitmapDisabled, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapDisabled }};
-//     !%wxchkver_3_1_1 void     SetBitmapDisabled(const wxBitmap& bitmap);
+//     !%wxchkver_3_0_0 void     SetBitmapDisabled(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxBitmapButton_SetBitmapDisabled(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -884,7 +884,7 @@ static int LUACALL wxLua_wxBitmapButton_SetBitmapDisabled(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapFocus[] = { &wxluatype_wxBitmapButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmapButton_SetBitmapFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_SetBitmapFocus[1] = {{ wxLua_wxBitmapButton_SetBitmapFocus, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapFocus }};
-//     !%wxchkver_3_1_1 void     SetBitmapFocus(const wxBitmap& bitmap);
+//     !%wxchkver_3_0_0 void     SetBitmapFocus(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxBitmapButton_SetBitmapFocus(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -897,13 +897,13 @@ static int LUACALL wxLua_wxBitmapButton_SetBitmapFocus(lua_State *L)
     return 0;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapHover[] = { &wxluatype_wxBitmapButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmapButton_SetBitmapHover(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_SetBitmapHover[1] = {{ wxLua_wxBitmapButton_SetBitmapHover, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapHover }};
-//     !%wxchkver_3_1_1 && %wxchkver_2_8 void SetBitmapHover(const wxBitmap& hover);
+//     !%wxchkver_3_0_0 && %wxchkver_2_8 void SetBitmapHover(const wxBitmap& hover);
 static int LUACALL wxLua_wxBitmapButton_SetBitmapHover(lua_State *L)
 {
     // const wxBitmap hover
@@ -916,13 +916,13 @@ static int LUACALL wxLua_wxBitmapButton_SetBitmapHover(lua_State *L)
     return 0;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapLabel[] = { &wxluatype_wxBitmapButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmapButton_SetBitmapLabel(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_SetBitmapLabel[1] = {{ wxLua_wxBitmapButton_SetBitmapLabel, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapLabel }};
-//     !%wxchkver_3_1_1 void     SetBitmapLabel(const wxBitmap& bitmap);
+//     !%wxchkver_3_0_0 void     SetBitmapLabel(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxBitmapButton_SetBitmapLabel(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -938,7 +938,7 @@ static int LUACALL wxLua_wxBitmapButton_SetBitmapLabel(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapSelected[] = { &wxluatype_wxBitmapButton, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmapButton_SetBitmapSelected(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapButton_SetBitmapSelected[1] = {{ wxLua_wxBitmapButton_SetBitmapSelected, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmapButton_SetBitmapSelected }};
-//     !%wxchkver_3_1_1 void     SetBitmapSelected(const wxBitmap& bitmap);
+//     !%wxchkver_3_0_0 void     SetBitmapSelected(const wxBitmap& bitmap);
 static int LUACALL wxLua_wxBitmapButton_SetBitmapSelected(lua_State *L)
 {
     // const wxBitmap bitmap
@@ -951,7 +951,7 @@ static int LUACALL wxLua_wxBitmapButton_SetBitmapSelected(lua_State *L)
     return 0;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
 #if ((((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapButton_constructor1[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_wxBitmap, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_wxValidator, &wxluatype_TSTRING, NULL };
@@ -1034,37 +1034,37 @@ wxLuaBindMethod wxBitmapButton_methods[] = {
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_Create, 1, NULL },
 #endif // ((((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
     { "GetBitmapDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_GetBitmapDisabled, 1, NULL },
     { "GetBitmapFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_GetBitmapFocus, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
     { "GetBitmapHover", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_GetBitmapHover, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
     { "GetBitmapLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_GetBitmapLabel, 1, NULL },
     { "GetBitmapSelected", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_GetBitmapSelected, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,1,1))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#if (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,0,0))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
     { "NewCloseButton", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxBitmapButton_NewCloseButton, 1, NULL },
-#endif // (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,1,1))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
+#endif // (((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxCHECK_VERSION(3,0,0))) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
     { "SetBitmapDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_SetBitmapDisabled, 1, NULL },
     { "SetBitmapFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_SetBitmapFocus, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
     { "SetBitmapHover", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_SetBitmapHover, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,8,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
     { "SetBitmapLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_SetBitmapLabel, 1, NULL },
     { "SetBitmapSelected", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapButton_SetBitmapSelected, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && ((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))) && (wxLUA_USE_wxBitmap)
 
 #if (((((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||((wxLUA_USE_wxBitmapButton && wxUSE_BMPBUTTON) && (wxLUA_USE_wxButton && wxUSE_BUTTON))
     { "wxBitmapButton", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxBitmapButton_constructor_overload, s_wxluafunc_wxLua_wxBitmapButton_constructor_overload_count, 0 },
@@ -1260,11 +1260,11 @@ int wxToggleButton_methodCount = sizeof(wxToggleButton_methods)/sizeof(wxLuaBind
 // Lua MetaTable Tag for Class 'wxBitmapToggleButton'
 int wxluatype_wxBitmapToggleButton = WXLUA_TUNKNOWN;
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapToggleButton_Create[] = { &wxluatype_wxBitmapToggleButton, &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_wxBitmap, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_wxValidator, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxBitmapToggleButton_Create(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapToggleButton_Create[1] = {{ wxLua_wxBitmapToggleButton_Create, WXLUAMETHOD_METHOD, 4, 9, s_wxluatypeArray_wxLua_wxBitmapToggleButton_Create }};
-//     %wxchkver_3_1_1 bool Create(wxWindow* parent, wxWindowID id, const wxBitmap& label, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = 0, const wxValidator& val = wxDefaultValidator, const wxString& name = wxCheckBoxNameStr);
+//     %wxchkver_3_0_0 bool Create(wxWindow* parent, wxWindowID id, const wxBitmap& label, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = 0, const wxValidator& val = wxDefaultValidator, const wxString& name = wxCheckBoxNameStr);
 static int LUACALL wxLua_wxBitmapToggleButton_Create(lua_State *L)
 {
     // get number of arguments
@@ -1295,13 +1295,13 @@ static int LUACALL wxLua_wxBitmapToggleButton_Create(lua_State *L)
     return 1;
 }
 
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapToggleButton_GetValue[] = { &wxluatype_wxBitmapToggleButton, NULL };
 static int LUACALL wxLua_wxBitmapToggleButton_GetValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapToggleButton_GetValue[1] = {{ wxLua_wxBitmapToggleButton_GetValue, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmapToggleButton_GetValue }};
-//     %wxchkver_3_1_1 bool GetValue() const;
+//     %wxchkver_3_0_0 bool GetValue() const;
 static int LUACALL wxLua_wxBitmapToggleButton_GetValue(lua_State *L)
 {
     // get this
@@ -1317,7 +1317,7 @@ static int LUACALL wxLua_wxBitmapToggleButton_GetValue(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapToggleButton_SetValue[] = { &wxluatype_wxBitmapToggleButton, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxBitmapToggleButton_SetValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapToggleButton_SetValue[1] = {{ wxLua_wxBitmapToggleButton_SetValue, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmapToggleButton_SetValue }};
-//     %wxchkver_3_1_1 void SetValue(bool state);
+//     %wxchkver_3_0_0 void SetValue(bool state);
 static int LUACALL wxLua_wxBitmapToggleButton_SetValue(lua_State *L)
 {
     // bool state
@@ -1330,13 +1330,13 @@ static int LUACALL wxLua_wxBitmapToggleButton_SetValue(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
 
-#if (((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#if (((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmapToggleButton_constructor1[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_wxBitmap, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_wxValidator, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxBitmapToggleButton_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapToggleButton_constructor1[1] = {{ wxLua_wxBitmapToggleButton_constructor1, WXLUAMETHOD_CONSTRUCTOR, 3, 8, s_wxluatypeArray_wxLua_wxBitmapToggleButton_constructor1 }};
-//     %wxchkver_3_1_1 wxBitmapToggleButton(wxWindow* parent, wxWindowID id, const wxBitmap& label, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = 0, const wxValidator& val = wxDefaultValidator, const wxString& name = wxCheckBoxNameStr);
+//     %wxchkver_3_0_0 wxBitmapToggleButton(wxWindow* parent, wxWindowID id, const wxBitmap& label, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = 0, const wxValidator& val = wxDefaultValidator, const wxString& name = wxCheckBoxNameStr);
 static int LUACALL wxLua_wxBitmapToggleButton_constructor1(lua_State *L)
 {
     // get number of arguments
@@ -1367,12 +1367,12 @@ static int LUACALL wxLua_wxBitmapToggleButton_constructor1(lua_State *L)
     return 1;
 }
 
-#endif // (((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#endif // (((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
 static int LUACALL wxLua_wxBitmapToggleButton_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapToggleButton_constructor[1] = {{ wxLua_wxBitmapToggleButton_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxBitmapToggleButton();
+//     %wxchkver_3_0_0 wxBitmapToggleButton();
 static int LUACALL wxLua_wxBitmapToggleButton_constructor(lua_State *L)
 {
     // call constructor
@@ -1385,26 +1385,26 @@ static int LUACALL wxLua_wxBitmapToggleButton_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
 
 
 
-#if ((((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
+#if ((((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmapToggleButton_constructor_overload[] =
 {
 
-#if (((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#if (((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
     { wxLua_wxBitmapToggleButton_constructor1, WXLUAMETHOD_CONSTRUCTOR, 3, 8, s_wxluatypeArray_wxLua_wxBitmapToggleButton_constructor1 },
-#endif // (((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#endif // (((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
     { wxLua_wxBitmapToggleButton_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
 };
 static int s_wxluafunc_wxLua_wxBitmapToggleButton_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxBitmapToggleButton_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
+#endif // ((((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
 
 void wxLua_wxBitmapToggleButton_delete_function(void** p)
 {
@@ -1414,18 +1414,18 @@ void wxLua_wxBitmapToggleButton_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxBitmapToggleButton_methods[] = {
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapToggleButton_Create, 1, NULL },
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
     { "GetValue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapToggleButton_GetValue, 1, NULL },
     { "SetValue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmapToggleButton_SetValue, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)
 
-#if ((((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
+#if ((((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
     { "wxBitmapToggleButton", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxBitmapToggleButton_constructor_overload, s_wxluafunc_wxLua_wxBitmapToggleButton_constructor_overload_count, 0 },
-#endif // ((((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
+#endif // ((((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN)) && (wxLUA_USE_wxToggleButton && wxUSE_TOGGLEBTN))
 
     { 0, 0, 0, 0 },
 };
@@ -8769,11 +8769,11 @@ int wxSpinCtrl_methodCount = sizeof(wxSpinCtrl_methods)/sizeof(wxLuaBindMethod) 
 // Lua MetaTable Tag for Class 'wxTextEntry'
 int wxluatype_wxTextEntry = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_AppendText[] = { &wxluatype_wxTextEntry, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextEntry_AppendText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_AppendText[1] = {{ wxLua_wxTextEntry_AppendText, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_AppendText }};
-//     %wxchkver_3_1_1 void AppendText(const wxString& text);
+//     %wxchkver_3_0_0 void AppendText(const wxString& text);
 static int LUACALL wxLua_wxTextEntry_AppendText(lua_State *L)
 {
     // const wxString text
@@ -8786,13 +8786,13 @@ static int LUACALL wxLua_wxTextEntry_AppendText(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_AutoComplete[] = { &wxluatype_wxTextEntry, &wxluatype_wxArrayString, NULL };
 static int LUACALL wxLua_wxTextEntry_AutoComplete(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_AutoComplete[1] = {{ wxLua_wxTextEntry_AutoComplete, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_AutoComplete }};
-//     %wxchkver_3_1_1 bool AutoComplete(const wxArrayString& choices);
+//     %wxchkver_3_0_0 bool AutoComplete(const wxArrayString& choices);
 static int LUACALL wxLua_wxTextEntry_AutoComplete(lua_State *L)
 {
     // const wxArrayString choices
@@ -8807,13 +8807,13 @@ static int LUACALL wxLua_wxTextEntry_AutoComplete(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_AutoCompleteDirectories[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_AutoCompleteDirectories(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_AutoCompleteDirectories[1] = {{ wxLua_wxTextEntry_AutoCompleteDirectories, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_AutoCompleteDirectories }};
-//     %wxchkver_3_1_1 bool AutoCompleteDirectories();
+//     %wxchkver_3_0_0 bool AutoCompleteDirectories();
 static int LUACALL wxLua_wxTextEntry_AutoCompleteDirectories(lua_State *L)
 {
     // get this
@@ -8829,7 +8829,7 @@ static int LUACALL wxLua_wxTextEntry_AutoCompleteDirectories(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_AutoCompleteFileNames[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_AutoCompleteFileNames(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_AutoCompleteFileNames[1] = {{ wxLua_wxTextEntry_AutoCompleteFileNames, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_AutoCompleteFileNames }};
-//     %wxchkver_3_1_1 bool AutoCompleteFileNames();
+//     %wxchkver_3_0_0 bool AutoCompleteFileNames();
 static int LUACALL wxLua_wxTextEntry_AutoCompleteFileNames(lua_State *L)
 {
     // get this
@@ -8845,7 +8845,7 @@ static int LUACALL wxLua_wxTextEntry_AutoCompleteFileNames(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_CanCopy[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_CanCopy(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_CanCopy[1] = {{ wxLua_wxTextEntry_CanCopy, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_CanCopy }};
-//     %wxchkver_3_1_1 bool CanCopy() const;
+//     %wxchkver_3_0_0 bool CanCopy() const;
 static int LUACALL wxLua_wxTextEntry_CanCopy(lua_State *L)
 {
     // get this
@@ -8861,7 +8861,7 @@ static int LUACALL wxLua_wxTextEntry_CanCopy(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_CanCut[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_CanCut(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_CanCut[1] = {{ wxLua_wxTextEntry_CanCut, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_CanCut }};
-//     %wxchkver_3_1_1 bool CanCut() const;
+//     %wxchkver_3_0_0 bool CanCut() const;
 static int LUACALL wxLua_wxTextEntry_CanCut(lua_State *L)
 {
     // get this
@@ -8877,7 +8877,7 @@ static int LUACALL wxLua_wxTextEntry_CanCut(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_CanPaste[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_CanPaste(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_CanPaste[1] = {{ wxLua_wxTextEntry_CanPaste, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_CanPaste }};
-//     %wxchkver_3_1_1 bool CanPaste() const;
+//     %wxchkver_3_0_0 bool CanPaste() const;
 static int LUACALL wxLua_wxTextEntry_CanPaste(lua_State *L)
 {
     // get this
@@ -8893,7 +8893,7 @@ static int LUACALL wxLua_wxTextEntry_CanPaste(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_CanRedo[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_CanRedo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_CanRedo[1] = {{ wxLua_wxTextEntry_CanRedo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_CanRedo }};
-//     %wxchkver_3_1_1 bool CanRedo() const;
+//     %wxchkver_3_0_0 bool CanRedo() const;
 static int LUACALL wxLua_wxTextEntry_CanRedo(lua_State *L)
 {
     // get this
@@ -8909,7 +8909,7 @@ static int LUACALL wxLua_wxTextEntry_CanRedo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_CanUndo[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_CanUndo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_CanUndo[1] = {{ wxLua_wxTextEntry_CanUndo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_CanUndo }};
-//     %wxchkver_3_1_1 bool CanUndo() const;
+//     %wxchkver_3_0_0 bool CanUndo() const;
 static int LUACALL wxLua_wxTextEntry_CanUndo(lua_State *L)
 {
     // get this
@@ -8925,7 +8925,7 @@ static int LUACALL wxLua_wxTextEntry_CanUndo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_ChangeValue[] = { &wxluatype_wxTextEntry, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextEntry_ChangeValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_ChangeValue[1] = {{ wxLua_wxTextEntry_ChangeValue, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_ChangeValue }};
-//     %wxchkver_3_1_1 void ChangeValue(const wxString& value);
+//     %wxchkver_3_0_0 void ChangeValue(const wxString& value);
 static int LUACALL wxLua_wxTextEntry_ChangeValue(lua_State *L)
 {
     // const wxString value
@@ -8941,7 +8941,7 @@ static int LUACALL wxLua_wxTextEntry_ChangeValue(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Clear[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_Clear(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Clear[1] = {{ wxLua_wxTextEntry_Clear, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_Clear }};
-//     %wxchkver_3_1_1 void Clear();
+//     %wxchkver_3_0_0 void Clear();
 static int LUACALL wxLua_wxTextEntry_Clear(lua_State *L)
 {
     // get this
@@ -8955,7 +8955,7 @@ static int LUACALL wxLua_wxTextEntry_Clear(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Copy[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_Copy(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Copy[1] = {{ wxLua_wxTextEntry_Copy, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_Copy }};
-//     %wxchkver_3_1_1 void Copy();
+//     %wxchkver_3_0_0 void Copy();
 static int LUACALL wxLua_wxTextEntry_Copy(lua_State *L)
 {
     // get this
@@ -8969,7 +8969,7 @@ static int LUACALL wxLua_wxTextEntry_Copy(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Cut[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_Cut(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Cut[1] = {{ wxLua_wxTextEntry_Cut, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_Cut }};
-//     %wxchkver_3_1_1 void Cut();
+//     %wxchkver_3_0_0 void Cut();
 static int LUACALL wxLua_wxTextEntry_Cut(lua_State *L)
 {
     // get this
@@ -8980,6 +8980,7 @@ static int LUACALL wxLua_wxTextEntry_Cut(lua_State *L)
     return 0;
 }
 
+#if wxCHECK_VERSION(3,1,1)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_ForceUpper[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_ForceUpper(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_ForceUpper[1] = {{ wxLua_wxTextEntry_ForceUpper, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_ForceUpper }};
@@ -8993,11 +8994,12 @@ static int LUACALL wxLua_wxTextEntry_ForceUpper(lua_State *L)
 
     return 0;
 }
+#endif
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetHint[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_GetHint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetHint[1] = {{ wxLua_wxTextEntry_GetHint, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_GetHint }};
-//     %wxchkver_3_1_1 wxString GetHint() const;
+//     %wxchkver_3_0_0 wxString GetHint() const;
 static int LUACALL wxLua_wxTextEntry_GetHint(lua_State *L)
 {
     // get this
@@ -9013,7 +9015,7 @@ static int LUACALL wxLua_wxTextEntry_GetHint(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetInsertionPoint[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_GetInsertionPoint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetInsertionPoint[1] = {{ wxLua_wxTextEntry_GetInsertionPoint, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_GetInsertionPoint }};
-//     %wxchkver_3_1_1 long GetInsertionPoint() const;
+//     %wxchkver_3_0_0 long GetInsertionPoint() const;
 static int LUACALL wxLua_wxTextEntry_GetInsertionPoint(lua_State *L)
 {
     // get this
@@ -9029,7 +9031,7 @@ static int LUACALL wxLua_wxTextEntry_GetInsertionPoint(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetLastPosition[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_GetLastPosition(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetLastPosition[1] = {{ wxLua_wxTextEntry_GetLastPosition, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_GetLastPosition }};
-//     %wxchkver_3_1_1 wxTextPos GetLastPosition() const;
+//     %wxchkver_3_0_0 wxTextPos GetLastPosition() const;
 static int LUACALL wxLua_wxTextEntry_GetLastPosition(lua_State *L)
 {
     // get this
@@ -9042,13 +9044,13 @@ static int LUACALL wxLua_wxTextEntry_GetLastPosition(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetMargins[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_GetMargins(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetMargins[1] = {{ wxLua_wxTextEntry_GetMargins, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_GetMargins }};
-//     %wxchkver_3_1_1 wxPoint GetMargins() const;
+//     %wxchkver_3_0_0 wxPoint GetMargins() const;
 static int LUACALL wxLua_wxTextEntry_GetMargins(lua_State *L)
 {
     // get this
@@ -9064,13 +9066,13 @@ static int LUACALL wxLua_wxTextEntry_GetMargins(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetRange[] = { &wxluatype_wxTextEntry, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextEntry_GetRange(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetRange[1] = {{ wxLua_wxTextEntry_GetRange, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxTextEntry_GetRange }};
-//     %wxchkver_3_1_1 wxString GetRange(long from, long to) const;
+//     %wxchkver_3_0_0 wxString GetRange(long from, long to) const;
 static int LUACALL wxLua_wxTextEntry_GetRange(lua_State *L)
 {
     // long to
@@ -9110,7 +9112,7 @@ static int LUACALL wxLua_wxTextEntry_GetSelection(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetStringSelection[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_GetStringSelection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetStringSelection[1] = {{ wxLua_wxTextEntry_GetStringSelection, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_GetStringSelection }};
-//     %wxchkver_3_1_1 wxString GetStringSelection() const;
+//     %wxchkver_3_0_0 wxString GetStringSelection() const;
 static int LUACALL wxLua_wxTextEntry_GetStringSelection(lua_State *L)
 {
     // get this
@@ -9126,7 +9128,7 @@ static int LUACALL wxLua_wxTextEntry_GetStringSelection(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_GetValue[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_GetValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_GetValue[1] = {{ wxLua_wxTextEntry_GetValue, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_GetValue }};
-//     %wxchkver_3_1_1 wxString GetValue() const;
+//     %wxchkver_3_0_0 wxString GetValue() const;
 static int LUACALL wxLua_wxTextEntry_GetValue(lua_State *L)
 {
     // get this
@@ -9142,7 +9144,7 @@ static int LUACALL wxLua_wxTextEntry_GetValue(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_IsEditable[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_IsEditable(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_IsEditable[1] = {{ wxLua_wxTextEntry_IsEditable, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_IsEditable }};
-//     %wxchkver_3_1_1 bool IsEditable() const;
+//     %wxchkver_3_0_0 bool IsEditable() const;
 static int LUACALL wxLua_wxTextEntry_IsEditable(lua_State *L)
 {
     // get this
@@ -9158,7 +9160,7 @@ static int LUACALL wxLua_wxTextEntry_IsEditable(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_IsEmpty[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_IsEmpty(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_IsEmpty[1] = {{ wxLua_wxTextEntry_IsEmpty, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_IsEmpty }};
-//     %wxchkver_3_1_1 bool IsEmpty() const;
+//     %wxchkver_3_0_0 bool IsEmpty() const;
 static int LUACALL wxLua_wxTextEntry_IsEmpty(lua_State *L)
 {
     // get this
@@ -9174,7 +9176,7 @@ static int LUACALL wxLua_wxTextEntry_IsEmpty(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Paste[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_Paste(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Paste[1] = {{ wxLua_wxTextEntry_Paste, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_Paste }};
-//     %wxchkver_3_1_1 void Paste();
+//     %wxchkver_3_0_0 void Paste();
 static int LUACALL wxLua_wxTextEntry_Paste(lua_State *L)
 {
     // get this
@@ -9188,7 +9190,7 @@ static int LUACALL wxLua_wxTextEntry_Paste(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Redo[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_Redo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Redo[1] = {{ wxLua_wxTextEntry_Redo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_Redo }};
-//     %wxchkver_3_1_1 void Redo();
+//     %wxchkver_3_0_0 void Redo();
 static int LUACALL wxLua_wxTextEntry_Redo(lua_State *L)
 {
     // get this
@@ -9202,7 +9204,7 @@ static int LUACALL wxLua_wxTextEntry_Redo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Remove[] = { &wxluatype_wxTextEntry, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextEntry_Remove(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Remove[1] = {{ wxLua_wxTextEntry_Remove, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxTextEntry_Remove }};
-//     %wxchkver_3_1_1 void Remove(long from, long to);
+//     %wxchkver_3_0_0 void Remove(long from, long to);
 static int LUACALL wxLua_wxTextEntry_Remove(lua_State *L)
 {
     // long to
@@ -9220,7 +9222,7 @@ static int LUACALL wxLua_wxTextEntry_Remove(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Replace[] = { &wxluatype_wxTextEntry, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextEntry_Replace(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Replace[1] = {{ wxLua_wxTextEntry_Replace, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxTextEntry_Replace }};
-//     %wxchkver_3_1_1 void Replace(long from, long to, const wxString& value);
+//     %wxchkver_3_0_0 void Replace(long from, long to, const wxString& value);
 static int LUACALL wxLua_wxTextEntry_Replace(lua_State *L)
 {
     // const wxString value
@@ -9240,7 +9242,7 @@ static int LUACALL wxLua_wxTextEntry_Replace(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SelectAll[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_SelectAll(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SelectAll[1] = {{ wxLua_wxTextEntry_SelectAll, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_SelectAll }};
-//     %wxchkver_3_1_1 void SelectAll();
+//     %wxchkver_3_0_0 void SelectAll();
 static int LUACALL wxLua_wxTextEntry_SelectAll(lua_State *L)
 {
     // get this
@@ -9254,7 +9256,7 @@ static int LUACALL wxLua_wxTextEntry_SelectAll(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SelectNone[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_SelectNone(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SelectNone[1] = {{ wxLua_wxTextEntry_SelectNone, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_SelectNone }};
-//     %wxchkver_3_1_1 void SelectNone();
+//     %wxchkver_3_0_0 void SelectNone();
 static int LUACALL wxLua_wxTextEntry_SelectNone(lua_State *L)
 {
     // get this
@@ -9268,7 +9270,7 @@ static int LUACALL wxLua_wxTextEntry_SelectNone(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetEditable[] = { &wxluatype_wxTextEntry, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTextEntry_SetEditable(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetEditable[1] = {{ wxLua_wxTextEntry_SetEditable, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetEditable }};
-//     %wxchkver_3_1_1 void SetEditable(bool editable);
+//     %wxchkver_3_0_0 void SetEditable(bool editable);
 static int LUACALL wxLua_wxTextEntry_SetEditable(lua_State *L)
 {
     // bool editable
@@ -9284,7 +9286,7 @@ static int LUACALL wxLua_wxTextEntry_SetEditable(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetHint[] = { &wxluatype_wxTextEntry, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextEntry_SetHint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetHint[1] = {{ wxLua_wxTextEntry_SetHint, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetHint }};
-//     %wxchkver_3_1_1 bool SetHint(const wxString& hint);
+//     %wxchkver_3_0_0 bool SetHint(const wxString& hint);
 static int LUACALL wxLua_wxTextEntry_SetHint(lua_State *L)
 {
     // const wxString hint
@@ -9302,7 +9304,7 @@ static int LUACALL wxLua_wxTextEntry_SetHint(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetInsertionPoint[] = { &wxluatype_wxTextEntry, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextEntry_SetInsertionPoint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetInsertionPoint[1] = {{ wxLua_wxTextEntry_SetInsertionPoint, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetInsertionPoint }};
-//     %wxchkver_3_1_1 void SetInsertionPoint(long pos);
+//     %wxchkver_3_0_0 void SetInsertionPoint(long pos);
 static int LUACALL wxLua_wxTextEntry_SetInsertionPoint(lua_State *L)
 {
     // long pos
@@ -9318,7 +9320,7 @@ static int LUACALL wxLua_wxTextEntry_SetInsertionPoint(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetInsertionPointEnd[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_SetInsertionPointEnd(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetInsertionPointEnd[1] = {{ wxLua_wxTextEntry_SetInsertionPointEnd, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_SetInsertionPointEnd }};
-//     %wxchkver_3_1_1 void SetInsertionPointEnd();
+//     %wxchkver_3_0_0 void SetInsertionPointEnd();
 static int LUACALL wxLua_wxTextEntry_SetInsertionPointEnd(lua_State *L)
 {
     // get this
@@ -9332,7 +9334,7 @@ static int LUACALL wxLua_wxTextEntry_SetInsertionPointEnd(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetMargins1[] = { &wxluatype_wxTextEntry, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextEntry_SetMargins1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetMargins1[1] = {{ wxLua_wxTextEntry_SetMargins1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxTextEntry_SetMargins1 }};
-//     %wxchkver_3_1_1 bool SetMargins(wxCoord left, wxCoord top = -1);
+//     %wxchkver_3_0_0 bool SetMargins(wxCoord left, wxCoord top = -1);
 static int LUACALL wxLua_wxTextEntry_SetMargins1(lua_State *L)
 {
     // get number of arguments
@@ -9351,13 +9353,13 @@ static int LUACALL wxLua_wxTextEntry_SetMargins1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetMargins[] = { &wxluatype_wxTextEntry, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxTextEntry_SetMargins(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetMargins[1] = {{ wxLua_wxTextEntry_SetMargins, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetMargins }};
-//     %wxchkver_3_1_1 bool SetMargins(const wxPoint& pt);
+//     %wxchkver_3_0_0 bool SetMargins(const wxPoint& pt);
 static int LUACALL wxLua_wxTextEntry_SetMargins(lua_State *L)
 {
     // const wxPoint pt
@@ -9372,13 +9374,13 @@ static int LUACALL wxLua_wxTextEntry_SetMargins(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetMaxLength[] = { &wxluatype_wxTextEntry, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxTextEntry_SetMaxLength(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetMaxLength[1] = {{ wxLua_wxTextEntry_SetMaxLength, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetMaxLength }};
-//     %wxchkver_3_1_1 void SetMaxLength(unsigned long len);
+//     %wxchkver_3_0_0 void SetMaxLength(unsigned long len);
 static int LUACALL wxLua_wxTextEntry_SetMaxLength(lua_State *L)
 {
     // unsigned long len
@@ -9394,7 +9396,7 @@ static int LUACALL wxLua_wxTextEntry_SetMaxLength(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetSelection[] = { &wxluatype_wxTextEntry, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextEntry_SetSelection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetSelection[1] = {{ wxLua_wxTextEntry_SetSelection, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxTextEntry_SetSelection }};
-//     %wxchkver_3_1_1 void SetSelection(long from, long to);
+//     %wxchkver_3_0_0 void SetSelection(long from, long to);
 static int LUACALL wxLua_wxTextEntry_SetSelection(lua_State *L)
 {
     // long to
@@ -9412,7 +9414,7 @@ static int LUACALL wxLua_wxTextEntry_SetSelection(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_SetValue[] = { &wxluatype_wxTextEntry, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextEntry_SetValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetValue[1] = {{ wxLua_wxTextEntry_SetValue, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetValue }};
-//     %wxchkver_3_1_1 void SetValue(const wxString& value);
+//     %wxchkver_3_0_0 void SetValue(const wxString& value);
 static int LUACALL wxLua_wxTextEntry_SetValue(lua_State *L)
 {
     // const wxString value
@@ -9428,7 +9430,7 @@ static int LUACALL wxLua_wxTextEntry_SetValue(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_Undo[] = { &wxluatype_wxTextEntry, NULL };
 static int LUACALL wxLua_wxTextEntry_Undo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_Undo[1] = {{ wxLua_wxTextEntry_Undo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextEntry_Undo }};
-//     %wxchkver_3_1_1 void Undo();
+//     %wxchkver_3_0_0 void Undo();
 static int LUACALL wxLua_wxTextEntry_Undo(lua_State *L)
 {
     // get this
@@ -9442,7 +9444,7 @@ static int LUACALL wxLua_wxTextEntry_Undo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextEntry_WriteText[] = { &wxluatype_wxTextEntry, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextEntry_WriteText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_WriteText[1] = {{ wxLua_wxTextEntry_WriteText, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_WriteText }};
-//     %wxchkver_3_1_1 void WriteText(const wxString& text);
+//     %wxchkver_3_0_0 void WriteText(const wxString& text);
 static int LUACALL wxLua_wxTextEntry_WriteText(lua_State *L)
 {
     // const wxString text
@@ -9455,26 +9457,26 @@ static int LUACALL wxLua_wxTextEntry_WriteText(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextEntry_SetMargins_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { wxLua_wxTextEntry_SetMargins1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxTextEntry_SetMargins1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxTextEntry_SetMargins, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextEntry_SetMargins },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 };
 static int s_wxluafunc_wxLua_wxTextEntry_SetMargins_overload_count = sizeof(s_wxluafunc_wxLua_wxTextEntry_SetMargins_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
 
 void wxLua_wxTextEntry_delete_function(void** p)
 {
@@ -9484,15 +9486,15 @@ void wxLua_wxTextEntry_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxTextEntry_methods[] = {
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "AppendText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_AppendText, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
     { "AutoComplete", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_AutoComplete, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxArrayString)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "AutoCompleteDirectories", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_AutoCompleteDirectories, 1, NULL },
     { "AutoCompleteFileNames", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_AutoCompleteFileNames, 1, NULL },
     { "CanCopy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_CanCopy, 1, NULL },
@@ -9504,17 +9506,19 @@ wxLuaBindMethod wxTextEntry_methods[] = {
     { "Clear", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_Clear, 1, NULL },
     { "Copy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_Copy, 1, NULL },
     { "Cut", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_Cut, 1, NULL },
+#if (wxCHECK_VERSION(3,1,1))
     { "ForceUpper", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_ForceUpper, 1, NULL },
+#endif // (wxCHECK_VERSION(3,1,1))
     { "GetHint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetHint, 1, NULL },
     { "GetInsertionPoint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetInsertionPoint, 1, NULL },
     { "GetLastPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetLastPosition, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
     { "GetMargins", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetMargins, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "GetRange", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetRange, 1, NULL },
     { "GetSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetSelection, 1, NULL },
     { "GetStringSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_GetStringSelection, 1, NULL },
@@ -9531,19 +9535,19 @@ wxLuaBindMethod wxTextEntry_methods[] = {
     { "SetHint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetHint, 1, NULL },
     { "SetInsertionPoint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetInsertionPoint, 1, NULL },
     { "SetInsertionPointEnd", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetInsertionPointEnd, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
     { "SetMargins", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetMargins_overload, s_wxluafunc_wxLua_wxTextEntry_SetMargins_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "SetMaxLength", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetMaxLength, 1, NULL },
     { "SetSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetSelection, 1, NULL },
     { "SetValue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_SetValue, 1, NULL },
     { "Undo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_Undo, 1, NULL },
     { "WriteText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextEntry_WriteText, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { 0, 0, 0, 0 },
 };
@@ -9561,11 +9565,11 @@ int wxTextEntry_methodCount = sizeof(wxTextEntry_methods)/sizeof(wxLuaBindMethod
 // Lua MetaTable Tag for Class 'wxTextCtrl'
 int wxluatype_wxTextCtrl = WXLUA_TUNKNOWN;
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_AppendText[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_AppendText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_AppendText[1] = {{ wxLua_wxTextCtrl_AppendText, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_AppendText }};
-//     !%wxchkver_3_1_1 void AppendText(const wxString& text);
+//     !%wxchkver_3_0_0 void AppendText(const wxString& text);
 static int LUACALL wxLua_wxTextCtrl_AppendText(lua_State *L)
 {
     // const wxString text
@@ -9581,7 +9585,7 @@ static int LUACALL wxLua_wxTextCtrl_AppendText(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_CanCopy[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_CanCopy(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_CanCopy[1] = {{ wxLua_wxTextCtrl_CanCopy, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_CanCopy }};
-//     !%wxchkver_3_1_1 virtual bool CanCopy();
+//     !%wxchkver_3_0_0 virtual bool CanCopy();
 static int LUACALL wxLua_wxTextCtrl_CanCopy(lua_State *L)
 {
     // get this
@@ -9597,7 +9601,7 @@ static int LUACALL wxLua_wxTextCtrl_CanCopy(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_CanCut[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_CanCut(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_CanCut[1] = {{ wxLua_wxTextCtrl_CanCut, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_CanCut }};
-//     !%wxchkver_3_1_1 virtual bool CanCut();
+//     !%wxchkver_3_0_0 virtual bool CanCut();
 static int LUACALL wxLua_wxTextCtrl_CanCut(lua_State *L)
 {
     // get this
@@ -9613,7 +9617,7 @@ static int LUACALL wxLua_wxTextCtrl_CanCut(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_CanPaste[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_CanPaste(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_CanPaste[1] = {{ wxLua_wxTextCtrl_CanPaste, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_CanPaste }};
-//     !%wxchkver_3_1_1 virtual bool CanPaste();
+//     !%wxchkver_3_0_0 virtual bool CanPaste();
 static int LUACALL wxLua_wxTextCtrl_CanPaste(lua_State *L)
 {
     // get this
@@ -9629,7 +9633,7 @@ static int LUACALL wxLua_wxTextCtrl_CanPaste(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_CanRedo[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_CanRedo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_CanRedo[1] = {{ wxLua_wxTextCtrl_CanRedo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_CanRedo }};
-//     !%wxchkver_3_1_1 virtual bool CanRedo();
+//     !%wxchkver_3_0_0 virtual bool CanRedo();
 static int LUACALL wxLua_wxTextCtrl_CanRedo(lua_State *L)
 {
     // get this
@@ -9645,7 +9649,7 @@ static int LUACALL wxLua_wxTextCtrl_CanRedo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_CanUndo[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_CanUndo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_CanUndo[1] = {{ wxLua_wxTextCtrl_CanUndo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_CanUndo }};
-//     !%wxchkver_3_1_1 virtual bool CanUndo();
+//     !%wxchkver_3_0_0 virtual bool CanUndo();
 static int LUACALL wxLua_wxTextCtrl_CanUndo(lua_State *L)
 {
     // get this
@@ -9661,7 +9665,7 @@ static int LUACALL wxLua_wxTextCtrl_CanUndo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_ChangeValue[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_ChangeValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_ChangeValue[1] = {{ wxLua_wxTextCtrl_ChangeValue, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_ChangeValue }};
-//     !%wxchkver_3_1_1 virtual void ChangeValue(const wxString& value);
+//     !%wxchkver_3_0_0 virtual void ChangeValue(const wxString& value);
 static int LUACALL wxLua_wxTextCtrl_ChangeValue(lua_State *L)
 {
     // const wxString value
@@ -9677,7 +9681,7 @@ static int LUACALL wxLua_wxTextCtrl_ChangeValue(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Clear[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_Clear(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Clear[1] = {{ wxLua_wxTextCtrl_Clear, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_Clear }};
-//     !%wxchkver_3_1_1 virtual void Clear();
+//     !%wxchkver_3_0_0 virtual void Clear();
 static int LUACALL wxLua_wxTextCtrl_Clear(lua_State *L)
 {
     // get this
@@ -9691,7 +9695,7 @@ static int LUACALL wxLua_wxTextCtrl_Clear(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Copy[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_Copy(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Copy[1] = {{ wxLua_wxTextCtrl_Copy, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_Copy }};
-//     !%wxchkver_3_1_1 virtual void Copy();
+//     !%wxchkver_3_0_0 virtual void Copy();
 static int LUACALL wxLua_wxTextCtrl_Copy(lua_State *L)
 {
     // get this
@@ -9702,7 +9706,7 @@ static int LUACALL wxLua_wxTextCtrl_Copy(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 #if ((wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Create[] = { &wxluatype_wxTextCtrl, &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_wxValidator, &wxluatype_TSTRING, NULL };
@@ -9741,11 +9745,11 @@ static int LUACALL wxLua_wxTextCtrl_Create(lua_State *L)
 
 #endif // ((wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Cut[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_Cut(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Cut[1] = {{ wxLua_wxTextCtrl_Cut, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_Cut }};
-//     !%wxchkver_3_1_1 virtual void Cut();
+//     !%wxchkver_3_0_0 virtual void Cut();
 static int LUACALL wxLua_wxTextCtrl_Cut(lua_State *L)
 {
     // get this
@@ -9756,7 +9760,7 @@ static int LUACALL wxLua_wxTextCtrl_Cut(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_DiscardEdits[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_DiscardEdits(lua_State *L);
@@ -9807,11 +9811,11 @@ static int LUACALL wxLua_wxTextCtrl_GetDefaultStyle(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetInsertionPoint[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetInsertionPoint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_GetInsertionPoint[1] = {{ wxLua_wxTextCtrl_GetInsertionPoint, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_GetInsertionPoint }};
-//     !%wxchkver_3_1_1 virtual long GetInsertionPoint() const;
+//     !%wxchkver_3_0_0 virtual long GetInsertionPoint() const;
 static int LUACALL wxLua_wxTextCtrl_GetInsertionPoint(lua_State *L)
 {
     // get this
@@ -9827,7 +9831,7 @@ static int LUACALL wxLua_wxTextCtrl_GetInsertionPoint(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetLastPosition[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetLastPosition(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_GetLastPosition[1] = {{ wxLua_wxTextCtrl_GetLastPosition, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_GetLastPosition }};
-//     !%wxchkver_3_1_1 virtual long GetLastPosition() const;
+//     !%wxchkver_3_0_0 virtual long GetLastPosition() const;
 static int LUACALL wxLua_wxTextCtrl_GetLastPosition(lua_State *L)
 {
     // get this
@@ -9840,7 +9844,7 @@ static int LUACALL wxLua_wxTextCtrl_GetLastPosition(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetLineLength[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetLineLength(lua_State *L);
@@ -9895,11 +9899,11 @@ static int LUACALL wxLua_wxTextCtrl_GetNumberOfLines(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetRange[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetRange(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_GetRange[1] = {{ wxLua_wxTextCtrl_GetRange, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxTextCtrl_GetRange }};
-//     !%wxchkver_3_1_1 virtual wxString GetRange(long from, long to) const;
+//     !%wxchkver_3_0_0 virtual wxString GetRange(long from, long to) const;
 static int LUACALL wxLua_wxTextCtrl_GetRange(lua_State *L)
 {
     // long to
@@ -9939,7 +9943,7 @@ static int LUACALL wxLua_wxTextCtrl_GetSelection(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetStringSelection[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetStringSelection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_GetStringSelection[1] = {{ wxLua_wxTextCtrl_GetStringSelection, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_GetStringSelection }};
-//     !%wxchkver_3_1_1 virtual wxString GetStringSelection();
+//     !%wxchkver_3_0_0 virtual wxString GetStringSelection();
 static int LUACALL wxLua_wxTextCtrl_GetStringSelection(lua_State *L)
 {
     // get this
@@ -9952,7 +9956,7 @@ static int LUACALL wxLua_wxTextCtrl_GetStringSelection(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetStyle[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_wxTextAttr, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetStyle(lua_State *L);
@@ -9975,11 +9979,11 @@ static int LUACALL wxLua_wxTextCtrl_GetStyle(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_GetValue[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_GetValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_GetValue[1] = {{ wxLua_wxTextCtrl_GetValue, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_GetValue }};
-//     !%wxchkver_3_1_1 wxString GetValue() const;
+//     !%wxchkver_3_0_0 wxString GetValue() const;
 static int LUACALL wxLua_wxTextCtrl_GetValue(lua_State *L)
 {
     // get this
@@ -9992,7 +9996,7 @@ static int LUACALL wxLua_wxTextCtrl_GetValue(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 #if (wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_HitTest[] = { &wxluatype_wxTextCtrl, &wxluatype_wxPoint, NULL };
@@ -10046,11 +10050,11 @@ static int LUACALL wxLua_wxTextCtrl_HitTestPos(lua_State *L)
 
 #endif // (wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_IsEditable[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_IsEditable(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_IsEditable[1] = {{ wxLua_wxTextCtrl_IsEditable, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_IsEditable }};
-//     !%wxchkver_3_1_1 bool IsEditable() const;
+//     !%wxchkver_3_0_0 bool IsEditable() const;
 static int LUACALL wxLua_wxTextCtrl_IsEditable(lua_State *L)
 {
     // get this
@@ -10063,7 +10067,7 @@ static int LUACALL wxLua_wxTextCtrl_IsEditable(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_IsModified[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_IsModified(lua_State *L);
@@ -10114,11 +10118,11 @@ static int LUACALL wxLua_wxTextCtrl_IsSingleLine(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_LoadFile1[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_LoadFile1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_LoadFile1[1] = {{ wxLua_wxTextCtrl_LoadFile1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_LoadFile1 }};
-//     !%wxchkver_3_1_1 bool LoadFile(const wxString& filename);
+//     !%wxchkver_3_0_0 bool LoadFile(const wxString& filename);
 static int LUACALL wxLua_wxTextCtrl_LoadFile1(lua_State *L)
 {
     // const wxString filename
@@ -10133,13 +10137,13 @@ static int LUACALL wxLua_wxTextCtrl_LoadFile1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_LoadFile[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_LoadFile(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_LoadFile[1] = {{ wxLua_wxTextCtrl_LoadFile, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxTextCtrl_LoadFile }};
-//     %wxchkver_3_1_1 bool LoadFile(const wxString& filename, int fileType = wxTEXT_TYPE_ANY);
+//     %wxchkver_3_0_0 bool LoadFile(const wxString& filename, int fileType = wxTEXT_TYPE_ANY);
 static int LUACALL wxLua_wxTextCtrl_LoadFile(lua_State *L)
 {
     // get number of arguments
@@ -10158,7 +10162,7 @@ static int LUACALL wxLua_wxTextCtrl_LoadFile(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_MarkDirty[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_MarkDirty(lua_State *L);
@@ -10175,11 +10179,11 @@ static int LUACALL wxLua_wxTextCtrl_MarkDirty(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Paste[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_Paste(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Paste[1] = {{ wxLua_wxTextCtrl_Paste, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_Paste }};
-//     !%wxchkver_3_1_1 virtual void Paste();
+//     !%wxchkver_3_0_0 virtual void Paste();
 static int LUACALL wxLua_wxTextCtrl_Paste(lua_State *L)
 {
     // get this
@@ -10190,13 +10194,13 @@ static int LUACALL wxLua_wxTextCtrl_Paste(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_PositionToCoords[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_PositionToCoords(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_PositionToCoords[1] = {{ wxLua_wxTextCtrl_PositionToCoords, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_PositionToCoords }};
-//     %wxchkver_3_1_1 wxPoint PositionToCoords(long pos) const;
+//     %wxchkver_3_0_0 wxPoint PositionToCoords(long pos) const;
 static int LUACALL wxLua_wxTextCtrl_PositionToCoords(lua_State *L)
 {
     // long pos
@@ -10214,7 +10218,7 @@ static int LUACALL wxLua_wxTextCtrl_PositionToCoords(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_PositionToXY[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_PositionToXY(lua_State *L);
@@ -10241,11 +10245,11 @@ static int LUACALL wxLua_wxTextCtrl_PositionToXY(lua_State *L)
 
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Redo[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_Redo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Redo[1] = {{ wxLua_wxTextCtrl_Redo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_Redo }};
-//     !%wxchkver_3_1_1 virtual void Redo();
+//     !%wxchkver_3_0_0 virtual void Redo();
 static int LUACALL wxLua_wxTextCtrl_Redo(lua_State *L)
 {
     // get this
@@ -10259,7 +10263,7 @@ static int LUACALL wxLua_wxTextCtrl_Redo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Remove[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_Remove(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Remove[1] = {{ wxLua_wxTextCtrl_Remove, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxTextCtrl_Remove }};
-//     !%wxchkver_3_1_1 virtual void Remove(long from, long to);
+//     !%wxchkver_3_0_0 virtual void Remove(long from, long to);
 static int LUACALL wxLua_wxTextCtrl_Remove(lua_State *L)
 {
     // long to
@@ -10277,7 +10281,7 @@ static int LUACALL wxLua_wxTextCtrl_Remove(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Replace[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_Replace(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Replace[1] = {{ wxLua_wxTextCtrl_Replace, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxTextCtrl_Replace }};
-//     !%wxchkver_3_1_1 virtual void Replace(long from, long to, const wxString& value);
+//     !%wxchkver_3_0_0 virtual void Replace(long from, long to, const wxString& value);
 static int LUACALL wxLua_wxTextCtrl_Replace(lua_State *L)
 {
     // const wxString value
@@ -10297,7 +10301,7 @@ static int LUACALL wxLua_wxTextCtrl_Replace(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SaveFile1[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_SaveFile1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SaveFile1[1] = {{ wxLua_wxTextCtrl_SaveFile1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SaveFile1 }};
-//     !%wxchkver_3_1_1 bool SaveFile(const wxString& filename);
+//     !%wxchkver_3_0_0 bool SaveFile(const wxString& filename);
 static int LUACALL wxLua_wxTextCtrl_SaveFile1(lua_State *L)
 {
     // const wxString filename
@@ -10312,13 +10316,13 @@ static int LUACALL wxLua_wxTextCtrl_SaveFile1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SaveFile[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_SaveFile(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SaveFile[1] = {{ wxLua_wxTextCtrl_SaveFile, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxTextCtrl_SaveFile }};
-//     %wxchkver_3_1_1 bool SaveFile(const wxString& filename = wxEmptyString, int fileType = wxTEXT_TYPE_ANY);
+//     %wxchkver_3_0_0 bool SaveFile(const wxString& filename = wxEmptyString, int fileType = wxTEXT_TYPE_ANY);
 static int LUACALL wxLua_wxTextCtrl_SaveFile(lua_State *L)
 {
     // get number of arguments
@@ -10337,7 +10341,7 @@ static int LUACALL wxLua_wxTextCtrl_SaveFile(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetDefaultStyle[] = { &wxluatype_wxTextCtrl, &wxluatype_wxTextAttr, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetDefaultStyle(lua_State *L);
@@ -10358,11 +10362,11 @@ static int LUACALL wxLua_wxTextCtrl_SetDefaultStyle(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetEditable[] = { &wxluatype_wxTextCtrl, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetEditable(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetEditable[1] = {{ wxLua_wxTextCtrl_SetEditable, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SetEditable }};
-//     !%wxchkver_3_1_1 virtual void SetEditable(bool editable);
+//     !%wxchkver_3_0_0 virtual void SetEditable(bool editable);
 static int LUACALL wxLua_wxTextCtrl_SetEditable(lua_State *L)
 {
     // bool editable
@@ -10378,7 +10382,7 @@ static int LUACALL wxLua_wxTextCtrl_SetEditable(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetInsertionPoint[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetInsertionPoint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetInsertionPoint[1] = {{ wxLua_wxTextCtrl_SetInsertionPoint, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SetInsertionPoint }};
-//     !%wxchkver_3_1_1 virtual void SetInsertionPoint(long pos);
+//     !%wxchkver_3_0_0 virtual void SetInsertionPoint(long pos);
 static int LUACALL wxLua_wxTextCtrl_SetInsertionPoint(lua_State *L)
 {
     // long pos
@@ -10394,7 +10398,7 @@ static int LUACALL wxLua_wxTextCtrl_SetInsertionPoint(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetInsertionPointEnd[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetInsertionPointEnd(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetInsertionPointEnd[1] = {{ wxLua_wxTextCtrl_SetInsertionPointEnd, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_SetInsertionPointEnd }};
-//     !%wxchkver_3_1_1 virtual void SetInsertionPointEnd();
+//     !%wxchkver_3_0_0 virtual void SetInsertionPointEnd();
 static int LUACALL wxLua_wxTextCtrl_SetInsertionPointEnd(lua_State *L)
 {
     // get this
@@ -10408,7 +10412,7 @@ static int LUACALL wxLua_wxTextCtrl_SetInsertionPointEnd(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetMaxLength[] = { &wxluatype_wxTextCtrl, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetMaxLength(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetMaxLength[1] = {{ wxLua_wxTextCtrl_SetMaxLength, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SetMaxLength }};
-//     !%wxchkver_3_1_1 virtual void SetMaxLength(unsigned long value);
+//     !%wxchkver_3_0_0 virtual void SetMaxLength(unsigned long value);
 static int LUACALL wxLua_wxTextCtrl_SetMaxLength(lua_State *L)
 {
     // unsigned long value
@@ -10421,13 +10425,13 @@ static int LUACALL wxLua_wxTextCtrl_SetMaxLength(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetModified[] = { &wxluatype_wxTextCtrl, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetModified(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetModified[1] = {{ wxLua_wxTextCtrl_SetModified, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SetModified }};
-//     %wxchkver_3_1_1 void SetModified(bool modified);
+//     %wxchkver_3_0_0 void SetModified(bool modified);
 static int LUACALL wxLua_wxTextCtrl_SetModified(lua_State *L)
 {
     // bool modified
@@ -10440,13 +10444,13 @@ static int LUACALL wxLua_wxTextCtrl_SetModified(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetSelection[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetSelection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetSelection[1] = {{ wxLua_wxTextCtrl_SetSelection, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxTextCtrl_SetSelection }};
-//     !%wxchkver_3_1_1 virtual void SetSelection(long from, long to);
+//     !%wxchkver_3_0_0 virtual void SetSelection(long from, long to);
 static int LUACALL wxLua_wxTextCtrl_SetSelection(lua_State *L)
 {
     // long to
@@ -10461,7 +10465,7 @@ static int LUACALL wxLua_wxTextCtrl_SetSelection(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetStyle[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_wxTextAttr, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetStyle(lua_State *L);
@@ -10486,11 +10490,11 @@ static int LUACALL wxLua_wxTextCtrl_SetStyle(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_SetValue[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_SetValue(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SetValue[1] = {{ wxLua_wxTextCtrl_SetValue, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SetValue }};
-//     !%wxchkver_3_1_1 virtual void SetValue(const wxString& value);
+//     !%wxchkver_3_0_0 virtual void SetValue(const wxString& value);
 static int LUACALL wxLua_wxTextCtrl_SetValue(lua_State *L)
 {
     // const wxString value
@@ -10503,7 +10507,7 @@ static int LUACALL wxLua_wxTextCtrl_SetValue(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_ShowPosition[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_ShowPosition(lua_State *L);
@@ -10522,11 +10526,11 @@ static int LUACALL wxLua_wxTextCtrl_ShowPosition(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_Undo[] = { &wxluatype_wxTextCtrl, NULL };
 static int LUACALL wxLua_wxTextCtrl_Undo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_Undo[1] = {{ wxLua_wxTextCtrl_Undo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTextCtrl_Undo }};
-//     !%wxchkver_3_1_1 virtual void Undo();
+//     !%wxchkver_3_0_0 virtual void Undo();
 static int LUACALL wxLua_wxTextCtrl_Undo(lua_State *L)
 {
     // get this
@@ -10540,7 +10544,7 @@ static int LUACALL wxLua_wxTextCtrl_Undo(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_WriteText[] = { &wxluatype_wxTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxTextCtrl_WriteText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_WriteText[1] = {{ wxLua_wxTextCtrl_WriteText, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_WriteText }};
-//     !%wxchkver_3_1_1 void WriteText(const wxString& text);
+//     !%wxchkver_3_0_0 void WriteText(const wxString& text);
 static int LUACALL wxLua_wxTextCtrl_WriteText(lua_State *L)
 {
     // const wxString text
@@ -10553,7 +10557,7 @@ static int LUACALL wxLua_wxTextCtrl_WriteText(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTextCtrl_XYToPosition[] = { &wxluatype_wxTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTextCtrl_XYToPosition(lua_State *L);
@@ -10631,18 +10635,18 @@ static int LUACALL wxLua_wxTextCtrl_constructor(lua_State *L)
 
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_LoadFile_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { wxLua_wxTextCtrl_LoadFile1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_LoadFile1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { wxLua_wxTextCtrl_LoadFile, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxTextCtrl_LoadFile },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 };
 static int s_wxluafunc_wxLua_wxTextCtrl_LoadFile_overload_count = sizeof(s_wxluafunc_wxLua_wxTextCtrl_LoadFile_overload)/sizeof(wxLuaBindCFunc);
 
@@ -10650,17 +10654,17 @@ static int s_wxluafunc_wxLua_wxTextCtrl_LoadFile_overload_count = sizeof(s_wxlua
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTextCtrl_SaveFile_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { wxLua_wxTextCtrl_SaveFile1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTextCtrl_SaveFile1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { wxLua_wxTextCtrl_SaveFile, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxTextCtrl_SaveFile },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 };
 static int s_wxluafunc_wxLua_wxTextCtrl_SaveFile_overload_count = sizeof(s_wxluafunc_wxLua_wxTextCtrl_SaveFile_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
 
 #if (((wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 // function overload table
@@ -10684,7 +10688,7 @@ void wxLua_wxTextCtrl_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxTextCtrl_methods[] = {
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "AppendText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_AppendText, 1, NULL },
     { "CanCopy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_CanCopy, 1, NULL },
     { "CanCut", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_CanCut, 1, NULL },
@@ -10694,109 +10698,109 @@ wxLuaBindMethod wxTextCtrl_methods[] = {
     { "ChangeValue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_ChangeValue, 1, NULL },
     { "Clear", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Clear, 1, NULL },
     { "Copy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Copy, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 #if ((wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Create, 1, NULL },
 #endif // ((wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "Cut", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Cut, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "DiscardEdits", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_DiscardEdits, 1, NULL },
     { "EmulateKeyPress", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_EmulateKeyPress, 1, NULL },
     { "GetDefaultStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetDefaultStyle, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "GetInsertionPoint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetInsertionPoint, 1, NULL },
     { "GetLastPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetLastPosition, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "GetLineLength", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetLineLength, 1, NULL },
     { "GetLineText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetLineText, 1, NULL },
     { "GetNumberOfLines", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetNumberOfLines, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "GetRange", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetRange, 1, NULL },
     { "GetSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetSelection, 1, NULL },
     { "GetStringSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetStringSelection, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "GetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetStyle, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "GetValue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_GetValue, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 #if (wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "HitTest", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_HitTest, 1, NULL },
     { "HitTestPos", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_HitTestPos, 1, NULL },
 #endif // (wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "IsEditable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_IsEditable, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "IsModified", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_IsModified, 1, NULL },
     { "IsMultiLine", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_IsMultiLine, 1, NULL },
     { "IsSingleLine", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_IsSingleLine, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
     { "LoadFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_LoadFile_overload, s_wxluafunc_wxLua_wxTextCtrl_LoadFile_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
 
     { "MarkDirty", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_MarkDirty, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "Paste", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Paste, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
     { "PositionToCoords", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_PositionToCoords, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)) && (wxLUA_USE_wxPointSizeRect)
 
     { "PositionToXY", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_PositionToXY, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "Redo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Redo, 1, NULL },
     { "Remove", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Remove, 1, NULL },
     { "Replace", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Replace, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
     { "SaveFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SaveFile_overload, s_wxluafunc_wxLua_wxTextCtrl_SaveFile_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL))
 
     { "SetDefaultStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetDefaultStyle, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "SetEditable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetEditable, 1, NULL },
     { "SetInsertionPoint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetInsertionPoint, 1, NULL },
     { "SetInsertionPointEnd", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetInsertionPointEnd, 1, NULL },
     { "SetMaxLength", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetMaxLength, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "SetModified", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetModified, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "SetSelection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetSelection, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "SetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetStyle, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "SetValue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_SetValue, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "ShowPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_ShowPosition, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
     { "Undo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_Undo, 1, NULL },
     { "WriteText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_WriteText, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
     { "XYToPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTextCtrl_XYToPosition, 1, NULL },
 
@@ -11614,11 +11618,11 @@ static int LUACALL wxLua_wxTreeCtrl_AssignStateImageList(lua_State *L)
 
 #endif // (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_ClearFocusedItem[] = { &wxluatype_wxTreeCtrl, NULL };
 static int LUACALL wxLua_wxTreeCtrl_ClearFocusedItem(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_ClearFocusedItem[1] = {{ wxLua_wxTreeCtrl_ClearFocusedItem, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTreeCtrl_ClearFocusedItem }};
-//     %wxchkver_3_1_1 void ClearFocusedItem();
+//     %wxchkver_3_0_0 void ClearFocusedItem();
 static int LUACALL wxLua_wxTreeCtrl_ClearFocusedItem(lua_State *L)
 {
     // get this
@@ -11629,7 +11633,7 @@ static int LUACALL wxLua_wxTreeCtrl_ClearFocusedItem(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_Collapse[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, NULL };
 static int LUACALL wxLua_wxTreeCtrl_Collapse(lua_State *L);
@@ -11797,11 +11801,11 @@ static int LUACALL wxLua_wxTreeCtrl_EditLabel(lua_State *L)
 
 #endif // (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_EnableBellOnNoMatch[] = { &wxluatype_wxTreeCtrl, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTreeCtrl_EnableBellOnNoMatch(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_EnableBellOnNoMatch[1] = {{ wxLua_wxTreeCtrl_EnableBellOnNoMatch, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_EnableBellOnNoMatch }};
-//     %wxchkver_3_1_1 void EnableBellOnNoMatch(bool on = true);
+//     %wxchkver_3_0_0 void EnableBellOnNoMatch(bool on = true);
 static int LUACALL wxLua_wxTreeCtrl_EnableBellOnNoMatch(lua_State *L)
 {
     // get number of arguments
@@ -11816,7 +11820,7 @@ static int LUACALL wxLua_wxTreeCtrl_EnableBellOnNoMatch(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if ((defined(__WXMSW__)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_EndEditLabel[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, &wxluatype_TBOOLEAN, NULL };
@@ -12036,11 +12040,11 @@ static int LUACALL wxLua_wxTreeCtrl_GetFirstVisibleItem(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_GetFocusedItem[] = { &wxluatype_wxTreeCtrl, NULL };
 static int LUACALL wxLua_wxTreeCtrl_GetFocusedItem(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_GetFocusedItem[1] = {{ wxLua_wxTreeCtrl_GetFocusedItem, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxTreeCtrl_GetFocusedItem }};
-//     %wxchkver_3_1_1 wxTreeItemId GetFocusedItem() const;
+//     %wxchkver_3_0_0 wxTreeItemId GetFocusedItem() const;
 static int LUACALL wxLua_wxTreeCtrl_GetFocusedItem(lua_State *L)
 {
     // get this
@@ -12056,7 +12060,7 @@ static int LUACALL wxLua_wxTreeCtrl_GetFocusedItem(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_GetImageList[] = { &wxluatype_wxTreeCtrl, NULL };
@@ -12208,11 +12212,11 @@ static int LUACALL wxLua_wxTreeCtrl_GetItemParent(lua_State *L)
 
 #endif // ((wxCHECK_VERSION(2,4,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_GetItemState[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, NULL };
 static int LUACALL wxLua_wxTreeCtrl_GetItemState(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_GetItemState[1] = {{ wxLua_wxTreeCtrl_GetItemState, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_GetItemState }};
-//     %wxchkver_3_1_1 int GetItemState(const wxTreeItemId& item) const;
+//     %wxchkver_3_0_0 int GetItemState(const wxTreeItemId& item) const;
 static int LUACALL wxLua_wxTreeCtrl_GetItemState(lua_State *L)
 {
     // const wxTreeItemId item
@@ -12227,7 +12231,7 @@ static int LUACALL wxLua_wxTreeCtrl_GetItemState(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_GetItemText[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, NULL };
 static int LUACALL wxLua_wxTreeCtrl_GetItemText(lua_State *L);
@@ -12759,11 +12763,11 @@ static int LUACALL wxLua_wxTreeCtrl_ScrollTo(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SelectChildren[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, NULL };
 static int LUACALL wxLua_wxTreeCtrl_SelectChildren(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_SelectChildren[1] = {{ wxLua_wxTreeCtrl_SelectChildren, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_SelectChildren }};
-//     %wxchkver_3_1_1 void SelectChildren(const wxTreeItemId& parent);
+//     %wxchkver_3_0_0 void SelectChildren(const wxTreeItemId& parent);
 static int LUACALL wxLua_wxTreeCtrl_SelectChildren(lua_State *L)
 {
     // const wxTreeItemId parent
@@ -12776,7 +12780,7 @@ static int LUACALL wxLua_wxTreeCtrl_SelectChildren(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SelectItem[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxTreeCtrl_SelectItem(lua_State *L);
@@ -12799,11 +12803,11 @@ static int LUACALL wxLua_wxTreeCtrl_SelectItem(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SetFocusedItem[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, NULL };
 static int LUACALL wxLua_wxTreeCtrl_SetFocusedItem(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_SetFocusedItem[1] = {{ wxLua_wxTreeCtrl_SetFocusedItem, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_SetFocusedItem }};
-//     %wxchkver_3_1_1 void SetFocusedItem(const wxTreeItemId& item);
+//     %wxchkver_3_0_0 void SetFocusedItem(const wxTreeItemId& item);
 static int LUACALL wxLua_wxTreeCtrl_SetFocusedItem(lua_State *L)
 {
     // const wxTreeItemId item
@@ -12816,7 +12820,7 @@ static int LUACALL wxLua_wxTreeCtrl_SetFocusedItem(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SetImageList[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxImageList, NULL };
@@ -12837,11 +12841,11 @@ static int LUACALL wxLua_wxTreeCtrl_SetImageList(lua_State *L)
 
 #endif // (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SetIndent1[] = { &wxluatype_wxTreeCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxTreeCtrl_SetIndent1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_SetIndent1[1] = {{ wxLua_wxTreeCtrl_SetIndent1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_SetIndent1 }};
-//     !%wxchkver_3_1_1 void SetIndent(int indent);
+//     !%wxchkver_3_0_0 void SetIndent(int indent);
 static int LUACALL wxLua_wxTreeCtrl_SetIndent1(lua_State *L)
 {
     // int indent
@@ -12854,13 +12858,13 @@ static int LUACALL wxLua_wxTreeCtrl_SetIndent1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SetIndent[] = { &wxluatype_wxTreeCtrl, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxTreeCtrl_SetIndent(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_SetIndent[1] = {{ wxLua_wxTreeCtrl_SetIndent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_SetIndent }};
-//     %wxchkver_3_1_1 void SetIndent(unsigned int indent);
+//     %wxchkver_3_0_0 void SetIndent(unsigned int indent);
 static int LUACALL wxLua_wxTreeCtrl_SetIndent(lua_State *L)
 {
     // unsigned int indent
@@ -12873,7 +12877,7 @@ static int LUACALL wxLua_wxTreeCtrl_SetIndent(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if (wxLUA_USE_wxColourPenBrush) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxTreeCtrl_SetItemBackgroundColour[] = { &wxluatype_wxTreeCtrl, &wxluatype_wxTreeItemId, &wxluatype_wxColour, NULL };
@@ -13290,22 +13294,22 @@ static int s_wxluafunc_wxLua_wxTreeCtrl_InsertItem_overload_count = sizeof(s_wxl
 
 #endif // (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxTreeCtrl_SetIndent_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { wxLua_wxTreeCtrl_SetIndent1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_SetIndent1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { wxLua_wxTreeCtrl_SetIndent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxTreeCtrl_SetIndent },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 };
 static int s_wxluafunc_wxLua_wxTreeCtrl_SetIndent_overload_count = sizeof(s_wxluafunc_wxLua_wxTreeCtrl_SetIndent_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
 
 #if (((wxLUA_USE_wxPointSizeRect) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS))||(wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 // function overload table
@@ -13337,9 +13341,9 @@ wxLuaBindMethod wxTreeCtrl_methods[] = {
     { "AssignStateImageList", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_AssignStateImageList, 1, NULL },
 #endif // (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "ClearFocusedItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_ClearFocusedItem, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
     { "Collapse", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_Collapse, 1, NULL },
     { "CollapseAll", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_CollapseAll, 1, NULL },
@@ -13358,9 +13362,9 @@ wxLuaBindMethod wxTreeCtrl_methods[] = {
     { "EditLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_EditLabel, 1, NULL },
 #endif // (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "EnableBellOnNoMatch", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_EnableBellOnNoMatch, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if ((defined(__WXMSW__)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "EndEditLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_EndEditLabel, 1, NULL },
@@ -13385,9 +13389,9 @@ wxLuaBindMethod wxTreeCtrl_methods[] = {
     { "GetFirstChild", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetFirstChild, 1, NULL },
     { "GetFirstVisibleItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetFirstVisibleItem, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "GetFocusedItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetFocusedItem, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "GetImageList", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetImageList, 1, NULL },
@@ -13411,9 +13415,9 @@ wxLuaBindMethod wxTreeCtrl_methods[] = {
     { "GetItemParent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetItemParent, 1, NULL },
 #endif // ((wxCHECK_VERSION(2,4,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "GetItemState", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetItemState, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
     { "GetItemText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_GetItemText, 1, NULL },
 
@@ -13453,23 +13457,23 @@ wxLuaBindMethod wxTreeCtrl_methods[] = {
     { "PrependItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_PrependItem, 1, NULL },
     { "ScrollTo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_ScrollTo, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "SelectChildren", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_SelectChildren, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
     { "SelectItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_SelectItem, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "SetFocusedItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_SetFocusedItem, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
 #if (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "SetImageList", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_SetImageList, 1, NULL },
 #endif // (wxLUA_USE_wxImageList) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
     { "SetIndent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_SetIndent_overload, s_wxluafunc_wxLua_wxTreeCtrl_SetIndent_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL))
 
 #if (wxLUA_USE_wxColourPenBrush) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
     { "SetItemBackgroundColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxTreeCtrl_SetItemBackgroundColour, 1, NULL },

--- a/wxLua/modules/wxbind/src/wxcore_defsutils.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_defsutils.cpp
@@ -37,11 +37,11 @@
 // Lua MetaTable Tag for Class 'wxProcess'
 int wxluatype_wxProcess = WXLUA_TUNKNOWN;
 
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxProcess_Activate[] = { &wxluatype_wxProcess, NULL };
 static int LUACALL wxLua_wxProcess_Activate(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxProcess_Activate[1] = {{ wxLua_wxProcess_Activate, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxProcess_Activate }};
-//     %wxchkver_3_1_1 & %win bool Activate() const;
+//     %wxchkver_3_0_0 & %win bool Activate() const;
 static int LUACALL wxLua_wxProcess_Activate(lua_State *L)
 {
     // get this
@@ -54,7 +54,7 @@ static int LUACALL wxLua_wxProcess_Activate(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
 
 #if (wxLUA_USE_wxProcess) && (wxUSE_STREAMS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxProcess_CloseOutput[] = { &wxluatype_wxProcess, NULL };
@@ -400,9 +400,9 @@ void wxLua_wxProcess_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxProcess_methods[] = {
-#if (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
+#if (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
     { "Activate", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxProcess_Activate, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
+#endif // (wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxProcess)
 
 #if (wxLUA_USE_wxProcess) && (wxUSE_STREAMS)
     { "CloseOutput", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxProcess_CloseOutput, 1, NULL },
@@ -455,11 +455,11 @@ int wxProcess_methodCount = sizeof(wxProcess_methods)/sizeof(wxLuaBindMethod) - 
 // Lua MetaTable Tag for Class 'wxKeyboardState'
 int wxluatype_wxKeyboardState = WXLUA_TUNKNOWN;
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_AltDown[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_AltDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_AltDown[1] = {{ wxLua_wxKeyboardState_AltDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_AltDown }};
-//     %wxchkver_3_1_1 bool AltDown() const;
+//     %wxchkver_3_0_0 bool AltDown() const;
 static int LUACALL wxLua_wxKeyboardState_AltDown(lua_State *L)
 {
     // get this
@@ -475,7 +475,7 @@ static int LUACALL wxLua_wxKeyboardState_AltDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_CmdDown[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_CmdDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_CmdDown[1] = {{ wxLua_wxKeyboardState_CmdDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_CmdDown }};
-//     %wxchkver_3_1_1 bool CmdDown() const;
+//     %wxchkver_3_0_0 bool CmdDown() const;
 static int LUACALL wxLua_wxKeyboardState_CmdDown(lua_State *L)
 {
     // get this
@@ -491,7 +491,7 @@ static int LUACALL wxLua_wxKeyboardState_CmdDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_ControlDown[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_ControlDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_ControlDown[1] = {{ wxLua_wxKeyboardState_ControlDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_ControlDown }};
-//     %wxchkver_3_1_1 bool ControlDown() const;
+//     %wxchkver_3_0_0 bool ControlDown() const;
 static int LUACALL wxLua_wxKeyboardState_ControlDown(lua_State *L)
 {
     // get this
@@ -507,7 +507,7 @@ static int LUACALL wxLua_wxKeyboardState_ControlDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_GetModifiers[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_GetModifiers(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_GetModifiers[1] = {{ wxLua_wxKeyboardState_GetModifiers, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_GetModifiers }};
-//     %wxchkver_3_1_1 int GetModifiers() const;
+//     %wxchkver_3_0_0 int GetModifiers() const;
 static int LUACALL wxLua_wxKeyboardState_GetModifiers(lua_State *L)
 {
     // get this
@@ -523,7 +523,7 @@ static int LUACALL wxLua_wxKeyboardState_GetModifiers(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_HasAnyModifiers[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_HasAnyModifiers(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_HasAnyModifiers[1] = {{ wxLua_wxKeyboardState_HasAnyModifiers, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_HasAnyModifiers }};
-//     %wxchkver_3_1_1 bool HasAnyModifiers() const;
+//     %wxchkver_3_0_0 bool HasAnyModifiers() const;
 static int LUACALL wxLua_wxKeyboardState_HasAnyModifiers(lua_State *L)
 {
     // get this
@@ -539,7 +539,7 @@ static int LUACALL wxLua_wxKeyboardState_HasAnyModifiers(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_HasModifiers[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_HasModifiers(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_HasModifiers[1] = {{ wxLua_wxKeyboardState_HasModifiers, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_HasModifiers }};
-//     %wxchkver_3_1_1 bool HasModifiers() const;
+//     %wxchkver_3_0_0 bool HasModifiers() const;
 static int LUACALL wxLua_wxKeyboardState_HasModifiers(lua_State *L)
 {
     // get this
@@ -555,7 +555,7 @@ static int LUACALL wxLua_wxKeyboardState_HasModifiers(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_MetaDown[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_MetaDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_MetaDown[1] = {{ wxLua_wxKeyboardState_MetaDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_MetaDown }};
-//     %wxchkver_3_1_1 bool MetaDown() const;
+//     %wxchkver_3_0_0 bool MetaDown() const;
 static int LUACALL wxLua_wxKeyboardState_MetaDown(lua_State *L)
 {
     // get this
@@ -571,7 +571,7 @@ static int LUACALL wxLua_wxKeyboardState_MetaDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_RawControlDown[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_RawControlDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_RawControlDown[1] = {{ wxLua_wxKeyboardState_RawControlDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_RawControlDown }};
-//     %wxchkver_3_1_1 bool RawControlDown() const;
+//     %wxchkver_3_0_0 bool RawControlDown() const;
 static int LUACALL wxLua_wxKeyboardState_RawControlDown(lua_State *L)
 {
     // get this
@@ -587,7 +587,7 @@ static int LUACALL wxLua_wxKeyboardState_RawControlDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_SetAltDown[] = { &wxluatype_wxKeyboardState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxKeyboardState_SetAltDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_SetAltDown[1] = {{ wxLua_wxKeyboardState_SetAltDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxKeyboardState_SetAltDown }};
-//     %wxchkver_3_1_1 void SetAltDown(bool down);
+//     %wxchkver_3_0_0 void SetAltDown(bool down);
 static int LUACALL wxLua_wxKeyboardState_SetAltDown(lua_State *L)
 {
     // bool down
@@ -603,7 +603,7 @@ static int LUACALL wxLua_wxKeyboardState_SetAltDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_SetControlDown[] = { &wxluatype_wxKeyboardState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxKeyboardState_SetControlDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_SetControlDown[1] = {{ wxLua_wxKeyboardState_SetControlDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxKeyboardState_SetControlDown }};
-//     %wxchkver_3_1_1 void SetControlDown(bool down);
+//     %wxchkver_3_0_0 void SetControlDown(bool down);
 static int LUACALL wxLua_wxKeyboardState_SetControlDown(lua_State *L)
 {
     // bool down
@@ -619,7 +619,7 @@ static int LUACALL wxLua_wxKeyboardState_SetControlDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_SetMetaDown[] = { &wxluatype_wxKeyboardState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxKeyboardState_SetMetaDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_SetMetaDown[1] = {{ wxLua_wxKeyboardState_SetMetaDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxKeyboardState_SetMetaDown }};
-//     %wxchkver_3_1_1 void SetMetaDown(bool down);
+//     %wxchkver_3_0_0 void SetMetaDown(bool down);
 static int LUACALL wxLua_wxKeyboardState_SetMetaDown(lua_State *L)
 {
     // bool down
@@ -635,7 +635,7 @@ static int LUACALL wxLua_wxKeyboardState_SetMetaDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_SetRawControlDown[] = { &wxluatype_wxKeyboardState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxKeyboardState_SetRawControlDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_SetRawControlDown[1] = {{ wxLua_wxKeyboardState_SetRawControlDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxKeyboardState_SetRawControlDown }};
-//     %wxchkver_3_1_1 void SetRawControlDown(bool down);
+//     %wxchkver_3_0_0 void SetRawControlDown(bool down);
 static int LUACALL wxLua_wxKeyboardState_SetRawControlDown(lua_State *L)
 {
     // bool down
@@ -651,7 +651,7 @@ static int LUACALL wxLua_wxKeyboardState_SetRawControlDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_SetShiftDown[] = { &wxluatype_wxKeyboardState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxKeyboardState_SetShiftDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_SetShiftDown[1] = {{ wxLua_wxKeyboardState_SetShiftDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxKeyboardState_SetShiftDown }};
-//     %wxchkver_3_1_1 void SetShiftDown(bool down);
+//     %wxchkver_3_0_0 void SetShiftDown(bool down);
 static int LUACALL wxLua_wxKeyboardState_SetShiftDown(lua_State *L)
 {
     // bool down
@@ -667,7 +667,7 @@ static int LUACALL wxLua_wxKeyboardState_SetShiftDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_ShiftDown[] = { &wxluatype_wxKeyboardState, NULL };
 static int LUACALL wxLua_wxKeyboardState_ShiftDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_ShiftDown[1] = {{ wxLua_wxKeyboardState_ShiftDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxKeyboardState_ShiftDown }};
-//     %wxchkver_3_1_1 bool ShiftDown() const;
+//     %wxchkver_3_0_0 bool ShiftDown() const;
 static int LUACALL wxLua_wxKeyboardState_ShiftDown(lua_State *L)
 {
     // get this
@@ -683,7 +683,7 @@ static int LUACALL wxLua_wxKeyboardState_ShiftDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxKeyboardState_constructor[] = { &wxluatype_TBOOLEAN, &wxluatype_TBOOLEAN, &wxluatype_TBOOLEAN, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxKeyboardState_constructor(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxKeyboardState_constructor[1] = {{ wxLua_wxKeyboardState_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 4, s_wxluatypeArray_wxLua_wxKeyboardState_constructor }};
-//     %wxchkver_3_1_1 wxKeyboardState(bool controlDown = false, bool shiftDown = false, bool altDown = false, bool metaDown = false);
+//     %wxchkver_3_0_0 wxKeyboardState(bool controlDown = false, bool shiftDown = false, bool altDown = false, bool metaDown = false);
 static int LUACALL wxLua_wxKeyboardState_constructor(lua_State *L)
 {
     // get number of arguments
@@ -704,7 +704,7 @@ static int LUACALL wxLua_wxKeyboardState_constructor(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 
 
@@ -716,7 +716,7 @@ void wxLua_wxKeyboardState_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxKeyboardState_methods[] = {
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "AltDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxKeyboardState_AltDown, 1, NULL },
     { "CmdDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxKeyboardState_CmdDown, 1, NULL },
     { "ControlDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxKeyboardState_ControlDown, 1, NULL },
@@ -732,7 +732,7 @@ wxLuaBindMethod wxKeyboardState_methods[] = {
     { "SetShiftDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxKeyboardState_SetShiftDown, 1, NULL },
     { "ShiftDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxKeyboardState_ShiftDown, 1, NULL },
     { "wxKeyboardState", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxKeyboardState_constructor, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { 0, 0, 0, 0 },
 };
@@ -749,11 +749,11 @@ int wxKeyboardState_methodCount = sizeof(wxKeyboardState_methods)/sizeof(wxLuaBi
 // Lua MetaTable Tag for Class 'wxMouseState'
 int wxluatype_wxMouseState = WXLUA_TUNKNOWN;
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_AltDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_AltDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_AltDown[1] = {{ wxLua_wxMouseState_AltDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_AltDown }};
-//     !%wxchkver_3_1_1 bool        AltDown();
+//     !%wxchkver_3_0_0 bool        AltDown();
 static int LUACALL wxLua_wxMouseState_AltDown(lua_State *L)
 {
     // get this
@@ -766,13 +766,13 @@ static int LUACALL wxLua_wxMouseState_AltDown(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_Aux1IsDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_Aux1IsDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_Aux1IsDown[1] = {{ wxLua_wxMouseState_Aux1IsDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_Aux1IsDown }};
-//     %wxchkver_3_1_1 bool Aux1IsDown() const;
+//     %wxchkver_3_0_0 bool Aux1IsDown() const;
 static int LUACALL wxLua_wxMouseState_Aux1IsDown(lua_State *L)
 {
     // get this
@@ -788,7 +788,7 @@ static int LUACALL wxLua_wxMouseState_Aux1IsDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_Aux2IsDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_Aux2IsDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_Aux2IsDown[1] = {{ wxLua_wxMouseState_Aux2IsDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_Aux2IsDown }};
-//     %wxchkver_3_1_1 bool Aux2IsDown() const;
+//     %wxchkver_3_0_0 bool Aux2IsDown() const;
 static int LUACALL wxLua_wxMouseState_Aux2IsDown(lua_State *L)
 {
     // get this
@@ -801,13 +801,13 @@ static int LUACALL wxLua_wxMouseState_Aux2IsDown(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_CmdDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_CmdDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_CmdDown[1] = {{ wxLua_wxMouseState_CmdDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_CmdDown }};
-//     !%wxchkver_3_1_1 bool        CmdDown();
+//     !%wxchkver_3_0_0 bool        CmdDown();
 static int LUACALL wxLua_wxMouseState_CmdDown(lua_State *L)
 {
     // get this
@@ -823,7 +823,7 @@ static int LUACALL wxLua_wxMouseState_CmdDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_ControlDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_ControlDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_ControlDown[1] = {{ wxLua_wxMouseState_ControlDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_ControlDown }};
-//     !%wxchkver_3_1_1 bool        ControlDown();
+//     !%wxchkver_3_0_0 bool        ControlDown();
 static int LUACALL wxLua_wxMouseState_ControlDown(lua_State *L)
 {
     // get this
@@ -836,7 +836,7 @@ static int LUACALL wxLua_wxMouseState_ControlDown(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_GetX[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_GetX(lua_State *L);
@@ -871,11 +871,11 @@ static int LUACALL wxLua_wxMouseState_GetY(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_LeftDown1[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_LeftDown1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_LeftDown1[1] = {{ wxLua_wxMouseState_LeftDown1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_LeftDown1 }};
-//     !%wxchkver_3_1_1 bool        LeftDown();
+//     !%wxchkver_3_0_0 bool        LeftDown();
 static int LUACALL wxLua_wxMouseState_LeftDown1(lua_State *L)
 {
     // get this
@@ -888,13 +888,13 @@ static int LUACALL wxLua_wxMouseState_LeftDown1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_LeftDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_LeftDown(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_LeftDown[1] = {{ wxLua_wxMouseState_LeftDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_LeftDown }};
-//     %wxchkver_3_1_1 %rename LeftDown bool LeftIsDown() const; // for compatibility with previous wxlua versions
+//     %wxchkver_3_0_0 %rename LeftDown bool LeftIsDown() const; // for compatibility with previous wxlua versions
 static int LUACALL wxLua_wxMouseState_LeftDown(lua_State *L)
 {
     // get this
@@ -910,7 +910,7 @@ static int LUACALL wxLua_wxMouseState_LeftDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_LeftIsDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_LeftIsDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_LeftIsDown[1] = {{ wxLua_wxMouseState_LeftIsDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_LeftIsDown }};
-//     %wxchkver_3_1_1 bool LeftIsDown() const;
+//     %wxchkver_3_0_0 bool LeftIsDown() const;
 static int LUACALL wxLua_wxMouseState_LeftIsDown(lua_State *L)
 {
     // get this
@@ -923,13 +923,13 @@ static int LUACALL wxLua_wxMouseState_LeftIsDown(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_MetaDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_MetaDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_MetaDown[1] = {{ wxLua_wxMouseState_MetaDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_MetaDown }};
-//     !%wxchkver_3_1_1 bool        MetaDown();
+//     !%wxchkver_3_0_0 bool        MetaDown();
 static int LUACALL wxLua_wxMouseState_MetaDown(lua_State *L)
 {
     // get this
@@ -945,7 +945,7 @@ static int LUACALL wxLua_wxMouseState_MetaDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_MiddleDown1[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_MiddleDown1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_MiddleDown1[1] = {{ wxLua_wxMouseState_MiddleDown1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_MiddleDown1 }};
-//     !%wxchkver_3_1_1 bool        MiddleDown();
+//     !%wxchkver_3_0_0 bool        MiddleDown();
 static int LUACALL wxLua_wxMouseState_MiddleDown1(lua_State *L)
 {
     // get this
@@ -958,13 +958,13 @@ static int LUACALL wxLua_wxMouseState_MiddleDown1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_MiddleDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_MiddleDown(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_MiddleDown[1] = {{ wxLua_wxMouseState_MiddleDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_MiddleDown }};
-//     %wxchkver_3_1_1 %rename MiddleDown bool MiddleIsDown() const; // for compatibility with previous wxlua versions
+//     %wxchkver_3_0_0 %rename MiddleDown bool MiddleIsDown() const; // for compatibility with previous wxlua versions
 static int LUACALL wxLua_wxMouseState_MiddleDown(lua_State *L)
 {
     // get this
@@ -980,7 +980,7 @@ static int LUACALL wxLua_wxMouseState_MiddleDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_MiddleIsDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_MiddleIsDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_MiddleIsDown[1] = {{ wxLua_wxMouseState_MiddleIsDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_MiddleIsDown }};
-//     %wxchkver_3_1_1 bool MiddleIsDown() const;
+//     %wxchkver_3_0_0 bool MiddleIsDown() const;
 static int LUACALL wxLua_wxMouseState_MiddleIsDown(lua_State *L)
 {
     // get this
@@ -993,13 +993,13 @@ static int LUACALL wxLua_wxMouseState_MiddleIsDown(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_RightDown1[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_RightDown1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_RightDown1[1] = {{ wxLua_wxMouseState_RightDown1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_RightDown1 }};
-//     !%wxchkver_3_1_1 bool        RightDown();
+//     !%wxchkver_3_0_0 bool        RightDown();
 static int LUACALL wxLua_wxMouseState_RightDown1(lua_State *L)
 {
     // get this
@@ -1012,13 +1012,13 @@ static int LUACALL wxLua_wxMouseState_RightDown1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_RightDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_RightDown(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_RightDown[1] = {{ wxLua_wxMouseState_RightDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_RightDown }};
-//     %wxchkver_3_1_1 %rename RightDown bool RightIsDown() const; // for compatibility with previous wxlua versions
+//     %wxchkver_3_0_0 %rename RightDown bool RightIsDown() const; // for compatibility with previous wxlua versions
 static int LUACALL wxLua_wxMouseState_RightDown(lua_State *L)
 {
     // get this
@@ -1034,7 +1034,7 @@ static int LUACALL wxLua_wxMouseState_RightDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_RightIsDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_RightIsDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_RightIsDown[1] = {{ wxLua_wxMouseState_RightIsDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_RightIsDown }};
-//     %wxchkver_3_1_1 bool RightIsDown() const;
+//     %wxchkver_3_0_0 bool RightIsDown() const;
 static int LUACALL wxLua_wxMouseState_RightIsDown(lua_State *L)
 {
     // get this
@@ -1047,13 +1047,13 @@ static int LUACALL wxLua_wxMouseState_RightIsDown(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetAltDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetAltDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetAltDown[1] = {{ wxLua_wxMouseState_SetAltDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetAltDown }};
-//     !%wxchkver_3_1_1 void        SetAltDown(bool down);
+//     !%wxchkver_3_0_0 void        SetAltDown(bool down);
 static int LUACALL wxLua_wxMouseState_SetAltDown(lua_State *L)
 {
     // bool down
@@ -1066,13 +1066,13 @@ static int LUACALL wxLua_wxMouseState_SetAltDown(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetAux1Down[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetAux1Down(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetAux1Down[1] = {{ wxLua_wxMouseState_SetAux1Down, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetAux1Down }};
-//     %wxchkver_3_1_1 void SetAux1Down(bool down);
+//     %wxchkver_3_0_0 void SetAux1Down(bool down);
 static int LUACALL wxLua_wxMouseState_SetAux1Down(lua_State *L)
 {
     // bool down
@@ -1088,7 +1088,7 @@ static int LUACALL wxLua_wxMouseState_SetAux1Down(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetAux2Down[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetAux2Down(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetAux2Down[1] = {{ wxLua_wxMouseState_SetAux2Down, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetAux2Down }};
-//     %wxchkver_3_1_1 void SetAux2Down(bool down);
+//     %wxchkver_3_0_0 void SetAux2Down(bool down);
 static int LUACALL wxLua_wxMouseState_SetAux2Down(lua_State *L)
 {
     // bool down
@@ -1101,13 +1101,13 @@ static int LUACALL wxLua_wxMouseState_SetAux2Down(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetControlDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetControlDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetControlDown[1] = {{ wxLua_wxMouseState_SetControlDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetControlDown }};
-//     !%wxchkver_3_1_1 void        SetControlDown(bool down);
+//     !%wxchkver_3_0_0 void        SetControlDown(bool down);
 static int LUACALL wxLua_wxMouseState_SetControlDown(lua_State *L)
 {
     // bool down
@@ -1120,7 +1120,7 @@ static int LUACALL wxLua_wxMouseState_SetControlDown(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetLeftDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetLeftDown(lua_State *L);
@@ -1139,11 +1139,11 @@ static int LUACALL wxLua_wxMouseState_SetLeftDown(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetMetaDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetMetaDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetMetaDown[1] = {{ wxLua_wxMouseState_SetMetaDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetMetaDown }};
-//     !%wxchkver_3_1_1 void        SetMetaDown(bool down);
+//     !%wxchkver_3_0_0 void        SetMetaDown(bool down);
 static int LUACALL wxLua_wxMouseState_SetMetaDown(lua_State *L)
 {
     // bool down
@@ -1156,7 +1156,7 @@ static int LUACALL wxLua_wxMouseState_SetMetaDown(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetMiddleDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetMiddleDown(lua_State *L);
@@ -1175,11 +1175,11 @@ static int LUACALL wxLua_wxMouseState_SetMiddleDown(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetPosition[] = { &wxluatype_wxMouseState, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxMouseState_SetPosition(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetPosition[1] = {{ wxLua_wxMouseState_SetPosition, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetPosition }};
-//     %wxchkver_3_1_1 void SetPosition(wxPoint pos);
+//     %wxchkver_3_0_0 void SetPosition(wxPoint pos);
 static int LUACALL wxLua_wxMouseState_SetPosition(lua_State *L)
 {
     // wxPoint pos
@@ -1192,7 +1192,7 @@ static int LUACALL wxLua_wxMouseState_SetPosition(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetRightDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetRightDown(lua_State *L);
@@ -1211,11 +1211,11 @@ static int LUACALL wxLua_wxMouseState_SetRightDown(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetShiftDown[] = { &wxluatype_wxMouseState, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMouseState_SetShiftDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetShiftDown[1] = {{ wxLua_wxMouseState_SetShiftDown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetShiftDown }};
-//     !%wxchkver_3_1_1 void        SetShiftDown(bool down);
+//     !%wxchkver_3_0_0 void        SetShiftDown(bool down);
 static int LUACALL wxLua_wxMouseState_SetShiftDown(lua_State *L)
 {
     // bool down
@@ -1228,13 +1228,13 @@ static int LUACALL wxLua_wxMouseState_SetShiftDown(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxCHECK_VERSION(2,8,0))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetState[] = { &wxluatype_wxMouseState, &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_SetState(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_SetState[1] = {{ wxLua_wxMouseState_SetState, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMouseState_SetState }};
-//     %wxchkver_3_1_1 void SetState(const wxMouseState& state);
+//     %wxchkver_3_0_0 void SetState(const wxMouseState& state);
 static int LUACALL wxLua_wxMouseState_SetState(lua_State *L)
 {
     // const wxMouseState state
@@ -1247,7 +1247,7 @@ static int LUACALL wxLua_wxMouseState_SetState(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxCHECK_VERSION(2,8,0))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxCHECK_VERSION(2,8,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_SetX[] = { &wxluatype_wxMouseState, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxMouseState_SetX(lua_State *L);
@@ -1282,11 +1282,11 @@ static int LUACALL wxLua_wxMouseState_SetY(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_ShiftDown[] = { &wxluatype_wxMouseState, NULL };
 static int LUACALL wxLua_wxMouseState_ShiftDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_ShiftDown[1] = {{ wxLua_wxMouseState_ShiftDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_ShiftDown }};
-//     !%wxchkver_3_1_1 bool        ShiftDown();
+//     !%wxchkver_3_0_0 bool        ShiftDown();
 static int LUACALL wxLua_wxMouseState_ShiftDown(lua_State *L)
 {
     // get this
@@ -1299,7 +1299,7 @@ static int LUACALL wxLua_wxMouseState_ShiftDown(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMouseState_delete[] = { &wxluatype_wxMouseState, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_delete }};
@@ -1322,18 +1322,18 @@ static int LUACALL wxLua_wxMouseState_constructor(lua_State *L)
 
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_LeftDown_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { wxLua_wxMouseState_LeftDown1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_LeftDown1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { wxLua_wxMouseState_LeftDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_LeftDown },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 };
 static int s_wxluafunc_wxLua_wxMouseState_LeftDown_overload_count = sizeof(s_wxluafunc_wxLua_wxMouseState_LeftDown_overload)/sizeof(wxLuaBindCFunc);
 
@@ -1341,13 +1341,13 @@ static int s_wxluafunc_wxLua_wxMouseState_LeftDown_overload_count = sizeof(s_wxl
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_MiddleDown_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { wxLua_wxMouseState_MiddleDown1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_MiddleDown1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { wxLua_wxMouseState_MiddleDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_MiddleDown },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 };
 static int s_wxluafunc_wxLua_wxMouseState_MiddleDown_overload_count = sizeof(s_wxluafunc_wxLua_wxMouseState_MiddleDown_overload)/sizeof(wxLuaBindCFunc);
 
@@ -1355,17 +1355,17 @@ static int s_wxluafunc_wxLua_wxMouseState_MiddleDown_overload_count = sizeof(s_w
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMouseState_RightDown_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { wxLua_wxMouseState_RightDown1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_RightDown1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { wxLua_wxMouseState_RightDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMouseState_RightDown },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 };
 static int s_wxluafunc_wxLua_wxMouseState_RightDown_overload_count = sizeof(s_wxluafunc_wxLua_wxMouseState_RightDown_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
 
 void wxLua_wxMouseState_delete_function(void** p)
 {
@@ -1375,92 +1375,92 @@ void wxLua_wxMouseState_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxMouseState_methods[] = {
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "AltDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_AltDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { "Aux1IsDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_Aux1IsDown, 1, NULL },
     { "Aux2IsDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_Aux2IsDown, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "CmdDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_CmdDown, 1, NULL },
     { "ControlDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_ControlDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
     { "GetX", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_GetX, 1, NULL },
     { "GetY", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_GetY, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
     { "LeftDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_LeftDown_overload, s_wxluafunc_wxLua_wxMouseState_LeftDown_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { "LeftIsDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_LeftIsDown, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "MetaDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_MetaDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
     { "MiddleDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_MiddleDown_overload, s_wxluafunc_wxLua_wxMouseState_MiddleDown_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { "MiddleIsDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_MiddleIsDown, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
     { "RightDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_RightDown_overload, s_wxluafunc_wxLua_wxMouseState_RightDown_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1)))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0)))||((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0)))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { "RightIsDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_RightIsDown, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "SetAltDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetAltDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
     { "SetAux1Down", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetAux1Down, 1, NULL },
     { "SetAux2Down", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetAux2Down, 1, NULL },
-#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "SetControlDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetControlDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
     { "SetLeftDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetLeftDown, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "SetMetaDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetMetaDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
     { "SetMiddleDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetMiddleDown, 1, NULL },
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
     { "SetPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetPosition, 1, NULL },
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
 
     { "SetRightDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetRightDown, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "SetShiftDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetShiftDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxCHECK_VERSION(2,8,0))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxCHECK_VERSION(2,8,0))
     { "SetState", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetState, 1, NULL },
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxCHECK_VERSION(2,8,0))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxCHECK_VERSION(2,8,0))
 
     { "SetX", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetX, 1, NULL },
     { "SetY", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_SetY, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#if (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
     { "ShiftDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMouseState_ShiftDown, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxCHECK_VERSION(2,8,0))
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxCHECK_VERSION(2,8,0))
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxMouseState_delete, 1, NULL },
     { "wxMouseState", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxMouseState_constructor, 1, NULL },

--- a/wxLua/modules/wxbind/src/wxcore_gdi.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_gdi.cpp
@@ -1045,6 +1045,11 @@ wxLuaBindMethod wxSize_methods[] = {
     { "wxSize", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxSize_constructor_overload, s_wxluafunc_wxLua_wxSize_constructor_overload_count, 0 },
 #endif // (wxLUA_USE_wxPointSizeRect)
 
+    { "width", WXLUAMETHOD_SETPROP, s_wxluafunc_wxLua_wxSize_SetWidth, 1, NULL },
+    { "width", WXLUAMETHOD_GETPROP, s_wxluafunc_wxLua_wxSize_GetWidth, 1, NULL },
+    { "height", WXLUAMETHOD_SETPROP, s_wxluafunc_wxLua_wxSize_SetHeight, 1, NULL },
+    { "height", WXLUAMETHOD_GETPROP, s_wxluafunc_wxLua_wxSize_GetHeight, 1, NULL },
+
     { 0, 0, 0, 0 },
 };
 
@@ -2056,6 +2061,15 @@ wxLuaBindMethod wxRect_methods[] = {
 #if (wxLUA_USE_wxPointSizeRect)
     { "wxRect", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxRect_constructor_overload, s_wxluafunc_wxLua_wxRect_constructor_overload_count, 0 },
 #endif // (wxLUA_USE_wxPointSizeRect)
+
+    { "x", WXLUAMETHOD_SETPROP, s_wxluafunc_wxLua_wxRect_SetX, 1, NULL },
+    { "x", WXLUAMETHOD_GETPROP, s_wxluafunc_wxLua_wxRect_GetX, 1, NULL },
+    { "y", WXLUAMETHOD_SETPROP, s_wxluafunc_wxLua_wxRect_SetY, 1, NULL },
+    { "y", WXLUAMETHOD_GETPROP, s_wxluafunc_wxLua_wxRect_GetY, 1, NULL },
+    { "width", WXLUAMETHOD_SETPROP, s_wxluafunc_wxLua_wxRect_SetWidth, 1, NULL },
+    { "width", WXLUAMETHOD_GETPROP, s_wxluafunc_wxLua_wxRect_GetWidth, 1, NULL },
+    { "height", WXLUAMETHOD_SETPROP, s_wxluafunc_wxLua_wxRect_SetHeight, 1, NULL },
+    { "height", WXLUAMETHOD_GETPROP, s_wxluafunc_wxLua_wxRect_GetHeight, 1, NULL },
 
     { 0, 0, 0, 0 },
 };

--- a/wxLua/modules/wxbind/src/wxcore_gdi.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_gdi.cpp
@@ -3247,11 +3247,11 @@ int wxRegionIterator_methodCount = sizeof(wxRegionIterator_methods)/sizeof(wxLua
 // Lua MetaTable Tag for Class 'wxFontInfo'
 int wxluatype_wxFontInfo = WXLUA_TUNKNOWN;
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_AllFlags[] = { &wxluatype_wxFontInfo, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFontInfo_AllFlags(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_AllFlags[1] = {{ wxLua_wxFontInfo_AllFlags, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFontInfo_AllFlags }};
-//     %wxchkver_3_1_1 wxFontInfo& AllFlags(int flags);
+//     %wxchkver_3_0_0 wxFontInfo& AllFlags(int flags);
 static int LUACALL wxLua_wxFontInfo_AllFlags(lua_State *L)
 {
     // int flags
@@ -3269,7 +3269,7 @@ static int LUACALL wxLua_wxFontInfo_AllFlags(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_AntiAliased[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_AntiAliased(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_AntiAliased[1] = {{ wxLua_wxFontInfo_AntiAliased, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_AntiAliased }};
-//     %wxchkver_3_1_1 wxFontInfo& AntiAliased(bool antiAliased = true);
+//     %wxchkver_3_0_0 wxFontInfo& AntiAliased(bool antiAliased = true);
 static int LUACALL wxLua_wxFontInfo_AntiAliased(lua_State *L)
 {
     // get number of arguments
@@ -3289,7 +3289,7 @@ static int LUACALL wxLua_wxFontInfo_AntiAliased(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Bold[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_Bold(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Bold[1] = {{ wxLua_wxFontInfo_Bold, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_Bold }};
-//     %wxchkver_3_1_1 wxFontInfo& Bold(bool bold = true);
+//     %wxchkver_3_0_0 wxFontInfo& Bold(bool bold = true);
 static int LUACALL wxLua_wxFontInfo_Bold(lua_State *L)
 {
     // get number of arguments
@@ -3306,13 +3306,13 @@ static int LUACALL wxLua_wxFontInfo_Bold(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Encoding[] = { &wxluatype_wxFontInfo, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFontInfo_Encoding(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Encoding[1] = {{ wxLua_wxFontInfo_Encoding, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFontInfo_Encoding }};
-//     %wxchkver_3_1_1 wxFontInfo& Encoding(wxFontEncoding encoding);
+//     %wxchkver_3_0_0 wxFontInfo& Encoding(wxFontEncoding encoding);
 static int LUACALL wxLua_wxFontInfo_Encoding(lua_State *L)
 {
     // wxFontEncoding encoding
@@ -3327,13 +3327,13 @@ static int LUACALL wxLua_wxFontInfo_Encoding(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_FaceName[] = { &wxluatype_wxFontInfo, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFontInfo_FaceName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_FaceName[1] = {{ wxLua_wxFontInfo_FaceName, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFontInfo_FaceName }};
-//     %wxchkver_3_1_1 wxFontInfo& FaceName(const wxString& faceName);
+//     %wxchkver_3_0_0 wxFontInfo& FaceName(const wxString& faceName);
 static int LUACALL wxLua_wxFontInfo_FaceName(lua_State *L)
 {
     // const wxString faceName
@@ -3351,7 +3351,7 @@ static int LUACALL wxLua_wxFontInfo_FaceName(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Family[] = { &wxluatype_wxFontInfo, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFontInfo_Family(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Family[1] = {{ wxLua_wxFontInfo_Family, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFontInfo_Family }};
-//     %wxchkver_3_1_1 wxFontInfo& Family(wxFontFamily family);
+//     %wxchkver_3_0_0 wxFontInfo& Family(wxFontFamily family);
 static int LUACALL wxLua_wxFontInfo_Family(lua_State *L)
 {
     // wxFontFamily family
@@ -3369,7 +3369,7 @@ static int LUACALL wxLua_wxFontInfo_Family(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Italic[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_Italic(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Italic[1] = {{ wxLua_wxFontInfo_Italic, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_Italic }};
-//     %wxchkver_3_1_1 wxFontInfo& Italic(bool italic = true);
+//     %wxchkver_3_0_0 wxFontInfo& Italic(bool italic = true);
 static int LUACALL wxLua_wxFontInfo_Italic(lua_State *L)
 {
     // get number of arguments
@@ -3389,7 +3389,7 @@ static int LUACALL wxLua_wxFontInfo_Italic(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Light[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_Light(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Light[1] = {{ wxLua_wxFontInfo_Light, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_Light }};
-//     %wxchkver_3_1_1 wxFontInfo& Light(bool light = true);
+//     %wxchkver_3_0_0 wxFontInfo& Light(bool light = true);
 static int LUACALL wxLua_wxFontInfo_Light(lua_State *L)
 {
     // get number of arguments
@@ -3409,7 +3409,7 @@ static int LUACALL wxLua_wxFontInfo_Light(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Slant[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_Slant(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Slant[1] = {{ wxLua_wxFontInfo_Slant, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_Slant }};
-//     %wxchkver_3_1_1 wxFontInfo& Slant(bool slant = true);
+//     %wxchkver_3_0_0 wxFontInfo& Slant(bool slant = true);
 static int LUACALL wxLua_wxFontInfo_Slant(lua_State *L)
 {
     // get number of arguments
@@ -3429,7 +3429,7 @@ static int LUACALL wxLua_wxFontInfo_Slant(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Strikethrough[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_Strikethrough(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Strikethrough[1] = {{ wxLua_wxFontInfo_Strikethrough, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_Strikethrough }};
-//     %wxchkver_3_1_1 wxFontInfo& Strikethrough(bool strikethrough = true);
+//     %wxchkver_3_0_0 wxFontInfo& Strikethrough(bool strikethrough = true);
 static int LUACALL wxLua_wxFontInfo_Strikethrough(lua_State *L)
 {
     // get number of arguments
@@ -3449,7 +3449,7 @@ static int LUACALL wxLua_wxFontInfo_Strikethrough(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_Underlined[] = { &wxluatype_wxFontInfo, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFontInfo_Underlined(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_Underlined[1] = {{ wxLua_wxFontInfo_Underlined, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxFontInfo_Underlined }};
-//     %wxchkver_3_1_1 wxFontInfo& Underlined(bool underlined = true);
+//     %wxchkver_3_0_0 wxFontInfo& Underlined(bool underlined = true);
 static int LUACALL wxLua_wxFontInfo_Underlined(lua_State *L)
 {
     // get number of arguments
@@ -3466,13 +3466,13 @@ static int LUACALL wxLua_wxFontInfo_Underlined(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_constructor2[] = { &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxFontInfo_constructor2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_constructor2[1] = {{ wxLua_wxFontInfo_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFontInfo_constructor2 }};
-//     %wxchkver_3_1_1 wxFontInfo(const wxSize& pixelSize);
+//     %wxchkver_3_0_0 wxFontInfo(const wxSize& pixelSize);
 static int LUACALL wxLua_wxFontInfo_constructor2(lua_State *L)
 {
     // const wxSize pixelSize
@@ -3485,13 +3485,13 @@ static int LUACALL wxLua_wxFontInfo_constructor2(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFontInfo_constructor1[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFontInfo_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_constructor1[1] = {{ wxLua_wxFontInfo_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFontInfo_constructor1 }};
-//     %wxchkver_3_1_1 wxFontInfo(int pointSize);
+//     %wxchkver_3_0_0 wxFontInfo(int pointSize);
 static int LUACALL wxLua_wxFontInfo_constructor1(lua_State *L)
 {
     // int pointSize
@@ -3506,7 +3506,7 @@ static int LUACALL wxLua_wxFontInfo_constructor1(lua_State *L)
 
 static int LUACALL wxLua_wxFontInfo_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_constructor[1] = {{ wxLua_wxFontInfo_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxFontInfo();
+//     %wxchkver_3_0_0 wxFontInfo();
 static int LUACALL wxLua_wxFontInfo_constructor(lua_State *L)
 {
     // call constructor
@@ -3517,30 +3517,30 @@ static int LUACALL wxLua_wxFontInfo_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFontInfo_constructor_overload[] =
 {
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxFontInfo_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFontInfo_constructor2 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFontInfo_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFontInfo_constructor1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFontInfo_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 };
 static int s_wxluafunc_wxLua_wxFontInfo_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxFontInfo_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
 void wxLua_wxFontInfo_delete_function(void** p)
 {
@@ -3550,17 +3550,17 @@ void wxLua_wxFontInfo_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxFontInfo_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "AllFlags", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_AllFlags, 1, NULL },
     { "AntiAliased", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_AntiAliased, 1, NULL },
     { "Bold", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Bold, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
     { "Encoding", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Encoding, 1, NULL },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "FaceName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_FaceName, 1, NULL },
     { "Family", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Family, 1, NULL },
     { "Italic", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Italic, 1, NULL },
@@ -3568,11 +3568,11 @@ wxLuaBindMethod wxFontInfo_methods[] = {
     { "Slant", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Slant, 1, NULL },
     { "Strikethrough", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Strikethrough, 1, NULL },
     { "Underlined", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFontInfo_Underlined, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
     { "wxFontInfo", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxFontInfo_constructor_overload, s_wxluafunc_wxLua_wxFontInfo_constructor_overload_count, 0 },
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
     { 0, 0, 0, 0 },
 };
@@ -3590,11 +3590,11 @@ int wxFontInfo_methodCount = sizeof(wxFontInfo_methods)/sizeof(wxLuaBindMethod) 
 // Lua MetaTable Tag for Class 'wxFont'
 int wxluatype_wxFont = WXLUA_TUNKNOWN;
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Bold[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_Bold(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Bold[1] = {{ wxLua_wxFont_Bold, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_Bold }};
-//     %wxchkver_3_1_1 wxFont Bold() const;
+//     %wxchkver_3_0_0 wxFont Bold() const;
 static int LUACALL wxLua_wxFont_Bold(lua_State *L)
 {
     // get this
@@ -3610,10 +3610,11 @@ static int LUACALL wxLua_wxFont_Bold(lua_State *L)
     return 1;
 }
 
+#if (wxCHECK_VERSION(3,1,1))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetBaseFont[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetBaseFont(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_GetBaseFont[1] = {{ wxLua_wxFont_GetBaseFont, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_GetBaseFont }};
-//     %wxchkver_3_1_1 wxFont GetBaseFont() const;
+//     %wxchkver_3_0_0 wxFont GetBaseFont() const;
 static int LUACALL wxLua_wxFont_GetBaseFont(lua_State *L)
 {
     // get this
@@ -3628,8 +3629,9 @@ static int LUACALL wxLua_wxFont_GetBaseFont(lua_State *L)
 
     return 1;
 }
+#endif // (wxCHECK_VERSION(3,1,1))
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if (wxLUA_USE_wxFont) && (wxUSE_INTL)
 static int LUACALL wxLua_wxFont_GetDefaultEncoding(lua_State *L);
@@ -3647,11 +3649,11 @@ static int LUACALL wxLua_wxFont_GetDefaultEncoding(lua_State *L)
 
 #endif // (wxLUA_USE_wxFont) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetEncoding[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetEncoding(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_GetEncoding[1] = {{ wxLua_wxFont_GetEncoding, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_GetEncoding }};
-//     %wxchkver_3_1_1 wxFontEncoding GetEncoding() const;
+//     %wxchkver_3_0_0 wxFontEncoding GetEncoding() const;
 static int LUACALL wxLua_wxFont_GetEncoding(lua_State *L)
 {
     // get this
@@ -3664,7 +3666,7 @@ static int LUACALL wxLua_wxFont_GetEncoding(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetFaceName[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetFaceName(lua_State *L);
@@ -3699,11 +3701,11 @@ static int LUACALL wxLua_wxFont_GetFamily(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetNativeFontInfo[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetNativeFontInfo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_GetNativeFontInfo[1] = {{ wxLua_wxFont_GetNativeFontInfo, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_GetNativeFontInfo }};
-//     %wxchkver_3_1_1 const wxNativeFontInfo *GetNativeFontInfo() const;
+//     %wxchkver_3_0_0 const wxNativeFontInfo *GetNativeFontInfo() const;
 static int LUACALL wxLua_wxFont_GetNativeFontInfo(lua_State *L)
 {
     // get this
@@ -3716,7 +3718,7 @@ static int LUACALL wxLua_wxFont_GetNativeFontInfo(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetNativeFontInfoDesc[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetNativeFontInfoDesc(lua_State *L);
@@ -3735,11 +3737,11 @@ static int LUACALL wxLua_wxFont_GetNativeFontInfoDesc(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetNativeFontInfoUserDesc[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetNativeFontInfoUserDesc(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_GetNativeFontInfoUserDesc[1] = {{ wxLua_wxFont_GetNativeFontInfoUserDesc, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_GetNativeFontInfoUserDesc }};
-//     %wxchkver_3_1_1 wxString GetNativeFontInfoUserDesc() const;
+//     %wxchkver_3_0_0 wxString GetNativeFontInfoUserDesc() const;
 static int LUACALL wxLua_wxFont_GetNativeFontInfoUserDesc(lua_State *L)
 {
     // get this
@@ -3752,13 +3754,13 @@ static int LUACALL wxLua_wxFont_GetNativeFontInfoUserDesc(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetPixelSize[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetPixelSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_GetPixelSize[1] = {{ wxLua_wxFont_GetPixelSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_GetPixelSize }};
-//     %wxchkver_3_1_1 wxSize GetPixelSize() const;
+//     %wxchkver_3_0_0 wxSize GetPixelSize() const;
 static int LUACALL wxLua_wxFont_GetPixelSize(lua_State *L)
 {
     // get this
@@ -3774,7 +3776,7 @@ static int LUACALL wxLua_wxFont_GetPixelSize(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetPointSize[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetPointSize(lua_State *L);
@@ -3793,11 +3795,11 @@ static int LUACALL wxLua_wxFont_GetPointSize(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetStrikethrough[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetStrikethrough(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_GetStrikethrough[1] = {{ wxLua_wxFont_GetStrikethrough, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_GetStrikethrough }};
-//     %wxchkver_3_1_1 bool GetStrikethrough() const;
+//     %wxchkver_3_0_0 bool GetStrikethrough() const;
 static int LUACALL wxLua_wxFont_GetStrikethrough(lua_State *L)
 {
     // get this
@@ -3810,7 +3812,7 @@ static int LUACALL wxLua_wxFont_GetStrikethrough(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_GetStyle[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_GetStyle(lua_State *L);
@@ -3877,11 +3879,11 @@ static int LUACALL wxLua_wxFont_IsFixedWidth(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_IsOk[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_IsOk[1] = {{ wxLua_wxFont_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxFont_IsOk(lua_State *L)
 {
     // get this
@@ -3894,13 +3896,13 @@ static int LUACALL wxLua_wxFont_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Italic[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_Italic(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Italic[1] = {{ wxLua_wxFont_Italic, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_Italic }};
-//     %wxchkver_3_1_1 wxFont Italic() const;
+//     %wxchkver_3_0_0 wxFont Italic() const;
 static int LUACALL wxLua_wxFont_Italic(lua_State *L)
 {
     // get this
@@ -3919,7 +3921,7 @@ static int LUACALL wxLua_wxFont_Italic(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Larger[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_Larger(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Larger[1] = {{ wxLua_wxFont_Larger, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_Larger }};
-//     %wxchkver_3_1_1 wxFont Larger() const;
+//     %wxchkver_3_0_0 wxFont Larger() const;
 static int LUACALL wxLua_wxFont_Larger(lua_State *L)
 {
     // get this
@@ -3938,7 +3940,7 @@ static int LUACALL wxLua_wxFont_Larger(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_MakeBold[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_MakeBold(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_MakeBold[1] = {{ wxLua_wxFont_MakeBold, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_MakeBold }};
-//     %wxchkver_3_1_1 wxFont& MakeBold();
+//     %wxchkver_3_0_0 wxFont& MakeBold();
 static int LUACALL wxLua_wxFont_MakeBold(lua_State *L)
 {
     // get this
@@ -3954,7 +3956,7 @@ static int LUACALL wxLua_wxFont_MakeBold(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_MakeItalic[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_MakeItalic(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_MakeItalic[1] = {{ wxLua_wxFont_MakeItalic, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_MakeItalic }};
-//     %wxchkver_3_1_1 wxFont& MakeItalic();
+//     %wxchkver_3_0_0 wxFont& MakeItalic();
 static int LUACALL wxLua_wxFont_MakeItalic(lua_State *L)
 {
     // get this
@@ -3970,7 +3972,7 @@ static int LUACALL wxLua_wxFont_MakeItalic(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_MakeLarger[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_MakeLarger(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_MakeLarger[1] = {{ wxLua_wxFont_MakeLarger, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_MakeLarger }};
-//     %wxchkver_3_1_1 wxFont& MakeLarger();
+//     %wxchkver_3_0_0 wxFont& MakeLarger();
 static int LUACALL wxLua_wxFont_MakeLarger(lua_State *L)
 {
     // get this
@@ -3986,7 +3988,7 @@ static int LUACALL wxLua_wxFont_MakeLarger(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_MakeSmaller[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_MakeSmaller(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_MakeSmaller[1] = {{ wxLua_wxFont_MakeSmaller, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_MakeSmaller }};
-//     %wxchkver_3_1_1 wxFont& MakeSmaller();
+//     %wxchkver_3_0_0 wxFont& MakeSmaller();
 static int LUACALL wxLua_wxFont_MakeSmaller(lua_State *L)
 {
     // get this
@@ -4002,7 +4004,7 @@ static int LUACALL wxLua_wxFont_MakeSmaller(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_MakeStrikethrough[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_MakeStrikethrough(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_MakeStrikethrough[1] = {{ wxLua_wxFont_MakeStrikethrough, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_MakeStrikethrough }};
-//     %wxchkver_3_1_1 wxFont& MakeStrikethrough();
+//     %wxchkver_3_0_0 wxFont& MakeStrikethrough();
 static int LUACALL wxLua_wxFont_MakeStrikethrough(lua_State *L)
 {
     // get this
@@ -4018,7 +4020,7 @@ static int LUACALL wxLua_wxFont_MakeStrikethrough(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_MakeUnderlined[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_MakeUnderlined(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_MakeUnderlined[1] = {{ wxLua_wxFont_MakeUnderlined, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_MakeUnderlined }};
-//     %wxchkver_3_1_1 wxFont& MakeUnderlined();
+//     %wxchkver_3_0_0 wxFont& MakeUnderlined();
 static int LUACALL wxLua_wxFont_MakeUnderlined(lua_State *L)
 {
     // get this
@@ -4031,7 +4033,7 @@ static int LUACALL wxLua_wxFont_MakeUnderlined(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if (wxLUA_USE_wxFont) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_New3[] = { &wxluatype_TNUMBER, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TINTEGER, &wxluatype_TBOOLEAN, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
@@ -4175,11 +4177,11 @@ static int LUACALL wxLua_wxFont_Ok(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Scale[] = { &wxluatype_wxFont, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_Scale(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Scale[1] = {{ wxLua_wxFont_Scale, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_Scale }};
-//     %wxchkver_3_1_1 wxFont& Scale(float x);
+//     %wxchkver_3_0_0 wxFont& Scale(float x);
 static int LUACALL wxLua_wxFont_Scale(lua_State *L)
 {
     // float x
@@ -4197,7 +4199,7 @@ static int LUACALL wxLua_wxFont_Scale(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Scaled[] = { &wxluatype_wxFont, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_Scaled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Scaled[1] = {{ wxLua_wxFont_Scaled, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_Scaled }};
-//     %wxchkver_3_1_1 wxFont Scaled(float x) const;
+//     %wxchkver_3_0_0 wxFont Scaled(float x) const;
 static int LUACALL wxLua_wxFont_Scaled(lua_State *L)
 {
     // float x
@@ -4215,7 +4217,7 @@ static int LUACALL wxLua_wxFont_Scaled(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if (wxLUA_USE_wxFont) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetDefaultEncoding[] = { &wxluatype_TINTEGER, NULL };
@@ -4234,11 +4236,11 @@ static int LUACALL wxLua_wxFont_SetDefaultEncoding(lua_State *L)
 
 #endif // (wxLUA_USE_wxFont) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetEncoding[] = { &wxluatype_wxFont, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_SetEncoding(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetEncoding[1] = {{ wxLua_wxFont_SetEncoding, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetEncoding }};
-//     %wxchkver_3_1_1 void SetEncoding(wxFontEncoding encoding);
+//     %wxchkver_3_0_0 void SetEncoding(wxFontEncoding encoding);
 static int LUACALL wxLua_wxFont_SetEncoding(lua_State *L)
 {
     // wxFontEncoding encoding
@@ -4251,7 +4253,7 @@ static int LUACALL wxLua_wxFont_SetEncoding(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetFaceName[] = { &wxluatype_wxFont, &wxluatype_TSTRING, NULL };
@@ -4274,11 +4276,11 @@ static int LUACALL wxLua_wxFont_SetFaceName(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetFamily1[] = { &wxluatype_wxFont, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_SetFamily1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetFamily1[1] = {{ wxLua_wxFont_SetFamily1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetFamily1 }};
-//     !%wxchkver_3_1_1 void     SetFamily(int family);
+//     !%wxchkver_3_0_0 void     SetFamily(int family);
 static int LUACALL wxLua_wxFont_SetFamily1(lua_State *L)
 {
     // int family
@@ -4291,13 +4293,13 @@ static int LUACALL wxLua_wxFont_SetFamily1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetFamily[] = { &wxluatype_wxFont, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_SetFamily(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetFamily[1] = {{ wxLua_wxFont_SetFamily, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetFamily }};
-//     %wxchkver_3_1_1 void SetFamily(wxFontFamily family);
+//     %wxchkver_3_0_0 void SetFamily(wxFontFamily family);
 static int LUACALL wxLua_wxFont_SetFamily(lua_State *L)
 {
     // wxFontFamily family
@@ -4310,7 +4312,7 @@ static int LUACALL wxLua_wxFont_SetFamily(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetNativeFontInfo[] = { &wxluatype_wxFont, &wxluatype_TSTRING, NULL };
@@ -4351,11 +4353,11 @@ static int LUACALL wxLua_wxFont_SetNativeFontInfoUserDesc(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetPixelSize[] = { &wxluatype_wxFont, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxFont_SetPixelSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetPixelSize[1] = {{ wxLua_wxFont_SetPixelSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetPixelSize }};
-//     %wxchkver_3_1_1 void SetPixelSize(const wxSize& pixelSize);
+//     %wxchkver_3_0_0 void SetPixelSize(const wxSize& pixelSize);
 static int LUACALL wxLua_wxFont_SetPixelSize(lua_State *L)
 {
     // const wxSize pixelSize
@@ -4368,7 +4370,7 @@ static int LUACALL wxLua_wxFont_SetPixelSize(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetPointSize[] = { &wxluatype_wxFont, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_SetPointSize(lua_State *L);
@@ -4387,11 +4389,11 @@ static int LUACALL wxLua_wxFont_SetPointSize(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetStrikethrough[] = { &wxluatype_wxFont, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFont_SetStrikethrough(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetStrikethrough[1] = {{ wxLua_wxFont_SetStrikethrough, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetStrikethrough }};
-//     %wxchkver_3_1_1 void SetStrikethrough(bool strikethrough);
+//     %wxchkver_3_0_0 void SetStrikethrough(bool strikethrough);
 static int LUACALL wxLua_wxFont_SetStrikethrough(lua_State *L)
 {
     // bool strikethrough
@@ -4404,13 +4406,13 @@ static int LUACALL wxLua_wxFont_SetStrikethrough(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetStyle1[] = { &wxluatype_wxFont, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_SetStyle1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetStyle1[1] = {{ wxLua_wxFont_SetStyle1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetStyle1 }};
-//     !%wxchkver_3_1_1 void     SetStyle(int style);
+//     !%wxchkver_3_0_0 void     SetStyle(int style);
 static int LUACALL wxLua_wxFont_SetStyle1(lua_State *L)
 {
     // int style
@@ -4423,13 +4425,13 @@ static int LUACALL wxLua_wxFont_SetStyle1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetStyle[] = { &wxluatype_wxFont, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_SetStyle(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetStyle[1] = {{ wxLua_wxFont_SetStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetStyle }};
-//     %wxchkver_3_1_1 void SetStyle(wxFontStyle style);
+//     %wxchkver_3_0_0 void SetStyle(wxFontStyle style);
 static int LUACALL wxLua_wxFont_SetStyle(lua_State *L)
 {
     // wxFontStyle style
@@ -4442,13 +4444,13 @@ static int LUACALL wxLua_wxFont_SetStyle(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetSymbolicSize[] = { &wxluatype_wxFont, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_SetSymbolicSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetSymbolicSize[1] = {{ wxLua_wxFont_SetSymbolicSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetSymbolicSize }};
-//     %wxchkver_3_1_1 void SetSymbolicSize(wxFontSymbolicSize size);
+//     %wxchkver_3_0_0 void SetSymbolicSize(wxFontSymbolicSize size);
 static int LUACALL wxLua_wxFont_SetSymbolicSize(lua_State *L)
 {
     // wxFontSymbolicSize size
@@ -4464,7 +4466,7 @@ static int LUACALL wxLua_wxFont_SetSymbolicSize(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetSymbolicSizeRelativeTo[] = { &wxluatype_wxFont, &wxluatype_TINTEGER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_SetSymbolicSizeRelativeTo(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetSymbolicSizeRelativeTo[1] = {{ wxLua_wxFont_SetSymbolicSizeRelativeTo, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxFont_SetSymbolicSizeRelativeTo }};
-//     %wxchkver_3_1_1 void SetSymbolicSizeRelativeTo(wxFontSymbolicSize size, int base);
+//     %wxchkver_3_0_0 void SetSymbolicSizeRelativeTo(wxFontSymbolicSize size, int base);
 static int LUACALL wxLua_wxFont_SetSymbolicSizeRelativeTo(lua_State *L)
 {
     // int base
@@ -4479,13 +4481,13 @@ static int LUACALL wxLua_wxFont_SetSymbolicSizeRelativeTo(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetUnderlined1[] = { &wxluatype_wxFont, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFont_SetUnderlined1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetUnderlined1[1] = {{ wxLua_wxFont_SetUnderlined1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetUnderlined1 }};
-//     !%wxchkver_3_1_1 void     SetUnderlined(const bool underlined);
+//     !%wxchkver_3_0_0 void     SetUnderlined(const bool underlined);
 static int LUACALL wxLua_wxFont_SetUnderlined1(lua_State *L)
 {
     // const bool underlined
@@ -4498,13 +4500,13 @@ static int LUACALL wxLua_wxFont_SetUnderlined1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetUnderlined[] = { &wxluatype_wxFont, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxFont_SetUnderlined(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetUnderlined[1] = {{ wxLua_wxFont_SetUnderlined, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetUnderlined }};
-//     %wxchkver_3_1_1 void SetUnderlined(bool underlined);
+//     %wxchkver_3_0_0 void SetUnderlined(bool underlined);
 static int LUACALL wxLua_wxFont_SetUnderlined(lua_State *L)
 {
     // bool underlined
@@ -4517,13 +4519,13 @@ static int LUACALL wxLua_wxFont_SetUnderlined(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetWeight1[] = { &wxluatype_wxFont, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxFont_SetWeight1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetWeight1[1] = {{ wxLua_wxFont_SetWeight1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetWeight1 }};
-//     !%wxchkver_3_1_1 void     SetWeight(int weight);
+//     !%wxchkver_3_0_0 void     SetWeight(int weight);
 static int LUACALL wxLua_wxFont_SetWeight1(lua_State *L)
 {
     // int weight
@@ -4536,13 +4538,13 @@ static int LUACALL wxLua_wxFont_SetWeight1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_SetWeight[] = { &wxluatype_wxFont, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_SetWeight(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetWeight[1] = {{ wxLua_wxFont_SetWeight, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetWeight }};
-//     %wxchkver_3_1_1 void SetWeight(wxFontWeight weight);
+//     %wxchkver_3_0_0 void SetWeight(wxFontWeight weight);
 static int LUACALL wxLua_wxFont_SetWeight(lua_State *L)
 {
     // wxFontWeight weight
@@ -4558,7 +4560,7 @@ static int LUACALL wxLua_wxFont_SetWeight(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Smaller[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_Smaller(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Smaller[1] = {{ wxLua_wxFont_Smaller, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_Smaller }};
-//     %wxchkver_3_1_1 wxFont Smaller() const;
+//     %wxchkver_3_0_0 wxFont Smaller() const;
 static int LUACALL wxLua_wxFont_Smaller(lua_State *L)
 {
     // get this
@@ -4577,7 +4579,7 @@ static int LUACALL wxLua_wxFont_Smaller(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Strikethrough[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_Strikethrough(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Strikethrough[1] = {{ wxLua_wxFont_Strikethrough, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_Strikethrough }};
-//     %wxchkver_3_1_1 wxFont Strikethrough() const;
+//     %wxchkver_3_0_0 wxFont Strikethrough() const;
 static int LUACALL wxLua_wxFont_Strikethrough(lua_State *L)
 {
     // get this
@@ -4596,7 +4598,7 @@ static int LUACALL wxLua_wxFont_Strikethrough(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_Underlined[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_Underlined(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_Underlined[1] = {{ wxLua_wxFont_Underlined, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxFont_Underlined }};
-//     %wxchkver_3_1_1 wxFont Underlined() const;
+//     %wxchkver_3_0_0 wxFont Underlined() const;
 static int LUACALL wxLua_wxFont_Underlined(lua_State *L)
 {
     // get this
@@ -4612,17 +4614,17 @@ static int LUACALL wxLua_wxFont_Underlined(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_delete[] = { &wxluatype_wxFont, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxFont_delete }};
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_op_eq[] = { &wxluatype_wxFont, &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_op_eq(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_op_eq[1] = {{ wxLua_wxFont_op_eq, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_op_eq }};
-//     %wxchkver_3_1_1 bool operator==(const wxFont& font) const;
+//     %wxchkver_3_0_0 bool operator==(const wxFont& font) const;
 static int LUACALL wxLua_wxFont_op_eq(lua_State *L)
 {
     // const wxFont font
@@ -4640,7 +4642,7 @@ static int LUACALL wxLua_wxFont_op_eq(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_op_ne[] = { &wxluatype_wxFont, &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_op_ne(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_op_ne[1] = {{ wxLua_wxFont_op_ne, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_op_ne }};
-//     %wxchkver_3_1_1 bool operator!=(const wxFont& font) const;
+//     %wxchkver_3_0_0 bool operator!=(const wxFont& font) const;
 static int LUACALL wxLua_wxFont_op_ne(lua_State *L)
 {
     // const wxFont font
@@ -4655,13 +4657,13 @@ static int LUACALL wxLua_wxFont_op_ne(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_op_set1[] = { &wxluatype_wxFont, &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_op_set1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_op_set1[1] = {{ wxLua_wxFont_op_set1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_op_set1 }};
-//     !%wxchkver_3_1_1 wxFont& operator=(const wxFont& f) const;
+//     !%wxchkver_3_0_0 wxFont& operator=(const wxFont& f) const;
 static int LUACALL wxLua_wxFont_op_set1(lua_State *L)
 {
     // const wxFont f
@@ -4677,7 +4679,7 @@ static int LUACALL wxLua_wxFont_op_set1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_op_set[] = { &wxluatype_wxFont, &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_op_set(lua_State *L);
@@ -4699,11 +4701,11 @@ static int LUACALL wxLua_wxFont_op_set(lua_State *L)
 }
 
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor8[] = { &wxluatype_TNUMBER, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TINTEGER, &wxluatype_TBOOLEAN, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_constructor8(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor8[1] = {{ wxLua_wxFont_constructor8, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor8 }};
-//     !%wxchkver_3_1_1 wxFont(int pointSize, wxFontFamily family, int style, wxFontWeight weight, const bool underline = false, const wxString& faceName = "", wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
+//     !%wxchkver_3_0_0 wxFont(int pointSize, wxFontFamily family, int style, wxFontWeight weight, const bool underline = false, const wxString& faceName = "", wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
 static int LUACALL wxLua_wxFont_constructor8(lua_State *L)
 {
     // get number of arguments
@@ -4735,7 +4737,7 @@ static int LUACALL wxLua_wxFont_constructor8(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor7[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TBOOLEAN, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_constructor7(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor7[1] = {{ wxLua_wxFont_constructor7, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor7 }};
-//     !%wxchkver_3_1_1 wxFont(int pointSize, int family, int style, int weight, const bool underline = false, const wxString& faceName = "", wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
+//     !%wxchkver_3_0_0 wxFont(int pointSize, int family, int style, int weight, const bool underline = false, const wxString& faceName = "", wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
 static int LUACALL wxLua_wxFont_constructor7(lua_State *L)
 {
     // get number of arguments
@@ -4764,13 +4766,13 @@ static int LUACALL wxLua_wxFont_constructor7(lua_State *L)
     return 1;
 }
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor6[] = { &wxluatype_wxNativeFontInfo, NULL };
 static int LUACALL wxLua_wxFont_constructor6(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor6[1] = {{ wxLua_wxFont_constructor6, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor6 }};
-//     %wxchkver_3_1_1 wxFont(const wxNativeFontInfo& nativeInfo);
+//     %wxchkver_3_0_0 wxFont(const wxNativeFontInfo& nativeInfo);
 static int LUACALL wxLua_wxFont_constructor6(lua_State *L)
 {
     // const wxNativeFontInfo nativeInfo
@@ -4788,7 +4790,7 @@ static int LUACALL wxLua_wxFont_constructor6(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor5[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxFont_constructor5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor5[1] = {{ wxLua_wxFont_constructor5, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor5 }};
-//     %wxchkver_3_1_1 wxFont(const wxString& nativeInfoString);
+//     %wxchkver_3_0_0 wxFont(const wxString& nativeInfoString);
 static int LUACALL wxLua_wxFont_constructor5(lua_State *L)
 {
     // const wxString nativeInfoString
@@ -4803,13 +4805,13 @@ static int LUACALL wxLua_wxFont_constructor5(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor4[] = { &wxluatype_wxSize, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TBOOLEAN, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor4[1] = {{ wxLua_wxFont_constructor4, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor4 }};
-//     %wxchkver_3_1_1 wxFont(const wxSize& pixelSize, wxFontFamily family, wxFontStyle style, wxFontWeight weight, bool underline = false, const wxString& faceName = wxEmptyString, wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
+//     %wxchkver_3_0_0 wxFont(const wxSize& pixelSize, wxFontFamily family, wxFontStyle style, wxFontWeight weight, bool underline = false, const wxString& faceName = wxEmptyString, wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
 static int LUACALL wxLua_wxFont_constructor4(lua_State *L)
 {
     // get number of arguments
@@ -4838,13 +4840,13 @@ static int LUACALL wxLua_wxFont_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor3[] = { &wxluatype_TNUMBER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TBOOLEAN, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxFont_constructor3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor3[1] = {{ wxLua_wxFont_constructor3, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor3 }};
-//     %wxchkver_3_1_1 wxFont(int pointSize, wxFontFamily family, wxFontStyle style, wxFontWeight weight, bool underline = false, const wxString& faceName = wxEmptyString, wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
+//     %wxchkver_3_0_0 wxFont(int pointSize, wxFontFamily family, wxFontStyle style, wxFontWeight weight, bool underline = false, const wxString& faceName = wxEmptyString, wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
 static int LUACALL wxLua_wxFont_constructor3(lua_State *L)
 {
     // get number of arguments
@@ -4873,13 +4875,13 @@ static int LUACALL wxLua_wxFont_constructor3(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor2[] = { &wxluatype_wxFontInfo, NULL };
 static int LUACALL wxLua_wxFont_constructor2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor2[1] = {{ wxLua_wxFont_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor2 }};
-//     %wxchkver_3_1_1 wxFont(const wxFontInfo& font);
+//     %wxchkver_3_0_0 wxFont(const wxFontInfo& font);
 static int LUACALL wxLua_wxFont_constructor2(lua_State *L)
 {
     // const wxFontInfo font
@@ -4894,7 +4896,7 @@ static int LUACALL wxLua_wxFont_constructor2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxFont_constructor1[] = { &wxluatype_wxFont, NULL };
 static int LUACALL wxLua_wxFont_constructor1(lua_State *L);
@@ -4915,10 +4917,10 @@ static int LUACALL wxLua_wxFont_constructor1(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 static int LUACALL wxLua_wxFont_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor[1] = {{ wxLua_wxFont_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxFont();
+//     %wxchkver_3_0_0 wxFont();
 static int LUACALL wxLua_wxFont_constructor(lua_State *L)
 {
     // call constructor
@@ -4931,7 +4933,7 @@ static int LUACALL wxLua_wxFont_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 
 
@@ -4960,18 +4962,18 @@ static int s_wxluafunc_wxLua_wxFont_New_overload_count = sizeof(s_wxluafunc_wxLu
 
 #endif // ((wxLUA_USE_wxFont) && (wxUSE_INTL))||(((wxLUA_USE_wxFont) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetFamily_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetFamily1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetFamily1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetFamily, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetFamily },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 };
 static int s_wxluafunc_wxLua_wxFont_SetFamily_overload_count = sizeof(s_wxluafunc_wxLua_wxFont_SetFamily_overload)/sizeof(wxLuaBindCFunc);
 
@@ -4979,107 +4981,107 @@ static int s_wxluafunc_wxLua_wxFont_SetFamily_overload_count = sizeof(s_wxluafun
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetStyle_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetStyle1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetStyle1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetStyle },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 };
 static int s_wxluafunc_wxLua_wxFont_SetStyle_overload_count = sizeof(s_wxluafunc_wxLua_wxFont_SetStyle_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetUnderlined_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetUnderlined1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetUnderlined1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetUnderlined, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetUnderlined },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 };
 static int s_wxluafunc_wxLua_wxFont_SetUnderlined_overload_count = sizeof(s_wxluafunc_wxLua_wxFont_SetUnderlined_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_SetWeight_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetWeight1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetWeight1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_SetWeight, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_SetWeight },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 };
 static int s_wxluafunc_wxLua_wxFont_SetWeight_overload_count = sizeof(s_wxluafunc_wxLua_wxFont_SetWeight_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_op_set_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_op_set1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_op_set1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_op_set, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxFont_op_set },
 };
 static int s_wxluafunc_wxLua_wxFont_op_set_overload_count = sizeof(s_wxluafunc_wxLua_wxFont_op_set_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
 
-#if ((((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
+#if ((((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxFont_constructor_overload[] =
 {
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
     { wxLua_wxFont_constructor8, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor8 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
     { wxLua_wxFont_constructor7, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor7 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_constructor6, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor6 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_constructor5, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor5 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
+#if ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
     { wxLua_wxFont_constructor4, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor4 },
-#endif // ((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
+#endif // ((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
     { wxLua_wxFont_constructor3, WXLUAMETHOD_CONSTRUCTOR, 4, 7, s_wxluatypeArray_wxLua_wxFont_constructor3 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxFont_constructor1 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { wxLua_wxFont_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 };
 static int s_wxluafunc_wxLua_wxFont_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxFont_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
+#endif // ((((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
 
 void wxLua_wxFont_delete_function(void** p)
 {
@@ -5089,52 +5091,54 @@ void wxLua_wxFont_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxFont_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "Bold", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Bold, 1, NULL },
+#if (wxCHECK_VERSION(3,1,1))
     { "GetBaseFont", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetBaseFont, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if (wxLUA_USE_wxFont) && (wxUSE_INTL)
     { "GetDefaultEncoding", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFont_GetDefaultEncoding, 1, NULL },
 #endif // (wxLUA_USE_wxFont) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
     { "GetEncoding", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetEncoding, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
     { "GetFaceName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetFaceName, 1, NULL },
     { "GetFamily", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetFamily, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "GetNativeFontInfo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetNativeFontInfo, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
     { "GetNativeFontInfoDesc", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetNativeFontInfoDesc, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { "GetNativeFontInfoUserDesc", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetNativeFontInfoUserDesc, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
     { "GetPixelSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetPixelSize, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 
     { "GetPointSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetPointSize, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { "GetStrikethrough", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetStrikethrough, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
     { "GetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetStyle, 1, NULL },
     { "GetUnderlined", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetUnderlined, 1, NULL },
     { "GetWeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_GetWeight, 1, NULL },
     { "IsFixedWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_IsFixedWidth, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "Italic", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Italic, 1, NULL },
     { "Larger", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Larger, 1, NULL },
     { "MakeBold", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_MakeBold, 1, NULL },
@@ -5143,7 +5147,7 @@ wxLuaBindMethod wxFont_methods[] = {
     { "MakeSmaller", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_MakeSmaller, 1, NULL },
     { "MakeStrikethrough", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_MakeStrikethrough, 1, NULL },
     { "MakeUnderlined", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_MakeUnderlined, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if ((wxLUA_USE_wxFont) && (wxUSE_INTL))||(((wxLUA_USE_wxFont) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))
     { "New", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFont_New_overload, s_wxluafunc_wxLua_wxFont_New_overload_count, 0 },
@@ -5151,79 +5155,79 @@ wxLuaBindMethod wxFont_methods[] = {
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Ok, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "Scale", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Scale, 1, NULL },
     { "Scaled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Scaled, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
 #if (wxLUA_USE_wxFont) && (wxUSE_INTL)
     { "SetDefaultEncoding", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxFont_SetDefaultEncoding, 1, NULL },
 #endif // (wxLUA_USE_wxFont) && (wxUSE_INTL)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
     { "SetEncoding", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetEncoding, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
     { "SetFaceName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetFaceName, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
     { "SetFamily", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetFamily_overload, s_wxluafunc_wxLua_wxFont_SetFamily_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
     { "SetNativeFontInfo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetNativeFontInfo, 1, NULL },
     { "SetNativeFontInfoUserDesc", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetNativeFontInfoUserDesc, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxFont)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
     { "SetPixelSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetPixelSize, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)
 
     { "SetPointSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetPointSize, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { "SetStrikethrough", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetStrikethrough, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
     { "SetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetStyle_overload, s_wxluafunc_wxLua_wxFont_SetStyle_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
     { "SetSymbolicSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetSymbolicSize, 1, NULL },
     { "SetSymbolicSizeRelativeTo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetSymbolicSizeRelativeTo, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))
     { "SetUnderlined", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetUnderlined_overload, s_wxluafunc_wxLua_wxFont_SetUnderlined_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
     { "SetWeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_SetWeight_overload, s_wxluafunc_wxLua_wxFont_SetWeight_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "Smaller", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Smaller, 1, NULL },
     { "Strikethrough", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Strikethrough, 1, NULL },
     { "Underlined", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_Underlined, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxFont_delete, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
     { "op_eq", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_op_eq, 1, NULL },
     { "op_ne", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_op_ne, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxFont_op_set_overload, s_wxluafunc_wxLua_wxFont_op_set_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(wxLUA_USE_wxFont)
 
-#if ((((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
+#if ((((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
     { "wxFont", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxFont_constructor_overload, s_wxluafunc_wxLua_wxFont_constructor_overload_count, 0 },
-#endif // ((((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
+#endif // ((((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont))||(((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxPointSizeRect)) && (wxUSE_INTL))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxFont)) && (wxLUA_USE_wxFont)) && (wxUSE_INTL))||(wxLUA_USE_wxFont)
 
     { 0, 0, 0, 0 },
 };
@@ -6420,11 +6424,11 @@ static int LUACALL wxLua_wxColour_Alpha(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_AlphaBlend[] = { &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxColour_AlphaBlend(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_AlphaBlend[1] = {{ wxLua_wxColour_AlphaBlend, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 3, 3, s_wxluatypeArray_wxLua_wxColour_AlphaBlend }};
-//     %wxchkver_3_1_1 static unsigned char AlphaBlend(unsigned char fg, unsigned char bg, double alpha);
+//     %wxchkver_3_0_0 static unsigned char AlphaBlend(unsigned char fg, unsigned char bg, double alpha);
 static int LUACALL wxLua_wxColour_AlphaBlend(lua_State *L)
 {
     // double alpha
@@ -6441,7 +6445,7 @@ static int LUACALL wxLua_wxColour_AlphaBlend(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_Blue[] = { &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxColour_Blue(lua_State *L);
@@ -6460,11 +6464,11 @@ static int LUACALL wxLua_wxColour_Blue(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_ChangeLightness[] = { &wxluatype_wxColour, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxColour_ChangeLightness(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_ChangeLightness[1] = {{ wxLua_wxColour_ChangeLightness, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxColour_ChangeLightness }};
-//     %wxchkver_3_1_1 wxColour ChangeLightness(int ialpha) const;
+//     %wxchkver_3_0_0 wxColour ChangeLightness(int ialpha) const;
 static int LUACALL wxLua_wxColour_ChangeLightness(lua_State *L)
 {
     // int ialpha
@@ -6482,7 +6486,7 @@ static int LUACALL wxLua_wxColour_ChangeLightness(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_GetAsString[] = { &wxluatype_wxColour, &wxluatype_TNUMBER, NULL };
@@ -6507,11 +6511,11 @@ static int LUACALL wxLua_wxColour_GetAsString(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_GetRGB[] = { &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxColour_GetRGB(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_GetRGB[1] = {{ wxLua_wxColour_GetRGB, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxColour_GetRGB }};
-//     %wxchkver_3_1_1 wxUint32 GetRGB() const;
+//     %wxchkver_3_0_0 wxUint32 GetRGB() const;
 static int LUACALL wxLua_wxColour_GetRGB(lua_State *L)
 {
     // get this
@@ -6527,7 +6531,7 @@ static int LUACALL wxLua_wxColour_GetRGB(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_GetRGBA[] = { &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxColour_GetRGBA(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_GetRGBA[1] = {{ wxLua_wxColour_GetRGBA, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxColour_GetRGBA }};
-//     %wxchkver_3_1_1 wxUint32 GetRGBA() const;
+//     %wxchkver_3_0_0 wxUint32 GetRGBA() const;
 static int LUACALL wxLua_wxColour_GetRGBA(lua_State *L)
 {
     // get this
@@ -6540,7 +6544,7 @@ static int LUACALL wxLua_wxColour_GetRGBA(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_Green[] = { &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxColour_Green(lua_State *L);
@@ -6559,11 +6563,11 @@ static int LUACALL wxLua_wxColour_Green(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_IsOk[] = { &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxColour_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_IsOk[1] = {{ wxLua_wxColour_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxColour_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxColour_IsOk(lua_State *L)
 {
     // get this
@@ -6576,13 +6580,13 @@ static int LUACALL wxLua_wxColour_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_MakeDisabled[] = { &wxluatype_wxColour, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxColour_MakeDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_MakeDisabled[1] = {{ wxLua_wxColour_MakeDisabled, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxColour_MakeDisabled }};
-//     %wxchkver_3_1_1 wxColour& MakeDisabled(unsigned char brightness = 255);
+//     %wxchkver_3_0_0 wxColour& MakeDisabled(unsigned char brightness = 255);
 static int LUACALL wxLua_wxColour_MakeDisabled(lua_State *L)
 {
     // get number of arguments
@@ -6599,7 +6603,7 @@ static int LUACALL wxLua_wxColour_MakeDisabled(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_Ok[] = { &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxColour_Ok(lua_State *L);
@@ -6718,11 +6722,11 @@ static int LUACALL wxLua_wxColour_Set(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_SetRGB[] = { &wxluatype_wxColour, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxColour_SetRGB(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_SetRGB[1] = {{ wxLua_wxColour_SetRGB, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxColour_SetRGB }};
-//     %wxchkver_3_1_1 void SetRGB(wxUint32 colRGB);
+//     %wxchkver_3_0_0 void SetRGB(wxUint32 colRGB);
 static int LUACALL wxLua_wxColour_SetRGB(lua_State *L)
 {
     // wxUint32 colRGB
@@ -6738,7 +6742,7 @@ static int LUACALL wxLua_wxColour_SetRGB(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_SetRGBA[] = { &wxluatype_wxColour, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxColour_SetRGBA(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_SetRGBA[1] = {{ wxLua_wxColour_SetRGBA, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxColour_SetRGBA }};
-//     %wxchkver_3_1_1 void SetRGBA(wxUint32 colRGBA);
+//     %wxchkver_3_0_0 void SetRGBA(wxUint32 colRGBA);
 static int LUACALL wxLua_wxColour_SetRGBA(lua_State *L)
 {
     // wxUint32 colRGBA
@@ -6751,7 +6755,7 @@ static int LUACALL wxLua_wxColour_SetRGBA(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_delete[] = { &wxluatype_wxColour, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxColour_delete }};
@@ -6856,11 +6860,11 @@ static int LUACALL wxLua_wxColour_constructor4(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_constructor3[] = { &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxColour_constructor3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_constructor3[1] = {{ wxLua_wxColour_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxColour_constructor3 }};
-//     %wxchkver_3_1_1 wxColour(unsigned long colRGB);
+//     %wxchkver_3_0_0 wxColour(unsigned long colRGB);
 static int LUACALL wxLua_wxColour_constructor3(lua_State *L)
 {
     // unsigned long colRGB
@@ -6875,7 +6879,7 @@ static int LUACALL wxLua_wxColour_constructor3(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxColour_constructor2[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxColour_constructor2(lua_State *L);
@@ -6925,10 +6929,10 @@ static int LUACALL wxLua_wxColour_constructor1(lua_State *L)
 
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static int LUACALL wxLua_wxColour_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_constructor[1] = {{ wxLua_wxColour_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxColour();
+//     %wxchkver_3_0_0 wxColour();
 static int LUACALL wxLua_wxColour_constructor(lua_State *L)
 {
     // call constructor
@@ -6941,7 +6945,7 @@ static int LUACALL wxLua_wxColour_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 
 
@@ -6970,7 +6974,7 @@ static int s_wxluafunc_wxLua_wxColour_Set_overload_count = sizeof(s_wxluafunc_wx
 
 #endif // ((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush))
 
-#if (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_constructor_overload[] =
 {
@@ -6980,22 +6984,22 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxColour_constructor_overload[] =
 #endif // ((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxColour_constructor4, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxColour_constructor4 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxColour_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxColour_constructor3 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxColour_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxColour_constructor2 },
 
 #if ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxColour_constructor1, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxColour_constructor1 },
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxColour_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 };
 static int s_wxluafunc_wxLua_wxColour_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxColour_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 
 void wxLua_wxColour_delete_function(void** p)
 {
@@ -7009,34 +7013,34 @@ wxLuaBindMethod wxColour_methods[] = {
     { "Alpha", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_Alpha, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { "AlphaBlend", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxColour_AlphaBlend, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
     { "Blue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_Blue, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { "ChangeLightness", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_ChangeLightness, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
     { "GetAsString", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_GetAsString, 1, NULL },
 #endif // (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { "GetRGB", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_GetRGB, 1, NULL },
     { "GetRGBA", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_GetRGBA, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
     { "Green", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_Green, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { "MakeDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_MakeDisabled, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_Ok, 1, NULL },
     { "Red", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_Red, 1, NULL },
@@ -7045,19 +7049,19 @@ wxLuaBindMethod wxColour_methods[] = {
     { "Set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_Set_overload, s_wxluafunc_wxLua_wxColour_Set_overload_count, 0 },
 #endif // ((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { "SetRGB", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_SetRGB, 1, NULL },
     { "SetRGBA", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_SetRGBA, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxColour_delete, 1, NULL },
     { "op_eq", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_op_eq, 1, NULL },
     { "op_ne", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_op_ne, 1, NULL },
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxColour_op_set, 1, NULL },
 
-#if (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
     { "wxColour", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxColour_constructor_overload, s_wxluafunc_wxLua_wxColour_constructor_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 
     { 0, 0, 0, 0 },
 };
@@ -7287,11 +7291,11 @@ static int LUACALL wxLua_wxPen_GetWidth(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_IsNonTransparent[] = { &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_IsNonTransparent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_IsNonTransparent[1] = {{ wxLua_wxPen_IsNonTransparent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxPen_IsNonTransparent }};
-//     %wxchkver_3_1_1 bool IsNonTransparent() const;
+//     %wxchkver_3_0_0 bool IsNonTransparent() const;
 static int LUACALL wxLua_wxPen_IsNonTransparent(lua_State *L)
 {
     // get this
@@ -7307,7 +7311,7 @@ static int LUACALL wxLua_wxPen_IsNonTransparent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_IsOk[] = { &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_IsOk[1] = {{ wxLua_wxPen_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxPen_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxPen_IsOk(lua_State *L)
 {
     // get this
@@ -7323,7 +7327,7 @@ static int LUACALL wxLua_wxPen_IsOk(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_IsTransparent[] = { &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_IsTransparent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_IsTransparent[1] = {{ wxLua_wxPen_IsTransparent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxPen_IsTransparent }};
-//     %wxchkver_3_1_1 bool IsTransparent() const;
+//     %wxchkver_3_0_0 bool IsTransparent() const;
 static int LUACALL wxLua_wxPen_IsTransparent(lua_State *L)
 {
     // get this
@@ -7336,7 +7340,7 @@ static int LUACALL wxLua_wxPen_IsTransparent(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_Ok[] = { &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_Ok(lua_State *L);
@@ -7371,11 +7375,11 @@ static int LUACALL wxLua_wxPen_SetCap(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_SetColour2[] = { &wxluatype_wxPen, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxPen_SetColour2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_SetColour2[1] = {{ wxLua_wxPen_SetColour2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxPen_SetColour2 }};
-//     !%wxchkver_3_1_1 void SetColour(const wxString& colourName);
+//     !%wxchkver_3_0_0 void SetColour(const wxString& colourName);
 static int LUACALL wxLua_wxPen_SetColour2(lua_State *L)
 {
     // const wxString colourName
@@ -7388,7 +7392,7 @@ static int LUACALL wxLua_wxPen_SetColour2(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_SetColour1[] = { &wxluatype_wxPen, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxPen_SetColour1(lua_State *L);
@@ -7498,11 +7502,11 @@ static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_delete[] = { &wxluatype_wxPen, 
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxPen_delete }};
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_op_eq[] = { &wxluatype_wxPen, &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_op_eq(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_op_eq[1] = {{ wxLua_wxPen_op_eq, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxPen_op_eq }};
-//     %wxchkver_3_1_1 bool operator==(const wxPen& pen) const;
+//     %wxchkver_3_0_0 bool operator==(const wxPen& pen) const;
 static int LUACALL wxLua_wxPen_op_eq(lua_State *L)
 {
     // const wxPen pen
@@ -7520,7 +7524,7 @@ static int LUACALL wxLua_wxPen_op_eq(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_op_ne[] = { &wxluatype_wxPen, &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_op_ne(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_op_ne[1] = {{ wxLua_wxPen_op_ne, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxPen_op_ne }};
-//     %wxchkver_3_1_1 bool operator!=(const wxPen& pen) const;
+//     %wxchkver_3_0_0 bool operator!=(const wxPen& pen) const;
 static int LUACALL wxLua_wxPen_op_ne(lua_State *L)
 {
     // const wxPen pen
@@ -7535,7 +7539,7 @@ static int LUACALL wxLua_wxPen_op_ne(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_op_set[] = { &wxluatype_wxPen, &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_op_set(lua_State *L);
@@ -7557,11 +7561,11 @@ static int LUACALL wxLua_wxPen_op_set(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_constructor4[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxPen_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_constructor4[1] = {{ wxLua_wxPen_constructor4, WXLUAMETHOD_CONSTRUCTOR, 3, 3, s_wxluatypeArray_wxLua_wxPen_constructor4 }};
-//     !%wxchkver_3_1_1 wxPen(const wxString& colourName, int width, wxPenStyle style);
+//     !%wxchkver_3_0_0 wxPen(const wxString& colourName, int width, wxPenStyle style);
 static int LUACALL wxLua_wxPen_constructor4(lua_State *L)
 {
     // wxPenStyle style
@@ -7580,7 +7584,7 @@ static int LUACALL wxLua_wxPen_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPen_constructor3[] = { &wxluatype_wxPen, NULL };
 static int LUACALL wxLua_wxPen_constructor3(lua_State *L);
@@ -7664,29 +7668,29 @@ static int LUACALL wxLua_wxPen_constructor(lua_State *L)
 
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_SetColour_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxPen_SetColour2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxPen_SetColour2 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxPen_SetColour1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxPen_SetColour1 },
     { wxLua_wxPen_SetColour, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxPen_SetColour },
 };
 static int s_wxluafunc_wxLua_wxPen_SetColour_overload_count = sizeof(s_wxluafunc_wxLua_wxPen_SetColour_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_constructor_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxPen_constructor4, WXLUAMETHOD_CONSTRUCTOR, 3, 3, s_wxluatypeArray_wxLua_wxPen_constructor4 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxPen_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxPen_constructor3 },
 
 #if (((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush)
@@ -7697,7 +7701,7 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxPen_constructor_overload[] =
 };
 static int s_wxluafunc_wxLua_wxPen_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxPen_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
 
 void wxLua_wxPen_delete_function(void** p)
 {
@@ -7718,18 +7722,18 @@ wxLuaBindMethod wxPen_methods[] = {
     { "GetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_GetStyle, 1, NULL },
     { "GetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_GetWidth, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { "IsNonTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_IsNonTransparent, 1, NULL },
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_IsOk, 1, NULL },
     { "IsTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_IsTransparent, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_Ok, 1, NULL },
     { "SetCap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_SetCap, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
     { "SetColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_SetColour_overload, s_wxluafunc_wxLua_wxPen_SetColour_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)
 
     { "SetJoin", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_SetJoin, 1, NULL },
 
@@ -7741,16 +7745,16 @@ wxLuaBindMethod wxPen_methods[] = {
     { "SetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_SetWidth, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxPen_delete, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { "op_eq", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_op_eq, 1, NULL },
     { "op_ne", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_op_ne, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPen_op_set, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
     { "wxPen", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxPen_constructor_overload, s_wxluafunc_wxLua_wxPen_constructor_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((((defined(__WXMSW__)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxColourPenBrush))
 
     { 0, 0, 0, 0 },
 };
@@ -7895,11 +7899,11 @@ static int LUACALL wxLua_wxBrush_IsHatch(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_IsNonTransparent[] = { &wxluatype_wxBrush, NULL };
 static int LUACALL wxLua_wxBrush_IsNonTransparent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_IsNonTransparent[1] = {{ wxLua_wxBrush_IsNonTransparent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBrush_IsNonTransparent }};
-//     %wxchkver_3_1_1 bool IsNonTransparent() const;
+//     %wxchkver_3_0_0 bool IsNonTransparent() const;
 static int LUACALL wxLua_wxBrush_IsNonTransparent(lua_State *L)
 {
     // get this
@@ -7915,7 +7919,7 @@ static int LUACALL wxLua_wxBrush_IsNonTransparent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_IsOk[] = { &wxluatype_wxBrush, NULL };
 static int LUACALL wxLua_wxBrush_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_IsOk[1] = {{ wxLua_wxBrush_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBrush_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxBrush_IsOk(lua_State *L)
 {
     // get this
@@ -7931,7 +7935,7 @@ static int LUACALL wxLua_wxBrush_IsOk(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_IsTransparent[] = { &wxluatype_wxBrush, NULL };
 static int LUACALL wxLua_wxBrush_IsTransparent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_IsTransparent[1] = {{ wxLua_wxBrush_IsTransparent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBrush_IsTransparent }};
-//     %wxchkver_3_1_1 bool IsTransparent() const;
+//     %wxchkver_3_0_0 bool IsTransparent() const;
 static int LUACALL wxLua_wxBrush_IsTransparent(lua_State *L)
 {
     // get this
@@ -7944,7 +7948,7 @@ static int LUACALL wxLua_wxBrush_IsTransparent(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_Ok[] = { &wxluatype_wxBrush, NULL };
 static int LUACALL wxLua_wxBrush_Ok(lua_State *L);
@@ -7963,11 +7967,11 @@ static int LUACALL wxLua_wxBrush_Ok(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetColour4[] = { &wxluatype_wxBrush, &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxBrush_SetColour4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetColour4[1] = {{ wxLua_wxBrush_SetColour4, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetColour4 }};
-//     !%wxchkver_3_1_1 void SetColour(wxColour& colour);
+//     !%wxchkver_3_0_0 void SetColour(wxColour& colour);
 static int LUACALL wxLua_wxBrush_SetColour4(lua_State *L)
 {
     // wxColour colour
@@ -7980,13 +7984,13 @@ static int LUACALL wxLua_wxBrush_SetColour4(lua_State *L)
     return 0;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetColour3[] = { &wxluatype_wxBrush, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxBrush_SetColour3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetColour3[1] = {{ wxLua_wxBrush_SetColour3, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetColour3 }};
-//     !%wxchkver_3_1_1 void SetColour(const wxString& colourName);
+//     !%wxchkver_3_0_0 void SetColour(const wxString& colourName);
 static int LUACALL wxLua_wxBrush_SetColour3(lua_State *L)
 {
     // const wxString colourName
@@ -8002,7 +8006,7 @@ static int LUACALL wxLua_wxBrush_SetColour3(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetColour2[] = { &wxluatype_wxBrush, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBrush_SetColour2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetColour2[1] = {{ wxLua_wxBrush_SetColour2, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxBrush_SetColour2 }};
-//     !%wxchkver_3_1_1 void SetColour(const unsigned char red, const unsigned char green, const unsigned char blue);
+//     !%wxchkver_3_0_0 void SetColour(const unsigned char red, const unsigned char green, const unsigned char blue);
 static int LUACALL wxLua_wxBrush_SetColour2(lua_State *L)
 {
     // const unsigned char blue
@@ -8019,13 +8023,13 @@ static int LUACALL wxLua_wxBrush_SetColour2(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetColour1[] = { &wxluatype_wxBrush, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBrush_SetColour1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetColour1[1] = {{ wxLua_wxBrush_SetColour1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxBrush_SetColour1 }};
-//     %wxchkver_3_1_1 void SetColour(unsigned char red, unsigned char green, unsigned char blue);
+//     %wxchkver_3_0_0 void SetColour(unsigned char red, unsigned char green, unsigned char blue);
 static int LUACALL wxLua_wxBrush_SetColour1(lua_State *L)
 {
     // unsigned char blue
@@ -8042,13 +8046,13 @@ static int LUACALL wxLua_wxBrush_SetColour1(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetColour[] = { &wxluatype_wxBrush, &wxluatype_wxColour, NULL };
 static int LUACALL wxLua_wxBrush_SetColour(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetColour[1] = {{ wxLua_wxBrush_SetColour, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetColour }};
-//     %wxchkver_3_1_1 void SetColour(const wxColour& colour);
+//     %wxchkver_3_0_0 void SetColour(const wxColour& colour);
 static int LUACALL wxLua_wxBrush_SetColour(lua_State *L)
 {
     // const wxColour colour
@@ -8061,7 +8065,7 @@ static int LUACALL wxLua_wxBrush_SetColour(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetStipple[] = { &wxluatype_wxBrush, &wxluatype_wxBitmap, NULL };
@@ -8082,11 +8086,11 @@ static int LUACALL wxLua_wxBrush_SetStipple(lua_State *L)
 
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetStyle1[] = { &wxluatype_wxBrush, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBrush_SetStyle1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetStyle1[1] = {{ wxLua_wxBrush_SetStyle1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetStyle1 }};
-//     !%wxchkver_3_1_1 void SetStyle(int style);
+//     !%wxchkver_3_0_0 void SetStyle(int style);
 static int LUACALL wxLua_wxBrush_SetStyle1(lua_State *L)
 {
     // int style
@@ -8099,13 +8103,13 @@ static int LUACALL wxLua_wxBrush_SetStyle1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_SetStyle[] = { &wxluatype_wxBrush, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBrush_SetStyle(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetStyle[1] = {{ wxLua_wxBrush_SetStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetStyle }};
-//     %wxchkver_3_1_1 void SetStyle(wxBrushStyle style);
+//     %wxchkver_3_0_0 void SetStyle(wxBrushStyle style);
 static int LUACALL wxLua_wxBrush_SetStyle(lua_State *L)
 {
     // wxBrushStyle style
@@ -8118,7 +8122,7 @@ static int LUACALL wxLua_wxBrush_SetStyle(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_delete[] = { &wxluatype_wxBrush, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxBrush_delete }};
@@ -8160,11 +8164,11 @@ static int LUACALL wxLua_wxBrush_op_ne(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_op_set[] = { &wxluatype_wxBrush, &wxluatype_wxBrush, NULL };
 static int LUACALL wxLua_wxBrush_op_set(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_op_set[1] = {{ wxLua_wxBrush_op_set, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_op_set }};
-//     !%wxchkver_3_1_1 wxBrush& operator=(const wxBrush& b) const;
+//     !%wxchkver_3_0_0 wxBrush& operator=(const wxBrush& b) const;
 static int LUACALL wxLua_wxBrush_op_set(lua_State *L)
 {
     // const wxBrush b
@@ -8183,7 +8187,7 @@ static int LUACALL wxLua_wxBrush_op_set(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_constructor5[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBrush_constructor5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_constructor5[1] = {{ wxLua_wxBrush_constructor5, WXLUAMETHOD_CONSTRUCTOR, 2, 2, s_wxluatypeArray_wxLua_wxBrush_constructor5 }};
-//     !%wxchkver_3_1_1 wxBrush(const wxString& colourName, int style);
+//     !%wxchkver_3_0_0 wxBrush(const wxString& colourName, int style);
 static int LUACALL wxLua_wxBrush_constructor5(lua_State *L)
 {
     // int style
@@ -8203,7 +8207,7 @@ static int LUACALL wxLua_wxBrush_constructor5(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_constructor4[] = { &wxluatype_wxColour, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBrush_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_constructor4[1] = {{ wxLua_wxBrush_constructor4, WXLUAMETHOD_CONSTRUCTOR, 2, 2, s_wxluatypeArray_wxLua_wxBrush_constructor4 }};
-//     !%wxchkver_3_1_1 wxBrush(const wxColour& colour, int style);
+//     !%wxchkver_3_0_0 wxBrush(const wxColour& colour, int style);
 static int LUACALL wxLua_wxBrush_constructor4(lua_State *L)
 {
     // int style
@@ -8220,7 +8224,7 @@ static int LUACALL wxLua_wxBrush_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_constructor3[] = { &wxluatype_wxBrush, NULL };
 static int LUACALL wxLua_wxBrush_constructor3(lua_State *L);
@@ -8262,11 +8266,11 @@ static int LUACALL wxLua_wxBrush_constructor2(lua_State *L)
 
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBrush_constructor1[] = { &wxluatype_wxColour, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBrush_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_constructor1[1] = {{ wxLua_wxBrush_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxBrush_constructor1 }};
-//     %wxchkver_3_1_1 wxBrush(const wxColour& colour, wxBrushStyle style = wxBRUSHSTYLE_SOLID);
+//     %wxchkver_3_0_0 wxBrush(const wxColour& colour, wxBrushStyle style = wxBRUSHSTYLE_SOLID);
 static int LUACALL wxLua_wxBrush_constructor1(lua_State *L)
 {
     // get number of arguments
@@ -8285,7 +8289,7 @@ static int LUACALL wxLua_wxBrush_constructor1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
 static int LUACALL wxLua_wxBrush_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_constructor[1] = {{ wxLua_wxBrush_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
@@ -8305,78 +8309,78 @@ static int LUACALL wxLua_wxBrush_constructor(lua_State *L)
 
 
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetColour_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetColour4, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetColour4 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetColour3, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetColour3 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetColour2, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxBrush_SetColour2 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetColour1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxBrush_SetColour1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetColour, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetColour },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 };
 static int s_wxluafunc_wxLua_wxBrush_SetColour_overload_count = sizeof(s_wxluafunc_wxLua_wxBrush_SetColour_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_SetStyle_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetStyle1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetStyle1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_SetStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBrush_SetStyle },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 };
 static int s_wxluafunc_wxLua_wxBrush_SetStyle_overload_count = sizeof(s_wxluafunc_wxLua_wxBrush_SetStyle_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBrush_constructor_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_constructor5, WXLUAMETHOD_CONSTRUCTOR, 2, 2, s_wxluatypeArray_wxLua_wxBrush_constructor5 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_constructor4, WXLUAMETHOD_CONSTRUCTOR, 2, 2, s_wxluatypeArray_wxLua_wxBrush_constructor4 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxBrush_constructor3 },
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxBrush_constructor2 },
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxBrush_constructor1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { wxLua_wxBrush_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
 };
 static int s_wxluafunc_wxLua_wxBrush_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxBrush_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 
 void wxLua_wxBrush_delete_function(void** p)
 {
@@ -8395,37 +8399,37 @@ wxLuaBindMethod wxBrush_methods[] = {
     { "GetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_GetStyle, 1, NULL },
     { "IsHatch", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_IsHatch, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
     { "IsNonTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_IsNonTransparent, 1, NULL },
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_IsOk, 1, NULL },
     { "IsTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_IsTransparent, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_Ok, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
     { "SetColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_SetColour_overload, s_wxluafunc_wxLua_wxBrush_SetColour_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
     { "SetStipple", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_SetStipple, 1, NULL },
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))
     { "SetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_SetStyle_overload, s_wxluafunc_wxLua_wxBrush_SetStyle_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush))
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxBrush_delete, 1, NULL },
     { "op_eq", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_op_eq, 1, NULL },
     { "op_ne", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_op_ne, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBrush_op_set, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
     { "wxBrush", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxBrush_constructor_overload, s_wxluafunc_wxLua_wxBrush_constructor_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))||(wxLUA_USE_wxColourPenBrush)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxColourPenBrush))
 
     { 0, 0, 0, 0 },
 };
@@ -8790,11 +8794,11 @@ static int LUACALL wxLua_wxPalette_GetRGB(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPalette_IsOk[] = { &wxluatype_wxPalette, NULL };
 static int LUACALL wxLua_wxPalette_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPalette_IsOk[1] = {{ wxLua_wxPalette_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxPalette_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxPalette_IsOk(lua_State *L)
 {
     // get this
@@ -8807,7 +8811,7 @@ static int LUACALL wxLua_wxPalette_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPalette_Ok[] = { &wxluatype_wxPalette, NULL };
 static int LUACALL wxLua_wxPalette_Ok(lua_State *L);
@@ -8848,11 +8852,11 @@ static int LUACALL wxLua_wxPalette_op_set(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPalette_constructor2[] = { &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxPalette_constructor2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxPalette_constructor2[1] = {{ wxLua_wxPalette_constructor2, WXLUAMETHOD_CONSTRUCTOR, 4, 4, s_wxluatypeArray_wxLua_wxPalette_constructor2 }};
-//     %wxchkver_3_1_1 wxPalette(int n, const unsigned char* red, const unsigned char* green, const unsigned char* blue);
+//     %wxchkver_3_0_0 wxPalette(int n, const unsigned char* red, const unsigned char* green, const unsigned char* blue);
 static int LUACALL wxLua_wxPalette_constructor2(lua_State *L)
 {
     // const unsigned char blue
@@ -8873,7 +8877,7 @@ static int LUACALL wxLua_wxPalette_constructor2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxPalette_constructor1[] = { &wxluatype_wxPalette, NULL };
 static int LUACALL wxLua_wxPalette_constructor1(lua_State *L);
@@ -8911,20 +8915,20 @@ static int LUACALL wxLua_wxPalette_constructor(lua_State *L)
 
 
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxPalette_constructor_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { wxLua_wxPalette_constructor2, WXLUAMETHOD_CONSTRUCTOR, 4, 4, s_wxluatypeArray_wxLua_wxPalette_constructor2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { wxLua_wxPalette_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxPalette_constructor1 },
     { wxLua_wxPalette_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
 };
 static int s_wxluafunc_wxLua_wxPalette_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxPalette_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
 void wxLua_wxPalette_delete_function(void** p)
 {
@@ -8939,17 +8943,17 @@ wxLuaBindMethod wxPalette_methods[] = {
     { "GetPixel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPalette_GetPixel, 1, NULL },
     { "GetRGB", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPalette_GetRGB, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPalette_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPalette_Ok, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxPalette_delete, 1, NULL },
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxPalette_op_set, 1, NULL },
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { "wxPalette", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxPalette_constructor_overload, s_wxluafunc_wxLua_wxPalette_constructor_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
     { 0, 0, 0, 0 },
 };
@@ -8967,11 +8971,11 @@ int wxPalette_methodCount = sizeof(wxPalette_methods)/sizeof(wxLuaBindMethod) - 
 // Lua MetaTable Tag for Class 'wxIcon'
 int wxluatype_wxIcon = WXLUA_TUNKNOWN;
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_CopyFromBitmap[] = { &wxluatype_wxIcon, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxIcon_CopyFromBitmap(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_CopyFromBitmap[1] = {{ wxLua_wxIcon_CopyFromBitmap, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxIcon_CopyFromBitmap }};
-//     %wxchkver_3_1_1 void CopyFromBitmap(const wxBitmap& bmp);
+//     %wxchkver_3_0_0 void CopyFromBitmap(const wxBitmap& bmp);
 static int LUACALL wxLua_wxIcon_CopyFromBitmap(lua_State *L)
 {
     // const wxBitmap bmp
@@ -8984,7 +8988,7 @@ static int LUACALL wxLua_wxIcon_CopyFromBitmap(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_GetDepth[] = { &wxluatype_wxIcon, NULL };
 static int LUACALL wxLua_wxIcon_GetDepth(lua_State *L);
@@ -9035,11 +9039,11 @@ static int LUACALL wxLua_wxIcon_GetWidth(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_IsOk[] = { &wxluatype_wxIcon, NULL };
 static int LUACALL wxLua_wxIcon_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_IsOk[1] = {{ wxLua_wxIcon_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxIcon_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxIcon_IsOk(lua_State *L)
 {
     // get this
@@ -9052,13 +9056,13 @@ static int LUACALL wxLua_wxIcon_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_LoadFile1[] = { &wxluatype_wxIcon, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxIcon_LoadFile1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_LoadFile1[1] = {{ wxLua_wxIcon_LoadFile1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxIcon_LoadFile1 }};
-//     !%wxchkver_3_1_1 bool    LoadFile(const wxString& name, wxBitmapType flags);
+//     !%wxchkver_3_0_0 bool    LoadFile(const wxString& name, wxBitmapType flags);
 static int LUACALL wxLua_wxIcon_LoadFile1(lua_State *L)
 {
     // wxBitmapType flags
@@ -9075,13 +9079,13 @@ static int LUACALL wxLua_wxIcon_LoadFile1(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_LoadFile[] = { &wxluatype_wxIcon, &wxluatype_TSTRING, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxIcon_LoadFile(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_LoadFile[1] = {{ wxLua_wxIcon_LoadFile, WXLUAMETHOD_METHOD, 2, 5, s_wxluatypeArray_wxLua_wxIcon_LoadFile }};
-//     %wxchkver_3_1_1 bool LoadFile(const wxString& name, wxBitmapType type = wxICON_DEFAULT_TYPE, int desiredWidth = -1, int desiredHeight = -1);
+//     %wxchkver_3_0_0 bool LoadFile(const wxString& name, wxBitmapType type = wxICON_DEFAULT_TYPE, int desiredWidth = -1, int desiredHeight = -1);
 static int LUACALL wxLua_wxIcon_LoadFile(lua_State *L)
 {
     // get number of arguments
@@ -9104,7 +9108,7 @@ static int LUACALL wxLua_wxIcon_LoadFile(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_Ok[] = { &wxluatype_wxIcon, NULL };
 static int LUACALL wxLua_wxIcon_Ok(lua_State *L);
@@ -9193,11 +9197,11 @@ static int LUACALL wxLua_wxIcon_op_set(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_constructor3[] = { &wxluatype_wxIconLocation, NULL };
 static int LUACALL wxLua_wxIcon_constructor3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_constructor3[1] = {{ wxLua_wxIcon_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxIcon_constructor3 }};
-//     %wxchkver_3_1_1 wxIcon(const wxIconLocation& loc);
+//     %wxchkver_3_0_0 wxIcon(const wxIconLocation& loc);
 static int LUACALL wxLua_wxIcon_constructor3(lua_State *L)
 {
     // const wxIconLocation loc
@@ -9212,7 +9216,7 @@ static int LUACALL wxLua_wxIcon_constructor3(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_constructor2[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxIcon_constructor2(lua_State *L);
@@ -9241,11 +9245,11 @@ static int LUACALL wxLua_wxIcon_constructor2(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxIcon_constructor1[] = { &wxluatype_wxIcon, NULL };
 static int LUACALL wxLua_wxIcon_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_constructor1[1] = {{ wxLua_wxIcon_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxIcon_constructor1 }};
-//     %wxchkver_3_1_1 wxIcon(const wxIcon& icon);
+//     %wxchkver_3_0_0 wxIcon(const wxIcon& icon);
 static int LUACALL wxLua_wxIcon_constructor1(lua_State *L)
 {
     // const wxIcon icon
@@ -9260,7 +9264,7 @@ static int LUACALL wxLua_wxIcon_constructor1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
 
 static int LUACALL wxLua_wxIcon_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_constructor[1] = {{ wxLua_wxIcon_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
@@ -9280,41 +9284,41 @@ static int LUACALL wxLua_wxIcon_constructor(lua_State *L)
 
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_LoadFile_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
     { wxLua_wxIcon_LoadFile1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxIcon_LoadFile1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
     { wxLua_wxIcon_LoadFile, WXLUAMETHOD_METHOD, 2, 5, s_wxluatypeArray_wxLua_wxIcon_LoadFile },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 };
 static int s_wxluafunc_wxLua_wxIcon_LoadFile_overload_count = sizeof(s_wxluafunc_wxLua_wxIcon_LoadFile_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxIcon_constructor_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
     { wxLua_wxIcon_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxIcon_constructor3 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
     { wxLua_wxIcon_constructor2, WXLUAMETHOD_CONSTRUCTOR, 2, 4, s_wxluatypeArray_wxLua_wxIcon_constructor2 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
     { wxLua_wxIcon_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxIcon_constructor1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon)
     { wxLua_wxIcon_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
 };
 static int s_wxluafunc_wxLua_wxIcon_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxIcon_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
 
 void wxLua_wxIcon_delete_function(void** p)
 {
@@ -9324,21 +9328,21 @@ void wxLua_wxIcon_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxIcon_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
     { "CopyFromBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_CopyFromBitmap, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxBitmap)
 
     { "GetDepth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_GetDepth, 1, NULL },
     { "GetHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_GetHeight, 1, NULL },
     { "GetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_GetWidth, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))
     { "LoadFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_LoadFile_overload, s_wxluafunc_wxLua_wxIcon_LoadFile_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon))
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_Ok, 1, NULL },
     { "SetDepth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_SetDepth, 1, NULL },
@@ -9347,9 +9351,9 @@ wxLuaBindMethod wxIcon_methods[] = {
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxIcon_delete, 1, NULL },
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxIcon_op_set, 1, NULL },
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
     { "wxIcon", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxIcon_constructor_overload, s_wxluafunc_wxLua_wxIcon_constructor_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxIcon)) && (wxLUA_USE_wxIcon))||(wxLUA_USE_wxIcon)
 
     { 0, 0, 0, 0 },
 };
@@ -9602,11 +9606,11 @@ int wxIconBundle_methodCount = sizeof(wxIconBundle_methods)/sizeof(wxLuaBindMeth
 // Lua MetaTable Tag for Class 'wxBitmap'
 int wxluatype_wxBitmap = WXLUA_TUNKNOWN;
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_ConvertToDisabled[] = { &wxluatype_wxBitmap, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBitmap_ConvertToDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_ConvertToDisabled[1] = {{ wxLua_wxBitmap_ConvertToDisabled, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxBitmap_ConvertToDisabled }};
-//     %wxchkver_3_1_1 wxBitmap ConvertToDisabled(unsigned char brightness = 255) const;
+//     %wxchkver_3_0_0 wxBitmap ConvertToDisabled(unsigned char brightness = 255) const;
 static int LUACALL wxLua_wxBitmap_ConvertToDisabled(lua_State *L)
 {
     // get number of arguments
@@ -9626,7 +9630,7 @@ static int LUACALL wxLua_wxBitmap_ConvertToDisabled(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_ConvertToImage[] = { &wxluatype_wxBitmap, NULL };
@@ -9671,11 +9675,11 @@ static int LUACALL wxLua_wxBitmap_CopyFromIcon(lua_State *L)
 
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxIcon)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_Create2[] = { &wxluatype_wxBitmap, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_wxDC, NULL };
 static int LUACALL wxLua_wxBitmap_Create2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_Create2[1] = {{ wxLua_wxBitmap_Create2, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxBitmap_Create2 }};
-//     %wxchkver_3_1_1 bool Create(int width, int height, const wxDC& dc);
+//     %wxchkver_3_0_0 bool Create(int width, int height, const wxDC& dc);
 static int LUACALL wxLua_wxBitmap_Create2(lua_State *L)
 {
     // const wxDC dc
@@ -9694,13 +9698,13 @@ static int LUACALL wxLua_wxBitmap_Create2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_Create1[] = { &wxluatype_wxBitmap, &wxluatype_wxSize, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_Create1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_Create1[1] = {{ wxLua_wxBitmap_Create1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxBitmap_Create1 }};
-//     %wxchkver_3_1_1 bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
+//     %wxchkver_3_0_0 bool Create(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
 static int LUACALL wxLua_wxBitmap_Create1(lua_State *L)
 {
     // get number of arguments
@@ -9719,7 +9723,7 @@ static int LUACALL wxLua_wxBitmap_Create1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_Create[] = { &wxluatype_wxBitmap, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_Create(lua_State *L);
@@ -9746,11 +9750,11 @@ static int LUACALL wxLua_wxBitmap_Create(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_CreateScaled[] = { &wxluatype_wxBitmap, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_CreateScaled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_CreateScaled[1] = {{ wxLua_wxBitmap_CreateScaled, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxBitmap_CreateScaled }};
-//     %wxchkver_3_1_1 bool CreateScaled(int logwidth, int logheight, int depth, double logicalScale);
+//     %wxchkver_3_0_0 bool CreateScaled(int logwidth, int logheight, int depth, double logicalScale);
 static int LUACALL wxLua_wxBitmap_CreateScaled(lua_State *L)
 {
     // double logicalScale
@@ -9771,7 +9775,7 @@ static int LUACALL wxLua_wxBitmap_CreateScaled(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_GetDepth[] = { &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmap_GetDepth(lua_State *L);
@@ -9844,11 +9848,11 @@ static int LUACALL wxLua_wxBitmap_GetPalette(lua_State *L)
 
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_GetSize[] = { &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmap_GetSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_GetSize[1] = {{ wxLua_wxBitmap_GetSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmap_GetSize }};
-//     %wxchkver_3_1_1 wxSize GetSize() const;
+//     %wxchkver_3_0_0 wxSize GetSize() const;
 static int LUACALL wxLua_wxBitmap_GetSize(lua_State *L)
 {
     // get this
@@ -9864,7 +9868,7 @@ static int LUACALL wxLua_wxBitmap_GetSize(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_GetSubBitmap[] = { &wxluatype_wxBitmap, &wxluatype_wxRect, NULL };
@@ -9907,11 +9911,11 @@ static int LUACALL wxLua_wxBitmap_GetWidth(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_IsOk[] = { &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmap_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_IsOk[1] = {{ wxLua_wxBitmap_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxBitmap_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxBitmap_IsOk(lua_State *L)
 {
     // get this
@@ -9924,7 +9928,7 @@ static int LUACALL wxLua_wxBitmap_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_LoadFile[] = { &wxluatype_wxBitmap, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBitmap_LoadFile(lua_State *L);
@@ -9947,11 +9951,11 @@ static int LUACALL wxLua_wxBitmap_LoadFile(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_NewFromPNGData[] = { &wxluatype_TLIGHTUSERDATA, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxBitmap_NewFromPNGData(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_NewFromPNGData[1] = {{ wxLua_wxBitmap_NewFromPNGData, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxBitmap_NewFromPNGData }};
-//     %wxchkver_3_1_1 static wxBitmap NewFromPNGData(const void* data, size_t size);
+//     %wxchkver_3_0_0 static wxBitmap NewFromPNGData(const void* data, size_t size);
 static int LUACALL wxLua_wxBitmap_NewFromPNGData(lua_State *L)
 {
     // size_t size
@@ -9969,7 +9973,7 @@ static int LUACALL wxLua_wxBitmap_NewFromPNGData(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_Ok[] = { &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmap_Ok(lua_State *L);
@@ -9988,11 +9992,11 @@ static int LUACALL wxLua_wxBitmap_Ok(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_SaveFile1[] = { &wxluatype_wxBitmap, &wxluatype_TSTRING, &wxluatype_TINTEGER, &wxluatype_wxPalette, NULL };
 static int LUACALL wxLua_wxBitmap_SaveFile1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_SaveFile1[1] = {{ wxLua_wxBitmap_SaveFile1, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_SaveFile1 }};
-//     !%wxchkver_3_1_1 bool SaveFile(const wxString& name, wxBitmapType type, wxPalette* palette = NULL);
+//     !%wxchkver_3_0_0 bool SaveFile(const wxString& name, wxBitmapType type, wxPalette* palette = NULL);
 static int LUACALL wxLua_wxBitmap_SaveFile1(lua_State *L)
 {
     // get number of arguments
@@ -10013,13 +10017,13 @@ static int LUACALL wxLua_wxBitmap_SaveFile1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_SaveFile[] = { &wxluatype_wxBitmap, &wxluatype_TSTRING, &wxluatype_TINTEGER, &wxluatype_wxPalette, NULL };
 static int LUACALL wxLua_wxBitmap_SaveFile(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_SaveFile[1] = {{ wxLua_wxBitmap_SaveFile, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_SaveFile }};
-//     %wxchkver_3_1_1 bool SaveFile(const wxString& name, wxBitmapType type, const wxPalette* palette = NULL) const;
+//     %wxchkver_3_0_0 bool SaveFile(const wxString& name, wxBitmapType type, const wxPalette* palette = NULL) const;
 static int LUACALL wxLua_wxBitmap_SaveFile(lua_State *L)
 {
     // get number of arguments
@@ -10040,7 +10044,7 @@ static int LUACALL wxLua_wxBitmap_SaveFile(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_SetDepth[] = { &wxluatype_wxBitmap, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_SetDepth(lua_State *L);
@@ -10134,11 +10138,11 @@ static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_delete[] = { &wxluatype_wxBi
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxBitmap_delete }};
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_op_set[] = { &wxluatype_wxBitmap, &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmap_op_set(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_op_set[1] = {{ wxLua_wxBitmap_op_set, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxBitmap_op_set }};
-//     !%wxchkver_3_1_1 wxBitmap& operator=(const wxBitmap& b) const;
+//     !%wxchkver_3_0_0 wxBitmap& operator=(const wxBitmap& b) const;
 static int LUACALL wxLua_wxBitmap_op_set(lua_State *L)
 {
     // const wxBitmap b
@@ -10154,7 +10158,7 @@ static int LUACALL wxLua_wxBitmap_op_set(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
 #define wxLua_wxBitmap_constructor11 wxLua_wxBitmapFromXPMData_constructor
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor11[] = { &wxluatype_TTABLE, NULL };
@@ -10302,11 +10306,11 @@ static int LUACALL wxLua_wxBitmapFromBitTable_constructor(lua_State *L)
 
 
 
-#if (((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
+#if (((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor7[] = { &wxluatype_wxCursor, NULL };
 static int LUACALL wxLua_wxBitmap_constructor7(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_constructor7[1] = {{ wxLua_wxBitmap_constructor7, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxBitmap_constructor7 }};
-//     %wxchkver_3_1_1 & %win wxBitmap(const wxCursor& cursor); // %override windows only
+//     %wxchkver_3_0_0 & %win wxBitmap(const wxCursor& cursor); // %override windows only
 static int LUACALL wxLua_wxBitmap_constructor7(lua_State *L)
 {
     // const wxCursor cursor
@@ -10321,7 +10325,7 @@ static int LUACALL wxLua_wxBitmap_constructor7(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
+#endif // (((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor6[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, NULL };
@@ -10371,11 +10375,11 @@ static int LUACALL wxLua_wxBitmap_constructor5(lua_State *L)
 }
 
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor4[] = { &wxluatype_wxSize, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_constructor4[1] = {{ wxLua_wxBitmap_constructor4, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxBitmap_constructor4 }};
-//     %wxchkver_3_1_1 wxBitmap(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
+//     %wxchkver_3_0_0 wxBitmap(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
 static int LUACALL wxLua_wxBitmap_constructor4(lua_State *L)
 {
     // get number of arguments
@@ -10394,7 +10398,7 @@ static int LUACALL wxLua_wxBitmap_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor3[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_constructor3(lua_State *L);
@@ -10421,11 +10425,11 @@ static int LUACALL wxLua_wxBitmap_constructor3(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor2[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxBitmap_constructor2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_constructor2[1] = {{ wxLua_wxBitmap_constructor2, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_constructor2 }};
-//     %wxchkver_3_1_1 wxBitmap(const char bits[], int width, int height, int depth = 1);
+//     %wxchkver_3_0_0 wxBitmap(const char bits[], int width, int height, int depth = 1);
 static int LUACALL wxLua_wxBitmap_constructor2(lua_State *L)
 {
     // get number of arguments
@@ -10448,7 +10452,7 @@ static int LUACALL wxLua_wxBitmap_constructor2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxBitmap_constructor1[] = { &wxluatype_wxBitmap, NULL };
 static int LUACALL wxLua_wxBitmap_constructor1(lua_State *L);
@@ -10486,42 +10490,42 @@ static int LUACALL wxLua_wxBitmap_constructor(lua_State *L)
 
 
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_Create_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
     { wxLua_wxBitmap_Create2, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxBitmap_Create2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxBitmap_Create1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxBitmap_Create1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxBitmap_Create, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_Create },
 };
 static int s_wxluafunc_wxLua_wxBitmap_Create_overload_count = sizeof(s_wxluafunc_wxLua_wxBitmap_Create_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_SaveFile_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { wxLua_wxBitmap_SaveFile1, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_SaveFile1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { wxLua_wxBitmap_SaveFile, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_SaveFile },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 };
 static int s_wxluafunc_wxLua_wxBitmap_SaveFile_overload_count = sizeof(s_wxluafunc_wxLua_wxBitmap_SaveFile_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
 
-#if (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
+#if (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_constructor_overload[] =
 {
@@ -10533,29 +10537,29 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxBitmap_constructor_overload[] =
     { wxLua_wxBitmap_constructor9, WXLUAMETHOD_CONSTRUCTOR, 4, 4, s_wxluatypeArray_wxLua_wxBitmap_constructor9 },
     { wxLua_wxBitmap_constructor8, WXLUAMETHOD_CONSTRUCTOR, 4, 4, s_wxluatypeArray_wxLua_wxBitmap_constructor8 },
 
-#if (((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
+#if (((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
     { wxLua_wxBitmap_constructor7, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxBitmap_constructor7 },
-#endif // (((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
+#endif // (((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxBitmap_constructor6, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxBitmap_constructor6 },
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxBitmap_constructor5, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxBitmap_constructor5 },
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxBitmap_constructor4, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxBitmap_constructor4 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxBitmap_constructor3, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxBitmap_constructor3 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
     { wxLua_wxBitmap_constructor2, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxBitmap_constructor2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
     { wxLua_wxBitmap_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxBitmap_constructor1 },
     { wxLua_wxBitmap_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
 };
 static int s_wxluafunc_wxLua_wxBitmap_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxBitmap_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
+#endif // (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
 
 void wxLua_wxBitmap_delete_function(void** p)
 {
@@ -10565,9 +10569,9 @@ void wxLua_wxBitmap_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxBitmap_methods[] = {
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
     { "ConvertToDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_ConvertToDisabled, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "ConvertToImage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_ConvertToImage, 1, NULL },
@@ -10577,13 +10581,13 @@ wxLuaBindMethod wxBitmap_methods[] = {
     { "CopyFromIcon", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_CopyFromIcon, 1, NULL },
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxIcon)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_Create_overload, s_wxluafunc_wxLua_wxBitmap_Create_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxDC))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxBitmap)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
     { "CreateScaled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_CreateScaled, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
 
     { "GetDepth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_GetDepth, 1, NULL },
     { "GetHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_GetHeight, 1, NULL },
@@ -10596,9 +10600,9 @@ wxLuaBindMethod wxBitmap_methods[] = {
     { "GetPalette", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_GetPalette, 1, NULL },
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
     { "GetSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_GetSize, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxPointSizeRect)
     { "GetSubBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_GetSubBitmap, 1, NULL },
@@ -10606,21 +10610,21 @@ wxLuaBindMethod wxBitmap_methods[] = {
 
     { "GetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_GetWidth, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)
 
     { "LoadFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_LoadFile, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
     { "NewFromPNGData", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxBitmap_NewFromPNGData, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_Ok, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
     { "SaveFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_SaveFile_overload, s_wxluafunc_wxLua_wxBitmap_SaveFile_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE))
 
     { "SetDepth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_SetDepth, 1, NULL },
     { "SetHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_SetHeight, 1, NULL },
@@ -10636,13 +10640,13 @@ wxLuaBindMethod wxBitmap_methods[] = {
     { "SetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_SetWidth, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxBitmap_delete, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxBitmap_op_set, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)
 
-#if (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
+#if (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
     { "wxBitmap", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxBitmap_constructor_overload, s_wxluafunc_wxLua_wxBitmap_constructor_overload_count, 0 },
-#endif // (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,1,1) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
+#endif // (wxLUA_USE_wxBitmap)||(((defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))||((((wxCHECK_VERSION(3,0,0) && defined(__WXMSW__)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxBitmap))
 
     { 0, 0, 0, 0 },
 };
@@ -10736,11 +10740,11 @@ static int LUACALL wxLua_wxCursor_GetWidth(lua_State *L)
 
 #endif // (defined(__WXMSW__)) && (wxLUA_USE_wxCursor)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_IsOk[] = { &wxluatype_wxCursor, NULL };
 static int LUACALL wxLua_wxCursor_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_IsOk[1] = {{ wxLua_wxCursor_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxCursor_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxCursor_IsOk(lua_State *L)
 {
     // get this
@@ -10753,7 +10757,7 @@ static int LUACALL wxLua_wxCursor_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_Ok[] = { &wxluatype_wxCursor, NULL };
 static int LUACALL wxLua_wxCursor_Ok(lua_State *L);
@@ -10775,11 +10779,11 @@ static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_delete[] = { &wxluatype_wxCu
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxCursor_delete }};
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_op_set1[] = { &wxluatype_wxCursor, &wxluatype_wxCursor, NULL };
 static int LUACALL wxLua_wxCursor_op_set1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_op_set1[1] = {{ wxLua_wxCursor_op_set1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxCursor_op_set1 }};
-//     !%wxchkver_3_1_1 wxCursor& operator=(const wxCursor& c) const;
+//     !%wxchkver_3_0_0 wxCursor& operator=(const wxCursor& c) const;
 static int LUACALL wxLua_wxCursor_op_set1(lua_State *L)
 {
     // const wxCursor c
@@ -10795,7 +10799,7 @@ static int LUACALL wxLua_wxCursor_op_set1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_op_set[] = { &wxluatype_wxCursor, &wxluatype_wxCursor, NULL };
 static int LUACALL wxLua_wxCursor_op_set(lua_State *L);
@@ -10817,11 +10821,11 @@ static int LUACALL wxLua_wxCursor_op_set(lua_State *L)
 }
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_constructor5[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxCursor_constructor5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_constructor5[1] = {{ wxLua_wxCursor_constructor5, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor5 }};
-//     !%wxchkver_3_1_1 wxCursor(int id);
+//     !%wxchkver_3_0_0 wxCursor(int id);
 static int LUACALL wxLua_wxCursor_constructor5(lua_State *L)
 {
     // int id
@@ -10836,13 +10840,13 @@ static int LUACALL wxLua_wxCursor_constructor5(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_constructor4[] = { &wxluatype_wxCursor, NULL };
 static int LUACALL wxLua_wxCursor_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_constructor4[1] = {{ wxLua_wxCursor_constructor4, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor4 }};
-//     %wxchkver_3_1_1 wxCursor(const wxCursor& cursor);
+//     %wxchkver_3_0_0 wxCursor(const wxCursor& cursor);
 static int LUACALL wxLua_wxCursor_constructor4(lua_State *L)
 {
     // const wxCursor cursor
@@ -10857,7 +10861,7 @@ static int LUACALL wxLua_wxCursor_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
 #if (wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_constructor3[] = { &wxluatype_wxImage, NULL };
@@ -10880,11 +10884,11 @@ static int LUACALL wxLua_wxCursor_constructor3(lua_State *L)
 
 #endif // (wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_constructor2[] = { &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxCursor_constructor2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_constructor2[1] = {{ wxLua_wxCursor_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor2 }};
-//     %wxchkver_3_1_1 wxCursor(wxStockCursor cursorId);
+//     %wxchkver_3_0_0 wxCursor(wxStockCursor cursorId);
 static int LUACALL wxLua_wxCursor_constructor2(lua_State *L)
 {
     // wxStockCursor cursorId
@@ -10899,7 +10903,7 @@ static int LUACALL wxLua_wxCursor_constructor2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
 #if ((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCursor_constructor1[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
@@ -10948,40 +10952,40 @@ static int LUACALL wxLua_wxCursor_constructor(lua_State *L)
 
 
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_op_set_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
     { wxLua_wxCursor_op_set1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxCursor_op_set1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
     { wxLua_wxCursor_op_set, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxCursor_op_set },
 };
 static int s_wxluafunc_wxLua_wxCursor_op_set_overload_count = sizeof(s_wxluafunc_wxLua_wxCursor_op_set_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_constructor_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
     { wxLua_wxCursor_constructor5, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor5 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
     { wxLua_wxCursor_constructor4, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor4 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
 #if (wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxCursor_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor3 },
 #endif // (wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
     { wxLua_wxCursor_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxCursor_constructor2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
 
 #if ((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor)
     { wxLua_wxCursor_constructor1, WXLUAMETHOD_CONSTRUCTOR, 2, 4, s_wxluatypeArray_wxLua_wxCursor_constructor1 },
@@ -10990,7 +10994,7 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxCursor_constructor_overload[] =
 };
 static int s_wxluafunc_wxLua_wxCursor_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxCursor_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
 
 void wxLua_wxCursor_delete_function(void** p)
 {
@@ -11013,20 +11017,20 @@ wxLuaBindMethod wxCursor_methods[] = {
     { "GetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxCursor_GetWidth, 1, NULL },
 #endif // (defined(__WXMSW__)) && (wxLUA_USE_wxCursor)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxCursor_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)
 
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxCursor_Ok, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxCursor_delete, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxCursor_op_set_overload, s_wxluafunc_wxLua_wxCursor_op_set_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
     { "wxCursor", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxCursor_constructor_overload, s_wxluafunc_wxLua_wxCursor_constructor_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||((wxLUA_USE_wxCursor) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,9,0)) && (wxLUA_USE_wxCursor)) && (wxLUA_USE_wxCursor))||(wxLUA_USE_wxCursor)
 
     { 0, 0, 0, 0 },
 };
@@ -11111,11 +11115,11 @@ static int LUACALL wxLua_wxMask_Create(lua_State *L)
 
 #endif // ((defined(__WXMSW__)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMask_GetBitmap[] = { &wxluatype_wxMask, NULL };
 static int LUACALL wxLua_wxMask_GetBitmap(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMask_GetBitmap[1] = {{ wxLua_wxMask_GetBitmap, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMask_GetBitmap }};
-//     %wxchkver_3_1_1 wxBitmap GetBitmap() const;
+//     %wxchkver_3_0_0 wxBitmap GetBitmap() const;
 static int LUACALL wxLua_wxMask_GetBitmap(lua_State *L)
 {
     // get this
@@ -11131,17 +11135,17 @@ static int LUACALL wxLua_wxMask_GetBitmap(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMask_delete[] = { &wxluatype_wxMask, NULL };
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMask_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxMask_delete }};
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMask_op_set[] = { &wxluatype_wxMask, &wxluatype_wxMask, NULL };
 static int LUACALL wxLua_wxMask_op_set(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMask_op_set[1] = {{ wxLua_wxMask_op_set, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMask_op_set }};
-//     !%wxchkver_3_1_1 wxMask& operator=(const wxMask& m) const;
+//     !%wxchkver_3_0_0 wxMask& operator=(const wxMask& m) const;
 static int LUACALL wxLua_wxMask_op_set(lua_State *L)
 {
     // const wxMask m
@@ -11157,7 +11161,7 @@ static int LUACALL wxLua_wxMask_op_set(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
 
 #if ((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxMask)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMask_constructor3[] = { &wxluatype_wxBitmap, &wxluatype_wxColour, NULL };
@@ -11299,15 +11303,15 @@ wxLuaBindMethod wxMask_methods[] = {
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMask_Create_overload, s_wxluafunc_wxLua_wxMask_Create_overload_count, 0 },
 #endif // (((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxMask))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxMask))||(((defined(__WXMSW__)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
     { "GetBitmap", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMask_GetBitmap, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)
 
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxMask_delete, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMask_op_set, 1, NULL },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxMask)
 
 #if (((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxColourPenBrush)) && (wxLUA_USE_wxMask))||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxMask))||((((defined(__WXMSW__)) && (wxLUA_USE_wxMask)) && (wxLUA_USE_wxBitmap)) && (wxLUA_USE_wxMask))||(wxLUA_USE_wxMask)
     { "wxMask", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxMask_constructor_overload, s_wxluafunc_wxLua_wxMask_constructor_overload_count, 0 },
@@ -15725,11 +15729,11 @@ static int LUACALL wxLua_wxDisplay_GetName(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDisplay_IsOk[] = { &wxluatype_wxDisplay, NULL };
 static int LUACALL wxLua_wxDisplay_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDisplay_IsOk[1] = {{ wxLua_wxDisplay_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxDisplay_IsOk }};
-//     !%wxchkver_3_1_1 bool  IsOk() const;
+//     !%wxchkver_3_0_0 bool  IsOk() const;
 static int LUACALL wxLua_wxDisplay_IsOk(lua_State *L)
 {
     // get this
@@ -15742,7 +15746,7 @@ static int LUACALL wxLua_wxDisplay_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDisplay_IsPrimary[] = { &wxluatype_wxDisplay, NULL };
 static int LUACALL wxLua_wxDisplay_IsPrimary(lua_State *L);
@@ -15764,11 +15768,11 @@ static wxLuaArgType s_wxluatypeArray_wxLua_wxDisplay_delete[] = { &wxluatype_wxD
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDisplay_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxDisplay_delete }};
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDisplay_constructor1[] = { &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxDisplay_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxDisplay_constructor1[1] = {{ wxLua_wxDisplay_constructor1, WXLUAMETHOD_CONSTRUCTOR, 0, 1, s_wxluatypeArray_wxLua_wxDisplay_constructor1 }};
-//     !%wxchkver_3_1_1 wxDisplay(size_t index = 0);
+//     !%wxchkver_3_0_0 wxDisplay(size_t index = 0);
 static int LUACALL wxLua_wxDisplay_constructor1(lua_State *L)
 {
     // get number of arguments
@@ -15785,13 +15789,13 @@ static int LUACALL wxLua_wxDisplay_constructor1(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxDisplay_constructor[] = { &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxDisplay_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxDisplay_constructor[1] = {{ wxLua_wxDisplay_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 1, s_wxluatypeArray_wxLua_wxDisplay_constructor }};
-//     %wxchkver_3_1_1 wxDisplay(unsigned int index = 0);
+//     %wxchkver_3_0_0 wxDisplay(unsigned int index = 0);
 static int LUACALL wxLua_wxDisplay_constructor(lua_State *L)
 {
     // get number of arguments
@@ -15808,26 +15812,26 @@ static int LUACALL wxLua_wxDisplay_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
 
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxDisplay_constructor_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
     { wxLua_wxDisplay_constructor1, WXLUAMETHOD_CONSTRUCTOR, 0, 1, s_wxluatypeArray_wxLua_wxDisplay_constructor1 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
     { wxLua_wxDisplay_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 1, s_wxluatypeArray_wxLua_wxDisplay_constructor },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 };
 static int s_wxluafunc_wxLua_wxDisplay_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxDisplay_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
 
 void wxLua_wxDisplay_delete_function(void** p)
 {
@@ -15861,16 +15865,16 @@ wxLuaBindMethod wxDisplay_methods[] = {
     { "GetModes", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDisplay_GetModes, 1, NULL },
     { "GetName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDisplay_GetName, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDisplay_IsOk, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)
 
     { "IsPrimary", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxDisplay_IsPrimary, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxDisplay_delete, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
     { "wxDisplay", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxDisplay_constructor_overload, s_wxluafunc_wxLua_wxDisplay_constructor_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY)) && (wxLUA_USE_wxDisplay && wxUSE_DISPLAY))
 
     { 0, 0, 0, 0 },
 };

--- a/wxLua/modules/wxbind/src/wxcore_image.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_image.cpp
@@ -119,11 +119,11 @@ static int LUACALL wxLua_wxImage_BlurVertical(lua_State *L)
 
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_CanRead1[] = { &wxluatype_wxInputStream, NULL };
 static int LUACALL wxLua_wxImage_CanRead1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_CanRead1[1] = {{ wxLua_wxImage_CanRead1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_CanRead1 }};
-//     %wxchkver_3_1_1 static bool CanRead(wxInputStream& stream);
+//     %wxchkver_3_0_0 static bool CanRead(wxInputStream& stream);
 static int LUACALL wxLua_wxImage_CanRead1(lua_State *L)
 {
     // wxInputStream stream
@@ -136,13 +136,13 @@ static int LUACALL wxLua_wxImage_CanRead1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_CanRead[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxImage_CanRead(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_CanRead[1] = {{ wxLua_wxImage_CanRead, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_CanRead }};
-//     %wxchkver_3_1_1 static bool CanRead(const wxString& filename);
+//     %wxchkver_3_0_0 static bool CanRead(const wxString& filename);
 static int LUACALL wxLua_wxImage_CanRead(lua_State *L)
 {
     // const wxString filename
@@ -155,7 +155,7 @@ static int LUACALL wxLua_wxImage_CanRead(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static int LUACALL wxLua_wxImage_CleanUpHandlers(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_CleanUpHandlers[1] = {{ wxLua_wxImage_CleanUpHandlers, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
@@ -169,11 +169,11 @@ static int LUACALL wxLua_wxImage_CleanUpHandlers(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Clear[] = { &wxluatype_wxImage, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_Clear(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Clear[1] = {{ wxLua_wxImage_Clear, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxImage_Clear }};
-//     %wxchkver_3_1_1 void Clear(unsigned char value = 0);
+//     %wxchkver_3_0_0 void Clear(unsigned char value = 0);
 static int LUACALL wxLua_wxImage_Clear(lua_State *L)
 {
     // get number of arguments
@@ -191,7 +191,7 @@ static int LUACALL wxLua_wxImage_Clear(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_ClearAlpha[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_ClearAlpha(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_ClearAlpha[1] = {{ wxLua_wxImage_ClearAlpha, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxImage_ClearAlpha }};
-//     %wxchkver_3_1_1 void ClearAlpha();
+//     %wxchkver_3_0_0 void ClearAlpha();
 static int LUACALL wxLua_wxImage_ClearAlpha(lua_State *L)
 {
     // get this
@@ -202,7 +202,7 @@ static int LUACALL wxLua_wxImage_ClearAlpha(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_ComputeHistogram[] = { &wxluatype_wxImage, &wxluatype_wxImageHistogram, NULL };
 static int LUACALL wxLua_wxImage_ComputeHistogram(lua_State *L);
@@ -223,11 +223,11 @@ static int LUACALL wxLua_wxImage_ComputeHistogram(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_ConvertAlphaToMask1[] = { &wxluatype_wxImage, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_ConvertAlphaToMask1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask1[1] = {{ wxLua_wxImage_ConvertAlphaToMask1, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxImage_ConvertAlphaToMask1 }};
-//     %wxchkver_3_1_1 bool ConvertAlphaToMask(unsigned char mr, unsigned char mg, unsigned char mb, unsigned char threshold = wxIMAGE_ALPHA_THRESHOLD);
+//     %wxchkver_3_0_0 bool ConvertAlphaToMask(unsigned char mr, unsigned char mg, unsigned char mb, unsigned char threshold = wxIMAGE_ALPHA_THRESHOLD);
 static int LUACALL wxLua_wxImage_ConvertAlphaToMask1(lua_State *L)
 {
     // get number of arguments
@@ -253,7 +253,7 @@ static int LUACALL wxLua_wxImage_ConvertAlphaToMask1(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_ConvertAlphaToMask[] = { &wxluatype_wxImage, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_ConvertAlphaToMask(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask[1] = {{ wxLua_wxImage_ConvertAlphaToMask, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxImage_ConvertAlphaToMask }};
-//     %wxchkver_3_1_1 bool ConvertAlphaToMask(unsigned char threshold = wxIMAGE_ALPHA_THRESHOLD);
+//     %wxchkver_3_0_0 bool ConvertAlphaToMask(unsigned char threshold = wxIMAGE_ALPHA_THRESHOLD);
 static int LUACALL wxLua_wxImage_ConvertAlphaToMask(lua_State *L)
 {
     // get number of arguments
@@ -270,13 +270,13 @@ static int LUACALL wxLua_wxImage_ConvertAlphaToMask(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_ConvertToDisabled[] = { &wxluatype_wxImage, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_ConvertToDisabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_ConvertToDisabled[1] = {{ wxLua_wxImage_ConvertToDisabled, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxImage_ConvertToDisabled }};
-//     %wxchkver_3_1_1 wxImage ConvertToDisabled(unsigned char brightness = 255) const;
+//     %wxchkver_3_0_0 wxImage ConvertToDisabled(unsigned char brightness = 255) const;
 static int LUACALL wxLua_wxImage_ConvertToDisabled(lua_State *L)
 {
     // get number of arguments
@@ -296,7 +296,7 @@ static int LUACALL wxLua_wxImage_ConvertToDisabled(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 #if ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_ConvertToGreyscale[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
@@ -373,11 +373,11 @@ static int LUACALL wxLua_wxImage_Copy(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Create5[] = { &wxluatype_wxImage, &wxluatype_wxSize, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Create5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Create5[1] = {{ wxLua_wxImage_Create5, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxImage_Create5 }};
-//     %wxchkver_3_1_1 bool Create(const wxSize& sz, unsigned char* data, unsigned char* alpha, bool static_data = false);
+//     %wxchkver_3_0_0 bool Create(const wxSize& sz, unsigned char* data, unsigned char* alpha, bool static_data = false);
 static int LUACALL wxLua_wxImage_Create5(lua_State *L)
 {
     // get number of arguments
@@ -400,13 +400,13 @@ static int LUACALL wxLua_wxImage_Create5(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Create4[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Create4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Create4[1] = {{ wxLua_wxImage_Create4, WXLUAMETHOD_METHOD, 5, 6, s_wxluatypeArray_wxLua_wxImage_Create4 }};
-//     %wxchkver_3_1_1 bool Create(int width, int height, unsigned char* data, unsigned char* alpha, bool static_data = false);
+//     %wxchkver_3_0_0 bool Create(int width, int height, unsigned char* data, unsigned char* alpha, bool static_data = false);
 static int LUACALL wxLua_wxImage_Create4(lua_State *L)
 {
     // get number of arguments
@@ -431,13 +431,13 @@ static int LUACALL wxLua_wxImage_Create4(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Create3[] = { &wxluatype_wxImage, &wxluatype_wxSize, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Create3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Create3[1] = {{ wxLua_wxImage_Create3, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxImage_Create3 }};
-//     %wxchkver_3_1_1 bool Create(const wxSize& sz, unsigned char* data, bool static_data = false);
+//     %wxchkver_3_0_0 bool Create(const wxSize& sz, unsigned char* data, bool static_data = false);
 static int LUACALL wxLua_wxImage_Create3(lua_State *L)
 {
     // get number of arguments
@@ -458,13 +458,13 @@ static int LUACALL wxLua_wxImage_Create3(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Create2[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Create2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Create2[1] = {{ wxLua_wxImage_Create2, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxImage_Create2 }};
-//     %wxchkver_3_1_1 bool Create(int width, int height, unsigned char* data, bool static_data = false);
+//     %wxchkver_3_0_0 bool Create(int width, int height, unsigned char* data, bool static_data = false);
 static int LUACALL wxLua_wxImage_Create2(lua_State *L)
 {
     // get number of arguments
@@ -487,13 +487,13 @@ static int LUACALL wxLua_wxImage_Create2(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Create1[] = { &wxluatype_wxImage, &wxluatype_wxSize, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Create1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Create1[1] = {{ wxLua_wxImage_Create1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxImage_Create1 }};
-//     %wxchkver_3_1_1 bool Create(const wxSize& sz, bool clear = true);
+//     %wxchkver_3_0_0 bool Create(const wxSize& sz, bool clear = true);
 static int LUACALL wxLua_wxImage_Create1(lua_State *L)
 {
     // get number of arguments
@@ -512,7 +512,7 @@ static int LUACALL wxLua_wxImage_Create1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Create[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Create(lua_State *L);
@@ -581,11 +581,11 @@ static int LUACALL wxLua_wxImage_FindFirstUnusedColour(lua_State *L)
 
 
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_FindHandler4[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_FindHandler4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_FindHandler4[1] = {{ wxLua_wxImage_FindHandler4, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_FindHandler4 }};
-//     !%wxchkver_3_1_1 static wxImageHandler* FindHandler(long imageType);
+//     !%wxchkver_3_0_0 static wxImageHandler* FindHandler(long imageType);
 static int LUACALL wxLua_wxImage_FindHandler4(lua_State *L)
 {
     // long imageType
@@ -601,7 +601,7 @@ static int LUACALL wxLua_wxImage_FindHandler4(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_FindHandler3[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_FindHandler3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_FindHandler3[1] = {{ wxLua_wxImage_FindHandler3, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxImage_FindHandler3 }};
-//     !%wxchkver_3_1_1 static wxImageHandler* FindHandler(const wxString& extension, long imageType);
+//     !%wxchkver_3_0_0 static wxImageHandler* FindHandler(const wxString& extension, long imageType);
 static int LUACALL wxLua_wxImage_FindHandler3(lua_State *L)
 {
     // long imageType
@@ -616,13 +616,13 @@ static int LUACALL wxLua_wxImage_FindHandler3(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_FindHandler2[] = { &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_FindHandler2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_FindHandler2[1] = {{ wxLua_wxImage_FindHandler2, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_FindHandler2 }};
-//     %wxchkver_3_1_1 static wxImageHandler* FindHandler(wxBitmapType imageType);
+//     %wxchkver_3_0_0 static wxImageHandler* FindHandler(wxBitmapType imageType);
 static int LUACALL wxLua_wxImage_FindHandler2(lua_State *L)
 {
     // wxBitmapType imageType
@@ -638,7 +638,7 @@ static int LUACALL wxLua_wxImage_FindHandler2(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_FindHandler1[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_FindHandler1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_FindHandler1[1] = {{ wxLua_wxImage_FindHandler1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxImage_FindHandler1 }};
-//     %wxchkver_3_1_1 static wxImageHandler* FindHandler(const wxString& extension, wxBitmapType imageType);
+//     %wxchkver_3_0_0 static wxImageHandler* FindHandler(const wxString& extension, wxBitmapType imageType);
 static int LUACALL wxLua_wxImage_FindHandler1(lua_State *L)
 {
     // wxBitmapType imageType
@@ -653,7 +653,7 @@ static int LUACALL wxLua_wxImage_FindHandler1(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_FindHandler[] = { &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxImage_FindHandler(lua_State *L);
@@ -770,10 +770,10 @@ static int LUACALL wxLua_wxImage_GetData(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static int LUACALL wxLua_wxImage_GetDefaultLoadFlags(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_GetDefaultLoadFlags[1] = {{ wxLua_wxImage_GetDefaultLoadFlags, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 static int GetDefaultLoadFlags();
+//     %wxchkver_3_1_0 static int GetDefaultLoadFlags();
 static int LUACALL wxLua_wxImage_GetDefaultLoadFlags(lua_State *L)
 {
     // call GetDefaultLoadFlags
@@ -784,7 +784,7 @@ static int LUACALL wxLua_wxImage_GetDefaultLoadFlags(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetGreen[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_GetGreen(lua_State *L);
@@ -897,11 +897,11 @@ static int LUACALL wxLua_wxImage_GetImageExtWildcard(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetLoadFlags[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_GetLoadFlags(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_GetLoadFlags[1] = {{ wxLua_wxImage_GetLoadFlags, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxImage_GetLoadFlags }};
-//     %wxchkver_3_1_1 int GetLoadFlags() const;
+//     %wxchkver_3_1_0 int GetLoadFlags() const;
 static int LUACALL wxLua_wxImage_GetLoadFlags(lua_State *L)
 {
     // get this
@@ -914,7 +914,7 @@ static int LUACALL wxLua_wxImage_GetLoadFlags(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetMaskBlue[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_GetMaskBlue(lua_State *L);
@@ -1066,11 +1066,11 @@ static int LUACALL wxLua_wxImage_GetRed(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetSize[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_GetSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_GetSize[1] = {{ wxLua_wxImage_GetSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxImage_GetSize }};
-//     %wxchkver_3_1_1 wxSize GetSize() const;
+//     %wxchkver_3_0_0 wxSize GetSize() const;
 static int LUACALL wxLua_wxImage_GetSize(lua_State *L)
 {
     // get this
@@ -1086,7 +1086,7 @@ static int LUACALL wxLua_wxImage_GetSize(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetSubImage[] = { &wxluatype_wxImage, &wxluatype_wxRect, NULL };
@@ -1112,11 +1112,11 @@ static int LUACALL wxLua_wxImage_GetSubImage(lua_State *L)
 
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetType[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_GetType(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_GetType[1] = {{ wxLua_wxImage_GetType, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxImage_GetType }};
-//     %wxchkver_3_1_1 wxBitmapType GetType() const;
+//     %wxchkver_3_0_0 wxBitmapType GetType() const;
 static int LUACALL wxLua_wxImage_GetType(lua_State *L)
 {
     // get this
@@ -1129,7 +1129,7 @@ static int LUACALL wxLua_wxImage_GetType(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_GetWidth[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_GetWidth(lua_State *L);
@@ -1262,11 +1262,11 @@ static int LUACALL wxLua_wxImage_InsertHandler(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_IsOk[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_IsOk(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_IsOk[1] = {{ wxLua_wxImage_IsOk, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxImage_IsOk }};
-//     %wxchkver_3_1_1 bool IsOk() const;
+//     %wxchkver_3_0_0 bool IsOk() const;
 static int LUACALL wxLua_wxImage_IsOk(lua_State *L)
 {
     // get this
@@ -1279,7 +1279,7 @@ static int LUACALL wxLua_wxImage_IsOk(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_IsTransparent[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_IsTransparent(lua_State *L);
@@ -1449,11 +1449,11 @@ static int LUACALL wxLua_wxImage_Ok(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Paste[] = { &wxluatype_wxImage, &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_Paste(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Paste[1] = {{ wxLua_wxImage_Paste, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxImage_Paste }};
-//     %wxchkver_3_1_1 void Paste(const wxImage& image, int x, int y);
+//     %wxchkver_3_0_0 void Paste(const wxImage& image, int x, int y);
 static int LUACALL wxLua_wxImage_Paste(lua_State *L)
 {
     // int y
@@ -1470,7 +1470,7 @@ static int LUACALL wxLua_wxImage_Paste(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_RGBtoHSV[] = { &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_RGBtoHSV(lua_State *L);
@@ -1753,11 +1753,11 @@ static int LUACALL wxLua_wxImage_Rotate(lua_State *L)
 
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Rotate180[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_Rotate180(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Rotate180[1] = {{ wxLua_wxImage_Rotate180, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxImage_Rotate180 }};
-//     %wxchkver_3_1_1 wxImage Rotate180() const;
+//     %wxchkver_3_0_0 wxImage Rotate180() const;
 static int LUACALL wxLua_wxImage_Rotate180(lua_State *L)
 {
     // get this
@@ -1773,7 +1773,7 @@ static int LUACALL wxLua_wxImage_Rotate180(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Rotate90[] = { &wxluatype_wxImage, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_Rotate90(lua_State *L);
@@ -1815,11 +1815,11 @@ static int LUACALL wxLua_wxImage_RotateHue(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SaveFile5[] = { &wxluatype_wxImage, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_SaveFile5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SaveFile5[1] = {{ wxLua_wxImage_SaveFile5, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile5 }};
-//     !%wxchkver_3_1_1 bool SaveFile(const wxString& name, int type);
+//     !%wxchkver_3_0_0 bool SaveFile(const wxString& name, int type);
 static int LUACALL wxLua_wxImage_SaveFile5(lua_State *L)
 {
     // int type
@@ -1836,13 +1836,13 @@ static int LUACALL wxLua_wxImage_SaveFile5(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SaveFile4[] = { &wxluatype_wxImage, &wxluatype_wxOutputStream, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_SaveFile4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SaveFile4[1] = {{ wxLua_wxImage_SaveFile4, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile4 }};
-//     %wxchkver_3_1_1 bool SaveFile(wxOutputStream& stream, wxBitmapType type) const;
+//     %wxchkver_3_0_0 bool SaveFile(wxOutputStream& stream, wxBitmapType type) const;
 static int LUACALL wxLua_wxImage_SaveFile4(lua_State *L)
 {
     // wxBitmapType type
@@ -1859,7 +1859,7 @@ static int LUACALL wxLua_wxImage_SaveFile4(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SaveFile3[] = { &wxluatype_wxImage, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxImage_SaveFile3(lua_State *L);
@@ -1900,11 +1900,11 @@ static int LUACALL wxLua_wxImage_SaveFile2(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SaveFile1[] = { &wxluatype_wxImage, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_SaveFile1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SaveFile1[1] = {{ wxLua_wxImage_SaveFile1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile1 }};
-//     %wxchkver_3_1_1 bool SaveFile(const wxString& name, wxBitmapType type) const;
+//     %wxchkver_3_0_0 bool SaveFile(const wxString& name, wxBitmapType type) const;
 static int LUACALL wxLua_wxImage_SaveFile1(lua_State *L)
 {
     // wxBitmapType type
@@ -1921,13 +1921,13 @@ static int LUACALL wxLua_wxImage_SaveFile1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SaveFile[] = { &wxluatype_wxImage, &wxluatype_wxOutputStream, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxImage_SaveFile(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SaveFile[1] = {{ wxLua_wxImage_SaveFile, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile }};
-//     %wxchkver_3_1_1 bool SaveFile(wxOutputStream& stream, const wxString& mimetype) const;
+//     %wxchkver_3_0_0 bool SaveFile(wxOutputStream& stream, const wxString& mimetype) const;
 static int LUACALL wxLua_wxImage_SaveFile(lua_State *L)
 {
     // const wxString mimetype
@@ -1944,7 +1944,7 @@ static int LUACALL wxLua_wxImage_SaveFile(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
 #if ((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Scale1[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
@@ -2048,11 +2048,11 @@ static int LUACALL wxLua_wxImage_SetAlpha1(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetAlpha[] = { &wxluatype_wxImage, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_SetAlpha(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetAlpha[1] = {{ wxLua_wxImage_SetAlpha, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxImage_SetAlpha }};
-//     %wxchkver_3_1_1 void SetAlpha(unsigned char* alpha = NULL, bool static_data = false);
+//     %wxchkver_3_0_0 void SetAlpha(unsigned char* alpha = NULL, bool static_data = false);
 static int LUACALL wxLua_wxImage_SetAlpha(lua_State *L)
 {
     // get number of arguments
@@ -2069,7 +2069,7 @@ static int LUACALL wxLua_wxImage_SetAlpha(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetData[] = { &wxluatype_wxImage, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxImage_SetData(lua_State *L);
@@ -2095,11 +2095,11 @@ static int LUACALL wxLua_wxImage_SetData(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetDefaultLoadFlags[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_SetDefaultLoadFlags(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetDefaultLoadFlags[1] = {{ wxLua_wxImage_SetDefaultLoadFlags, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_SetDefaultLoadFlags }};
-//     %wxchkver_3_1_1 static void SetDefaultLoadFlags(int flags);
+//     %wxchkver_3_1_0 static void SetDefaultLoadFlags(int flags);
 static int LUACALL wxLua_wxImage_SetDefaultLoadFlags(lua_State *L)
 {
     // int flags
@@ -2113,7 +2113,7 @@ static int LUACALL wxLua_wxImage_SetDefaultLoadFlags(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetLoadFlags[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_SetLoadFlags(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetLoadFlags[1] = {{ wxLua_wxImage_SetLoadFlags, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxImage_SetLoadFlags }};
-//     %wxchkver_3_1_1 void SetLoadFlags(int flags);
+//     %wxchkver_3_1_0 void SetLoadFlags(int flags);
 static int LUACALL wxLua_wxImage_SetLoadFlags(lua_State *L)
 {
     // int flags
@@ -2126,7 +2126,7 @@ static int LUACALL wxLua_wxImage_SetLoadFlags(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetMask[] = { &wxluatype_wxImage, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_SetMask(lua_State *L);
@@ -2246,11 +2246,11 @@ static int LUACALL wxLua_wxImage_SetPalette(lua_State *L)
 
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetRGB2[] = { &wxluatype_wxImage, &wxluatype_wxRect, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_SetRGB2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetRGB2[1] = {{ wxLua_wxImage_SetRGB2, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxImage_SetRGB2 }};
-//     !%wxchkver_3_1_1 void SetRGB(wxRect& rect, unsigned char red, unsigned char green, unsigned char blue);
+//     !%wxchkver_3_0_0 void SetRGB(wxRect& rect, unsigned char red, unsigned char green, unsigned char blue);
 static int LUACALL wxLua_wxImage_SetRGB2(lua_State *L)
 {
     // unsigned char blue
@@ -2269,13 +2269,13 @@ static int LUACALL wxLua_wxImage_SetRGB2(lua_State *L)
     return 0;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetRGB1[] = { &wxluatype_wxImage, &wxluatype_wxRect, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_SetRGB1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetRGB1[1] = {{ wxLua_wxImage_SetRGB1, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxImage_SetRGB1 }};
-//     %wxchkver_3_1_1 void SetRGB(const wxRect& rect, unsigned char red, unsigned char green, unsigned char blue);
+//     %wxchkver_3_0_0 void SetRGB(const wxRect& rect, unsigned char red, unsigned char green, unsigned char blue);
 static int LUACALL wxLua_wxImage_SetRGB1(lua_State *L)
 {
     // unsigned char blue
@@ -2294,7 +2294,7 @@ static int LUACALL wxLua_wxImage_SetRGB1(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetRGB[] = { &wxluatype_wxImage, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_SetRGB(lua_State *L);
@@ -2321,11 +2321,11 @@ static int LUACALL wxLua_wxImage_SetRGB(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_SetType[] = { &wxluatype_wxImage, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxImage_SetType(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetType[1] = {{ wxLua_wxImage_SetType, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxImage_SetType }};
-//     %wxchkver_3_1_1 void SetType(wxBitmapType type);
+//     %wxchkver_3_0_0 void SetType(wxBitmapType type);
 static int LUACALL wxLua_wxImage_SetType(lua_State *L)
 {
     // wxBitmapType type
@@ -2338,7 +2338,7 @@ static int LUACALL wxLua_wxImage_SetType(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 #if (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_Size[] = { &wxluatype_wxImage, &wxluatype_wxSize, &wxluatype_wxPoint, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
@@ -2450,11 +2450,11 @@ static int LUACALL wxLua_wxImageFromBitmap_constructor(lua_State *L)
 
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor11[] = { &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_constructor11(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor11[1] = {{ wxLua_wxImage_constructor11, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxImage_constructor11 }};
-//     !%wxchkver_3_1_1 wxImage(const wxString& name, long type = wxBITMAP_TYPE_ANY);
+//     !%wxchkver_3_0_0 wxImage(const wxString& name, long type = wxBITMAP_TYPE_ANY);
 static int LUACALL wxLua_wxImage_constructor11(lua_State *L)
 {
     // get number of arguments
@@ -2476,7 +2476,7 @@ static int LUACALL wxLua_wxImage_constructor11(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor10[] = { &wxluatype_wxImage, NULL };
 static int LUACALL wxLua_wxImage_constructor10(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor10[1] = {{ wxLua_wxImage_constructor10, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxImage_constructor10 }};
-//     !%wxchkver_3_1_1 wxImage(const wxImage& image);
+//     !%wxchkver_3_0_0 wxImage(const wxImage& image);
 static int LUACALL wxLua_wxImage_constructor10(lua_State *L)
 {
     // const wxImage image
@@ -2491,13 +2491,13 @@ static int LUACALL wxLua_wxImage_constructor10(lua_State *L)
     return 1;
 }
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor9[] = { &wxluatype_wxInputStream, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_constructor9(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor9[1] = {{ wxLua_wxImage_constructor9, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor9 }};
-//     %wxchkver_3_1_1 wxImage(wxInputStream& stream, const wxString& mimetype, int index = -1);
+//     %wxchkver_3_0_0 wxImage(wxInputStream& stream, const wxString& mimetype, int index = -1);
 static int LUACALL wxLua_wxImage_constructor9(lua_State *L)
 {
     // get number of arguments
@@ -2521,7 +2521,7 @@ static int LUACALL wxLua_wxImage_constructor9(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor8[] = { &wxluatype_wxInputStream, &wxluatype_TINTEGER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_constructor8(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor8[1] = {{ wxLua_wxImage_constructor8, WXLUAMETHOD_CONSTRUCTOR, 1, 3, s_wxluatypeArray_wxLua_wxImage_constructor8 }};
-//     %wxchkver_3_1_1 wxImage(wxInputStream& stream, wxBitmapType type = wxBITMAP_TYPE_ANY, int index = -1);
+//     %wxchkver_3_0_0 wxImage(wxInputStream& stream, wxBitmapType type = wxBITMAP_TYPE_ANY, int index = -1);
 static int LUACALL wxLua_wxImage_constructor8(lua_State *L)
 {
     // get number of arguments
@@ -2542,13 +2542,13 @@ static int LUACALL wxLua_wxImage_constructor8(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor7[] = { &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_constructor7(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor7[1] = {{ wxLua_wxImage_constructor7, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor7 }};
-//     %wxchkver_3_1_1 wxImage(const wxString& name, const wxString& mimetype, int index = -1);
+//     %wxchkver_3_0_0 wxImage(const wxString& name, const wxString& mimetype, int index = -1);
 static int LUACALL wxLua_wxImage_constructor7(lua_State *L)
 {
     // get number of arguments
@@ -2572,7 +2572,7 @@ static int LUACALL wxLua_wxImage_constructor7(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor6[] = { &wxluatype_TSTRING, &wxluatype_TINTEGER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxImage_constructor6(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor6[1] = {{ wxLua_wxImage_constructor6, WXLUAMETHOD_CONSTRUCTOR, 1, 3, s_wxluatypeArray_wxLua_wxImage_constructor6 }};
-//     %wxchkver_3_1_1 wxImage(const wxString& name, wxBitmapType type = wxBITMAP_TYPE_ANY, int index = -1);
+//     %wxchkver_3_0_0 wxImage(const wxString& name, wxBitmapType type = wxBITMAP_TYPE_ANY, int index = -1);
 static int LUACALL wxLua_wxImage_constructor6(lua_State *L)
 {
     // get number of arguments
@@ -2593,13 +2593,13 @@ static int LUACALL wxLua_wxImage_constructor6(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor5[] = { &wxluatype_wxSize, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_constructor5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor5[1] = {{ wxLua_wxImage_constructor5, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxImage_constructor5 }};
-//     %wxchkver_3_1_1 wxImage(const wxSize& sz, unsigned char* data, unsigned char* alpha, bool static_data = false);
+//     %wxchkver_3_0_0 wxImage(const wxSize& sz, unsigned char* data, unsigned char* alpha, bool static_data = false);
 static int LUACALL wxLua_wxImage_constructor5(lua_State *L)
 {
     // get number of arguments
@@ -2622,13 +2622,13 @@ static int LUACALL wxLua_wxImage_constructor5(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor4[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_constructor4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor4[1] = {{ wxLua_wxImage_constructor4, WXLUAMETHOD_CONSTRUCTOR, 4, 5, s_wxluatypeArray_wxLua_wxImage_constructor4 }};
-//     %wxchkver_3_1_1 wxImage(int width, int height, unsigned char* data, unsigned char* alpha, bool static_data = false);
+//     %wxchkver_3_0_0 wxImage(int width, int height, unsigned char* data, unsigned char* alpha, bool static_data = false);
 static int LUACALL wxLua_wxImage_constructor4(lua_State *L)
 {
     // get number of arguments
@@ -2653,13 +2653,13 @@ static int LUACALL wxLua_wxImage_constructor4(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor3[] = { &wxluatype_wxSize, &wxluatype_TSTRING, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_constructor3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor3[1] = {{ wxLua_wxImage_constructor3, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor3 }};
-//     %wxchkver_3_1_1 wxImage(const wxSize& sz, unsigned char* data, bool static_data = false);
+//     %wxchkver_3_0_0 wxImage(const wxSize& sz, unsigned char* data, bool static_data = false);
 static int LUACALL wxLua_wxImage_constructor3(lua_State *L)
 {
     // get number of arguments
@@ -2683,7 +2683,7 @@ static int LUACALL wxLua_wxImage_constructor3(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor2[] = { &wxluatype_wxSize, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_constructor2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor2[1] = {{ wxLua_wxImage_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxImage_constructor2 }};
-//     %wxchkver_3_1_1 wxImage(const wxSize& sz, bool clear = true);
+//     %wxchkver_3_0_0 wxImage(const wxSize& sz, bool clear = true);
 static int LUACALL wxLua_wxImage_constructor2(lua_State *L)
 {
     // get number of arguments
@@ -2702,7 +2702,7 @@ static int LUACALL wxLua_wxImage_constructor2(lua_State *L)
     return 1;
 }
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxImage_constructor1[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxImage_constructor1(lua_State *L);
@@ -2746,95 +2746,95 @@ static int LUACALL wxLua_wxImage_constructor(lua_State *L)
 
 
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_CanRead_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
     { wxLua_wxImage_CanRead1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_CanRead1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_CanRead, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_CanRead },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 };
 static int s_wxluafunc_wxLua_wxImage_CanRead_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_CanRead_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_ConvertAlphaToMask1, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxImage_ConvertAlphaToMask1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_ConvertAlphaToMask, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxImage_ConvertAlphaToMask },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 };
 static int s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_Create_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_Create5, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxImage_Create5 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_Create4, WXLUAMETHOD_METHOD, 5, 6, s_wxluatypeArray_wxLua_wxImage_Create4 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_Create3, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxImage_Create3 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_Create2, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxImage_Create2 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_Create1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxImage_Create1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_Create, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxImage_Create },
 };
 static int s_wxluafunc_wxLua_wxImage_Create_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_Create_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_FindHandler_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_FindHandler4, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_FindHandler4 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_FindHandler3, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxImage_FindHandler3 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_FindHandler2, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_FindHandler2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_FindHandler1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 2, 2, s_wxluatypeArray_wxLua_wxImage_FindHandler1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_FindHandler, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 1, s_wxluatypeArray_wxLua_wxImage_FindHandler },
 };
 static int s_wxluafunc_wxLua_wxImage_FindHandler_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_FindHandler_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 #if (wxLUA_USE_wxImage && wxUSE_IMAGE)
 // function overload table
@@ -2894,32 +2894,32 @@ static int s_wxluafunc_wxLua_wxImage_Rescale_overload_count = sizeof(s_wxluafunc
 
 #endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SaveFile_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_SaveFile5, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile5 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
     { wxLua_wxImage_SaveFile4, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile4 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
     { wxLua_wxImage_SaveFile3, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxImage_SaveFile3 },
     { wxLua_wxImage_SaveFile2, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile2 },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_SaveFile1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
     { wxLua_wxImage_SaveFile, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxImage_SaveFile },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 };
 static int s_wxluafunc_wxLua_wxImage_SaveFile_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_SaveFile_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
 #if (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 // function overload table
@@ -2938,20 +2938,20 @@ static int s_wxluafunc_wxLua_wxImage_Scale_overload_count = sizeof(s_wxluafunc_w
 
 #endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
-#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetAlpha_overload[] =
 {
     { wxLua_wxImage_SetAlpha2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxImage_SetAlpha2 },
     { wxLua_wxImage_SetAlpha1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxImage_SetAlpha1 },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_SetAlpha, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxImage_SetAlpha },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 };
 static int s_wxluafunc_wxLua_wxImage_SetAlpha_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_SetAlpha_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
 #if (wxLUA_USE_wxImage && wxUSE_IMAGE)
 // function overload table
@@ -2964,25 +2964,25 @@ static int s_wxluafunc_wxLua_wxImage_SetOption_overload_count = sizeof(s_wxluafu
 
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_SetRGB_overload[] =
 {
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_SetRGB2, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxImage_SetRGB2 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_SetRGB1, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxImage_SetRGB1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_SetRGB, WXLUAMETHOD_METHOD, 6, 6, s_wxluatypeArray_wxLua_wxImage_SetRGB },
 };
 static int s_wxluafunc_wxLua_wxImage_SetRGB_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_SetRGB_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
+#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor_overload[] =
 {
@@ -2992,51 +2992,51 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxImage_constructor_overload[] =
     { wxLua_wxImage_constructor12, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxImage_constructor12 },
 #endif // (wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_constructor11, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxImage_constructor11 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_constructor10, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxImage_constructor10 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
     { wxLua_wxImage_constructor9, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor9 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
     { wxLua_wxImage_constructor8, WXLUAMETHOD_CONSTRUCTOR, 1, 3, s_wxluatypeArray_wxLua_wxImage_constructor8 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_constructor7, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor7 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_constructor6, WXLUAMETHOD_CONSTRUCTOR, 1, 3, s_wxluatypeArray_wxLua_wxImage_constructor6 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_constructor5, WXLUAMETHOD_CONSTRUCTOR, 3, 4, s_wxluatypeArray_wxLua_wxImage_constructor5 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { wxLua_wxImage_constructor4, WXLUAMETHOD_CONSTRUCTOR, 4, 5, s_wxluatypeArray_wxLua_wxImage_constructor4 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_constructor3, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor3 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_constructor2, WXLUAMETHOD_CONSTRUCTOR, 1, 2, s_wxluatypeArray_wxLua_wxImage_constructor2 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxImage_constructor1, WXLUAMETHOD_CONSTRUCTOR, 2, 3, s_wxluatypeArray_wxLua_wxImage_constructor1 },
     { wxLua_wxImage_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
 };
 static int s_wxluafunc_wxLua_wxImage_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxImage_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
+#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
 
 void wxLua_wxImage_delete_function(void** p)
 {
@@ -3054,26 +3054,26 @@ wxLuaBindMethod wxImage_methods[] = {
     { "BlurVertical", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_BlurVertical, 1, NULL },
 #endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
     { "CanRead", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_CanRead_overload, s_wxluafunc_wxLua_wxImage_CanRead_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
     { "CleanUpHandlers", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_CleanUpHandlers, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "Clear", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Clear, 1, NULL },
     { "ClearAlpha", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_ClearAlpha, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "ComputeHistogram", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_ComputeHistogram, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
     { "ConvertAlphaToMask", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask_overload, s_wxluafunc_wxLua_wxImage_ConvertAlphaToMask_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "ConvertToDisabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_ConvertToDisabled, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 #if ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "ConvertToGreyscale", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_ConvertToGreyscale, 1, NULL },
@@ -3082,16 +3082,16 @@ wxLuaBindMethod wxImage_methods[] = {
     { "ConvertToMono", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_ConvertToMono, 1, NULL },
     { "Copy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Copy, 1, NULL },
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "Create", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Create_overload, s_wxluafunc_wxLua_wxImage_Create_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "Destroy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Destroy, 1, NULL },
     { "FindFirstUnusedColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_FindFirstUnusedColour, 1, NULL },
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "FindHandler", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_FindHandler_overload, s_wxluafunc_wxLua_wxImage_FindHandler_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "FindHandlerMime", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_FindHandlerMime, 1, NULL },
 
@@ -3102,9 +3102,9 @@ wxLuaBindMethod wxImage_methods[] = {
     { "GetBlue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetBlue, 1, NULL },
     { "GetData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetData, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "GetDefaultLoadFlags", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_GetDefaultLoadFlags, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "GetGreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetGreen, 1, NULL },
 
@@ -3120,9 +3120,9 @@ wxLuaBindMethod wxImage_methods[] = {
 
     { "GetImageExtWildcard", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_GetImageExtWildcard, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "GetLoadFlags", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetLoadFlags, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "GetMaskBlue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetMaskBlue, 1, NULL },
     { "GetMaskGreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetMaskGreen, 1, NULL },
@@ -3137,17 +3137,17 @@ wxLuaBindMethod wxImage_methods[] = {
 
     { "GetRed", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetRed, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
     { "GetSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetSize, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
     { "GetSubImage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetSubImage, 1, NULL },
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "GetType", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetType, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "GetWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_GetWidth, 1, NULL },
     { "HSVtoRGB", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_HSVtoRGB, 1, NULL },
@@ -3158,9 +3158,9 @@ wxLuaBindMethod wxImage_methods[] = {
     { "InitStandardHandlers", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_InitStandardHandlers, 1, NULL },
     { "InsertHandler", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_InsertHandler, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "IsOk", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_IsOk, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "IsTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_IsTransparent, 1, NULL },
 
@@ -3171,9 +3171,9 @@ wxLuaBindMethod wxImage_methods[] = {
     { "Mirror", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Mirror, 1, NULL },
     { "Ok", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Ok, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "Paste", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Paste, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "RGBtoHSV", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_RGBtoHSV, 1, NULL },
     { "RemoveHandler", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_RemoveHandler, 1, NULL },
@@ -3204,31 +3204,31 @@ wxLuaBindMethod wxImage_methods[] = {
     { "Rotate", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Rotate, 1, NULL },
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "Rotate180", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Rotate180, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "Rotate90", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Rotate90, 1, NULL },
     { "RotateHue", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_RotateHue, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
     { "SaveFile", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SaveFile_overload, s_wxluafunc_wxLua_wxImage_SaveFile_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
 #if (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
     { "Scale", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Scale_overload, s_wxluafunc_wxLua_wxImage_Scale_overload_count, 0 },
 #endif // (((!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
-#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
     { "SetAlpha", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetAlpha_overload, s_wxluafunc_wxLua_wxImage_SetAlpha_overload_count, 0 },
-#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
+#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))
 
     { "SetData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetData, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "SetDefaultLoadFlags", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxImage_SetDefaultLoadFlags, 1, NULL },
     { "SetLoadFlags", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetLoadFlags, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,1,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
     { "SetMask", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetMask, 1, NULL },
     { "SetMaskColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetMaskColour, 1, NULL },
@@ -3242,13 +3242,13 @@ wxLuaBindMethod wxImage_methods[] = {
     { "SetPalette", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetPalette, 1, NULL },
 #endif // (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "SetRGB", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetRGB_overload, s_wxluafunc_wxLua_wxImage_SetRGB_overload_count, 0 },
-#endif // (((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxImage && wxUSE_IMAGE)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
     { "SetType", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_SetType, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)
 
 #if (wxLUA_USE_wxImage && wxUSE_IMAGE) && (wxLUA_USE_wxPointSizeRect)
     { "Size", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_Size, 1, NULL },
@@ -3257,9 +3257,9 @@ wxLuaBindMethod wxImage_methods[] = {
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxImage_delete, 1, NULL },
     { "op_set", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxImage_op_set, 1, NULL },
 
-#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
+#if (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
     { "wxImage", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxImage_constructor_overload, s_wxluafunc_wxLua_wxImage_constructor_overload_count, 0 },
-#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
+#endif // (wxLUA_USE_wxImage && wxUSE_IMAGE)||((wxLUA_USE_wxBitmap) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||(((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxUSE_STREAMS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE))||((((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxImage && wxUSE_IMAGE)) && (wxLUA_USE_wxPointSizeRect))
 
     { 0, 0, 0, 0 },
 };

--- a/wxLua/modules/wxbind/src/wxcore_menutool.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_menutool.cpp
@@ -198,11 +198,11 @@ static int LUACALL wxLua_wxMenu_AppendSubMenu(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Attach[] = { &wxluatype_wxMenu, &wxluatype_wxMenuBar, NULL };
 static int LUACALL wxLua_wxMenu_Attach(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_Attach[1] = {{ wxLua_wxMenu_Attach, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMenu_Attach }};
-//     %wxchkver_3_1_1 virtual void Attach(wxMenuBar *menubar);
+//     %wxchkver_3_0_0 virtual void Attach(wxMenuBar *menubar);
 static int LUACALL wxLua_wxMenu_Attach(lua_State *L)
 {
     // wxMenuBar menubar
@@ -215,7 +215,7 @@ static int LUACALL wxLua_wxMenu_Attach(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Break[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_Break(lua_State *L);
@@ -314,11 +314,11 @@ static int LUACALL wxLua_wxMenu_Destroy(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Detach[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_Detach(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_Detach[1] = {{ wxLua_wxMenu_Detach, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenu_Detach }};
-//     %wxchkver_3_1_1 virtual void Detach();
+//     %wxchkver_3_0_0 virtual void Detach();
 static int LUACALL wxLua_wxMenu_Detach(lua_State *L)
 {
     // get this
@@ -329,7 +329,7 @@ static int LUACALL wxLua_wxMenu_Detach(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Enable[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxMenu_Enable(lua_State *L);
@@ -350,11 +350,11 @@ static int LUACALL wxLua_wxMenu_Enable(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_FindChildItem[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, &wxluatype_TLIGHTUSERDATA, NULL };
 static int LUACALL wxLua_wxMenu_FindChildItem(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_FindChildItem[1] = {{ wxLua_wxMenu_FindChildItem, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxMenu_FindChildItem }};
-//     %wxchkver_3_1_1 wxMenuItem *FindChildItem(int id, size_t *pos = NULL) const;
+//     %wxchkver_3_0_0 wxMenuItem *FindChildItem(int id, size_t *pos = NULL) const;
 static int LUACALL wxLua_wxMenu_FindChildItem(lua_State *L)
 {
     // get number of arguments
@@ -373,7 +373,7 @@ static int LUACALL wxLua_wxMenu_FindChildItem(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 #define wxLua_wxMenu_FindItem1 wxLua_wxMenu_FindItemById
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_FindItem1[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, NULL };
@@ -457,11 +457,11 @@ static int LUACALL wxLua_wxMenu_GetHelpString(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetInvokingWindow[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_GetInvokingWindow(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_GetInvokingWindow[1] = {{ wxLua_wxMenu_GetInvokingWindow, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenu_GetInvokingWindow }};
-//     %wxchkver_3_1_1 wxWindow *GetInvokingWindow() const;
+//     %wxchkver_3_0_0 wxWindow *GetInvokingWindow() const;
 static int LUACALL wxLua_wxMenu_GetInvokingWindow(lua_State *L)
 {
     // get this
@@ -474,7 +474,7 @@ static int LUACALL wxLua_wxMenu_GetInvokingWindow(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetLabel[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxMenu_GetLabel(lua_State *L);
@@ -495,11 +495,11 @@ static int LUACALL wxLua_wxMenu_GetLabel(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetLabelText[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxMenu_GetLabelText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_GetLabelText[1] = {{ wxLua_wxMenu_GetLabelText, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMenu_GetLabelText }};
-//     %wxchkver_3_1_1 wxString GetLabelText(int id) const;
+//     %wxchkver_3_0_0 wxString GetLabelText(int id) const;
 static int LUACALL wxLua_wxMenu_GetLabelText(lua_State *L)
 {
     // int id
@@ -514,7 +514,7 @@ static int LUACALL wxLua_wxMenu_GetLabelText(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetMenuItemCount[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_GetMenuItemCount(lua_State *L);
@@ -549,11 +549,11 @@ static int LUACALL wxLua_wxMenu_GetMenuItems(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetParent[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_GetParent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_GetParent[1] = {{ wxLua_wxMenu_GetParent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenu_GetParent }};
-//     %wxchkver_3_1_1 wxMenu *GetParent() const;
+//     %wxchkver_3_0_0 wxMenu *GetParent() const;
 static int LUACALL wxLua_wxMenu_GetParent(lua_State *L)
 {
     // get this
@@ -566,13 +566,13 @@ static int LUACALL wxLua_wxMenu_GetParent(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetStyle[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_GetStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_GetStyle[1] = {{ wxLua_wxMenu_GetStyle, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenu_GetStyle }};
-//     %wxchkver_3_1_1 long GetStyle() const;
+//     %wxchkver_3_0_0 long GetStyle() const;
 static int LUACALL wxLua_wxMenu_GetStyle(lua_State *L)
 {
     // get this
@@ -585,7 +585,7 @@ static int LUACALL wxLua_wxMenu_GetStyle(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetTitle[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_GetTitle(lua_State *L);
@@ -604,11 +604,11 @@ static int LUACALL wxLua_wxMenu_GetTitle(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_GetWindow[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_GetWindow(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_GetWindow[1] = {{ wxLua_wxMenu_GetWindow, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenu_GetWindow }};
-//     %wxchkver_3_1_1 wxWindow *GetWindow() const;
+//     %wxchkver_3_0_0 wxWindow *GetWindow() const;
 static int LUACALL wxLua_wxMenu_GetWindow(lua_State *L)
 {
     // get this
@@ -621,13 +621,13 @@ static int LUACALL wxLua_wxMenu_GetWindow(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Insert2[] = { &wxluatype_wxMenu, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxMenu, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxMenu_Insert2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_Insert2[1] = {{ wxLua_wxMenu_Insert2, WXLUAMETHOD_METHOD, 5, 6, s_wxluatypeArray_wxLua_wxMenu_Insert2 }};
-//     %wxchkver_3_1_1 wxMenuItem* Insert(size_t pos, int id, const wxString& text, wxMenu* submenu, const wxString& help = wxEmptyString);
+//     %wxchkver_3_0_0 wxMenuItem* Insert(size_t pos, int id, const wxString& text, wxMenu* submenu, const wxString& help = wxEmptyString);
 static int LUACALL wxLua_wxMenu_Insert2(lua_State *L)
 {
     // get number of arguments
@@ -652,7 +652,7 @@ static int LUACALL wxLua_wxMenu_Insert2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Insert1[] = { &wxluatype_wxMenu, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxMenu_Insert1(lua_State *L);
@@ -774,11 +774,11 @@ static int LUACALL wxLua_wxMenu_InsertSeparator(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_IsAttached[] = { &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_IsAttached(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_IsAttached[1] = {{ wxLua_wxMenu_IsAttached, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenu_IsAttached }};
-//     %wxchkver_3_1_1 bool IsAttached() const;
+//     %wxchkver_3_0_0 bool IsAttached() const;
 static int LUACALL wxLua_wxMenu_IsAttached(lua_State *L)
 {
     // get this
@@ -791,7 +791,7 @@ static int LUACALL wxLua_wxMenu_IsAttached(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_IsChecked[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxMenu_IsChecked(lua_State *L);
@@ -830,11 +830,11 @@ static int LUACALL wxLua_wxMenu_IsEnabled(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Prepend2[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_wxMenu, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxMenu_Prepend2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_Prepend2[1] = {{ wxLua_wxMenu_Prepend2, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxMenu_Prepend2 }};
-//     %wxchkver_3_1_1 wxMenuItem* Prepend(int id, const wxString& text, wxMenu* submenu, const wxString& help = wxEmptyString);
+//     %wxchkver_3_0_0 wxMenuItem* Prepend(int id, const wxString& text, wxMenu* submenu, const wxString& help = wxEmptyString);
 static int LUACALL wxLua_wxMenu_Prepend2(lua_State *L)
 {
     // get number of arguments
@@ -857,7 +857,7 @@ static int LUACALL wxLua_wxMenu_Prepend2(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_Prepend1[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, &wxluatype_TSTRING, &wxluatype_TSTRING, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxMenu_Prepend1(lua_State *L);
@@ -1025,11 +1025,11 @@ static int LUACALL wxLua_wxMenu_SetHelpString(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_SetInvokingWindow[] = { &wxluatype_wxMenu, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxMenu_SetInvokingWindow(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_SetInvokingWindow[1] = {{ wxLua_wxMenu_SetInvokingWindow, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMenu_SetInvokingWindow }};
-//     %wxchkver_3_1_1 void SetInvokingWindow(wxWindow *win);
+//     %wxchkver_3_0_0 void SetInvokingWindow(wxWindow *win);
 static int LUACALL wxLua_wxMenu_SetInvokingWindow(lua_State *L)
 {
     // wxWindow win
@@ -1042,7 +1042,7 @@ static int LUACALL wxLua_wxMenu_SetInvokingWindow(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_SetLabel[] = { &wxluatype_wxMenu, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxMenu_SetLabel(lua_State *L);
@@ -1063,11 +1063,11 @@ static int LUACALL wxLua_wxMenu_SetLabel(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_SetParent[] = { &wxluatype_wxMenu, &wxluatype_wxMenu, NULL };
 static int LUACALL wxLua_wxMenu_SetParent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_SetParent[1] = {{ wxLua_wxMenu_SetParent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMenu_SetParent }};
-//     %wxchkver_3_1_1 void SetParent(wxMenu *parent);
+//     %wxchkver_3_0_0 void SetParent(wxMenu *parent);
 static int LUACALL wxLua_wxMenu_SetParent(lua_State *L)
 {
     // wxMenu parent
@@ -1080,7 +1080,7 @@ static int LUACALL wxLua_wxMenu_SetParent(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_SetTitle[] = { &wxluatype_wxMenu, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxMenu_SetTitle(lua_State *L);
@@ -1219,11 +1219,11 @@ static int LUACALL wxLua_wxMenu_constructor2(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenu_constructor1[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxMenu_constructor1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_constructor1[1] = {{ wxLua_wxMenu_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxMenu_constructor1 }};
-//     %wxchkver_3_1_1 wxMenu(long style);
+//     %wxchkver_3_0_0 wxMenu(long style);
 static int LUACALL wxLua_wxMenu_constructor1(lua_State *L)
 {
     // long style
@@ -1240,7 +1240,7 @@ static int LUACALL wxLua_wxMenu_constructor1(lua_State *L)
 
 static int LUACALL wxLua_wxMenu_constructor(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_constructor[1] = {{ wxLua_wxMenu_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None }};
-//     %wxchkver_3_1_1 wxMenu();
+//     %wxchkver_3_0_0 wxMenu();
 static int LUACALL wxLua_wxMenu_constructor(lua_State *L)
 {
     // call constructor
@@ -1253,7 +1253,7 @@ static int LUACALL wxLua_wxMenu_constructor(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 
 
@@ -1293,14 +1293,14 @@ static int s_wxluafunc_wxLua_wxMenu_FindItem_overload_count = sizeof(s_wxluafunc
 
 #endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_Insert_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxMenu_Insert2, WXLUAMETHOD_METHOD, 5, 6, s_wxluatypeArray_wxLua_wxMenu_Insert2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxMenu_Insert1, WXLUAMETHOD_METHOD, 4, 6, s_wxluatypeArray_wxLua_wxMenu_Insert1 },
     { wxLua_wxMenu_Insert, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxMenu_Insert },
 };
@@ -1310,15 +1310,15 @@ static int s_wxluafunc_wxLua_wxMenu_Insert_overload_count = sizeof(s_wxluafunc_w
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_Prepend_overload[] =
 {
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxMenu_Prepend2, WXLUAMETHOD_METHOD, 4, 5, s_wxluatypeArray_wxLua_wxMenu_Prepend2 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxMenu_Prepend1, WXLUAMETHOD_METHOD, 3, 5, s_wxluatypeArray_wxLua_wxMenu_Prepend1 },
     { wxLua_wxMenu_Prepend, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMenu_Prepend },
 };
 static int s_wxluafunc_wxLua_wxMenu_Prepend_overload_count = sizeof(s_wxluafunc_wxLua_wxMenu_Prepend_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 #if (wxLUA_USE_wxMenu && wxUSE_MENUS)
 // function overload table
@@ -1331,24 +1331,24 @@ static int s_wxluafunc_wxLua_wxMenu_Remove_overload_count = sizeof(s_wxluafunc_w
 
 #endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
+#if (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenu_constructor_overload[] =
 {
     { wxLua_wxMenu_constructor3, WXLUAMETHOD_CONSTRUCTOR, 1, 3, s_wxluatypeArray_wxLua_wxMenu_constructor3 },
     { wxLua_wxMenu_constructor2, WXLUAMETHOD_CONSTRUCTOR, 0, 2, s_wxluatypeArray_wxLua_wxMenu_constructor2 },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxMenu_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxMenu_constructor1 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxMenu_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 0, g_wxluaargtypeArray_None },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 };
 static int s_wxluafunc_wxLua_wxMenu_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxMenu_constructor_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
+#endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
 
 void wxLua_wxMenu_delete_function(void** p)
 {
@@ -1367,9 +1367,9 @@ wxLuaBindMethod wxMenu_methods[] = {
     { "AppendSeparator", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_AppendSeparator, 1, NULL },
     { "AppendSubMenu", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_AppendSubMenu, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "Attach", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Attach, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "Break", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Break, 1, NULL },
     { "Check", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Check, 1, NULL },
@@ -1379,15 +1379,15 @@ wxLuaBindMethod wxMenu_methods[] = {
     { "Destroy", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Destroy_overload, s_wxluafunc_wxLua_wxMenu_Destroy_overload_count, 0 },
 #endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "Detach", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Detach, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "Enable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Enable, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "FindChildItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_FindChildItem, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 #if (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "FindItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_FindItem_overload, s_wxluafunc_wxLua_wxMenu_FindItem_overload_count, 0 },
@@ -1396,51 +1396,51 @@ wxLuaBindMethod wxMenu_methods[] = {
     { "FindItemByPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_FindItemByPosition, 1, NULL },
     { "GetHelpString", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetHelpString, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "GetInvokingWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetInvokingWindow, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "GetLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetLabel, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "GetLabelText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetLabelText, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "GetMenuItemCount", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetMenuItemCount, 1, NULL },
     { "GetMenuItems", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetMenuItems, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "GetParent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetParent, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "GetStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetStyle, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "GetTitle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetTitle, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "GetWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_GetWindow, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "Insert", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Insert_overload, s_wxluafunc_wxLua_wxMenu_Insert_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "InsertCheckItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_InsertCheckItem, 1, NULL },
     { "InsertRadioItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_InsertRadioItem, 1, NULL },
     { "InsertSeparator", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_InsertSeparator, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "IsAttached", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_IsAttached, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "IsChecked", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_IsChecked, 1, NULL },
     { "IsEnabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_IsEnabled, 1, NULL },
 
-#if (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "Prepend", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_Prepend_overload, s_wxluafunc_wxLua_wxMenu_Prepend_overload_count, 0 },
-#endif // (((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "PrependCheckItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_PrependCheckItem, 1, NULL },
     { "PrependRadioItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_PrependRadioItem, 1, NULL },
@@ -1452,23 +1452,23 @@ wxLuaBindMethod wxMenu_methods[] = {
 
     { "SetHelpString", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_SetHelpString, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "SetInvokingWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_SetInvokingWindow, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "SetLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_SetLabel, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "SetParent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_SetParent, 1, NULL },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "SetTitle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_SetTitle, 1, NULL },
     { "UpdateUI", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenu_UpdateUI, 1, NULL },
     { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxMenu_delete, 1, NULL },
 
-#if (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
+#if (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
     { "wxMenu", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxMenu_constructor_overload, s_wxluafunc_wxLua_wxMenu_constructor_overload_count, 0 },
-#endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
+#endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))
 
     { 0, 0, 0, 0 },
 };
@@ -2387,11 +2387,11 @@ static int LUACALL wxLua_wxMenuItem_GetMenu(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenuItem_GetName[] = { &wxluatype_wxMenuItem, NULL };
 static int LUACALL wxLua_wxMenuItem_GetName(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenuItem_GetName[1] = {{ wxLua_wxMenuItem_GetName, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenuItem_GetName }};
-//     %wxchkver_3_1_1 wxString GetName() const;
+//     %wxchkver_3_0_0 wxString GetName() const;
 static int LUACALL wxLua_wxMenuItem_GetName(lua_State *L)
 {
     // get this
@@ -2404,7 +2404,7 @@ static int LUACALL wxLua_wxMenuItem_GetName(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenuItem_GetSubMenu[] = { &wxluatype_wxMenuItem, NULL };
 static int LUACALL wxLua_wxMenuItem_GetSubMenu(lua_State *L);
@@ -2477,11 +2477,11 @@ static int LUACALL wxLua_wxMenuItem_GetTextColour(lua_State *L)
 
 #endif // ((defined(__WXMSW__)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenuItem_IsCheck[] = { &wxluatype_wxMenuItem, NULL };
 static int LUACALL wxLua_wxMenuItem_IsCheck(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenuItem_IsCheck[1] = {{ wxLua_wxMenuItem_IsCheck, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenuItem_IsCheck }};
-//     %wxchkver_3_1_1 bool IsCheck() const;
+//     %wxchkver_3_0_0 bool IsCheck() const;
 static int LUACALL wxLua_wxMenuItem_IsCheck(lua_State *L)
 {
     // get this
@@ -2494,7 +2494,7 @@ static int LUACALL wxLua_wxMenuItem_IsCheck(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenuItem_IsCheckable[] = { &wxluatype_wxMenuItem, NULL };
 static int LUACALL wxLua_wxMenuItem_IsCheckable(lua_State *L);
@@ -2545,11 +2545,11 @@ static int LUACALL wxLua_wxMenuItem_IsEnabled(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenuItem_IsRadio[] = { &wxluatype_wxMenuItem, NULL };
 static int LUACALL wxLua_wxMenuItem_IsRadio(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxMenuItem_IsRadio[1] = {{ wxLua_wxMenuItem_IsRadio, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMenuItem_IsRadio }};
-//     %wxchkver_3_1_1 bool IsRadio() const;
+//     %wxchkver_3_0_0 bool IsRadio() const;
 static int LUACALL wxLua_wxMenuItem_IsRadio(lua_State *L)
 {
     // get this
@@ -2562,7 +2562,7 @@ static int LUACALL wxLua_wxMenuItem_IsRadio(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxMenuItem_IsSeparator[] = { &wxluatype_wxMenuItem, NULL };
 static int LUACALL wxLua_wxMenuItem_IsSeparator(lua_State *L);
@@ -2980,9 +2980,9 @@ wxLuaBindMethod wxMenuItem_methods[] = {
 
     { "GetMenu", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_GetMenu, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "GetName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_GetName, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "GetSubMenu", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_GetSubMenu, 1, NULL },
 
@@ -2994,17 +2994,17 @@ wxLuaBindMethod wxMenuItem_methods[] = {
     { "GetTextColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_GetTextColour, 1, NULL },
 #endif // ((defined(__WXMSW__)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxColourPenBrush)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "IsCheck", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsCheck, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "IsCheckable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsCheckable, 1, NULL },
     { "IsChecked", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsChecked, 1, NULL },
     { "IsEnabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsEnabled, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { "IsRadio", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsRadio, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
     { "IsSeparator", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsSeparator, 1, NULL },
     { "IsSubMenu", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMenuItem_IsSubMenu, 1, NULL },

--- a/wxLua/modules/wxbind/src/wxcore_windows.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_windows.cpp
@@ -427,11 +427,11 @@ int wxVisualAttributes_methodCount = sizeof(wxVisualAttributes_methods)/sizeof(w
 // Lua MetaTable Tag for Class 'wxWindow'
 int wxluatype_wxWindow = WXLUA_TUNKNOWN;
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_AcceptsFocus[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_AcceptsFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_AcceptsFocus[1] = {{ wxLua_wxWindow_AcceptsFocus, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_AcceptsFocus }};
-//     %wxchkver_3_1_1 bool AcceptsFocus() const;
+//     %wxchkver_3_0_0 bool AcceptsFocus() const;
 static int LUACALL wxLua_wxWindow_AcceptsFocus(lua_State *L)
 {
     // get this
@@ -447,7 +447,7 @@ static int LUACALL wxLua_wxWindow_AcceptsFocus(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_AcceptsFocusFromKeyboard[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_AcceptsFocusFromKeyboard(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_AcceptsFocusFromKeyboard[1] = {{ wxLua_wxWindow_AcceptsFocusFromKeyboard, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_AcceptsFocusFromKeyboard }};
-//     %wxchkver_3_1_1 bool AcceptsFocusFromKeyboard() const;
+//     %wxchkver_3_0_0 bool AcceptsFocusFromKeyboard() const;
 static int LUACALL wxLua_wxWindow_AcceptsFocusFromKeyboard(lua_State *L)
 {
     // get this
@@ -463,7 +463,7 @@ static int LUACALL wxLua_wxWindow_AcceptsFocusFromKeyboard(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_AcceptsFocusRecursively[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_AcceptsFocusRecursively(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_AcceptsFocusRecursively[1] = {{ wxLua_wxWindow_AcceptsFocusRecursively, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_AcceptsFocusRecursively }};
-//     %wxchkver_3_1_1 bool AcceptsFocusRecursively() const;
+//     %wxchkver_3_0_0 bool AcceptsFocusRecursively() const;
 static int LUACALL wxLua_wxWindow_AcceptsFocusRecursively(lua_State *L)
 {
     // get this
@@ -476,7 +476,7 @@ static int LUACALL wxLua_wxWindow_AcceptsFocusRecursively(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_AddChild[] = { &wxluatype_wxWindow, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_AddChild(lua_State *L);
@@ -495,11 +495,11 @@ static int LUACALL wxLua_wxWindow_AddChild(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_AdjustForLayoutDirection[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_AdjustForLayoutDirection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_AdjustForLayoutDirection[1] = {{ wxLua_wxWindow_AdjustForLayoutDirection, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxWindow_AdjustForLayoutDirection }};
-//     %wxchkver_3_1_1 wxCoord AdjustForLayoutDirection(wxCoord x, wxCoord width, wxCoord widthTotal) const;
+//     %wxchkver_3_0_0 wxCoord AdjustForLayoutDirection(wxCoord x, wxCoord width, wxCoord widthTotal) const;
 static int LUACALL wxLua_wxWindow_AdjustForLayoutDirection(lua_State *L)
 {
     // wxCoord widthTotal
@@ -521,7 +521,7 @@ static int LUACALL wxLua_wxWindow_AdjustForLayoutDirection(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_AlwaysShowScrollbars[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_AlwaysShowScrollbars(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_AlwaysShowScrollbars[1] = {{ wxLua_wxWindow_AlwaysShowScrollbars, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxWindow_AlwaysShowScrollbars }};
-//     %wxchkver_3_1_1 void AlwaysShowScrollbars(bool hflag = true, bool vflag = true);
+//     %wxchkver_3_0_0 void AlwaysShowScrollbars(bool hflag = true, bool vflag = true);
 static int LUACALL wxLua_wxWindow_AlwaysShowScrollbars(lua_State *L)
 {
     // get number of arguments
@@ -541,7 +541,7 @@ static int LUACALL wxLua_wxWindow_AlwaysShowScrollbars(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_BeginRepositioningChildren[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_BeginRepositioningChildren(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_BeginRepositioningChildren[1] = {{ wxLua_wxWindow_BeginRepositioningChildren, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_BeginRepositioningChildren }};
-//     %wxchkver_3_1_1 bool BeginRepositioningChildren();
+//     %wxchkver_3_0_0 bool BeginRepositioningChildren();
 static int LUACALL wxLua_wxWindow_BeginRepositioningChildren(lua_State *L)
 {
     // get this
@@ -554,7 +554,7 @@ static int LUACALL wxLua_wxWindow_BeginRepositioningChildren(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_CacheBestSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
@@ -575,11 +575,11 @@ static int LUACALL wxLua_wxWindow_CacheBestSize(lua_State *L)
 
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_CanAcceptFocus[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_CanAcceptFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_CanAcceptFocus[1] = {{ wxLua_wxWindow_CanAcceptFocus, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_CanAcceptFocus }};
-//     %wxchkver_3_1_1 bool CanAcceptFocus() const;
+//     %wxchkver_3_0_0 bool CanAcceptFocus() const;
 static int LUACALL wxLua_wxWindow_CanAcceptFocus(lua_State *L)
 {
     // get this
@@ -595,7 +595,7 @@ static int LUACALL wxLua_wxWindow_CanAcceptFocus(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_CanAcceptFocusFromKeyboard[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_CanAcceptFocusFromKeyboard(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_CanAcceptFocusFromKeyboard[1] = {{ wxLua_wxWindow_CanAcceptFocusFromKeyboard, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_CanAcceptFocusFromKeyboard }};
-//     %wxchkver_3_1_1 bool CanAcceptFocusFromKeyboard() const;
+//     %wxchkver_3_0_0 bool CanAcceptFocusFromKeyboard() const;
 static int LUACALL wxLua_wxWindow_CanAcceptFocusFromKeyboard(lua_State *L)
 {
     // get this
@@ -611,7 +611,7 @@ static int LUACALL wxLua_wxWindow_CanAcceptFocusFromKeyboard(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_CanScroll[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_CanScroll(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_CanScroll[1] = {{ wxLua_wxWindow_CanScroll, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_CanScroll }};
-//     %wxchkver_3_1_1 bool CanScroll(int orient) const;
+//     %wxchkver_3_0_0 bool CanScroll(int orient) const;
 static int LUACALL wxLua_wxWindow_CanScroll(lua_State *L)
 {
     // int orient
@@ -629,7 +629,7 @@ static int LUACALL wxLua_wxWindow_CanScroll(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_CanSetTransparent[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_CanSetTransparent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_CanSetTransparent[1] = {{ wxLua_wxWindow_CanSetTransparent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_CanSetTransparent }};
-//     %wxchkver_3_1_1 bool CanSetTransparent();
+//     %wxchkver_3_0_0 bool CanSetTransparent();
 static int LUACALL wxLua_wxWindow_CanSetTransparent(lua_State *L)
 {
     // get this
@@ -642,7 +642,7 @@ static int LUACALL wxLua_wxWindow_CanSetTransparent(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_CaptureMouse[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_CaptureMouse(lua_State *L);
@@ -854,11 +854,11 @@ static int LUACALL wxLua_wxWindow_ClientToScreenXY(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_ClientToWindowSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxWindow_ClientToWindowSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_ClientToWindowSize[1] = {{ wxLua_wxWindow_ClientToWindowSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_ClientToWindowSize }};
-//     %wxchkver_3_1_1 wxSize ClientToWindowSize(const wxSize& size) const;
+//     %wxchkver_3_0_0 wxSize ClientToWindowSize(const wxSize& size) const;
 static int LUACALL wxLua_wxWindow_ClientToWindowSize(lua_State *L)
 {
     // const wxSize size
@@ -876,7 +876,7 @@ static int LUACALL wxLua_wxWindow_ClientToWindowSize(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Close[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_Close(lua_State *L);
@@ -1063,11 +1063,11 @@ static int LUACALL wxLua_wxWindow_Disable(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_DoUpdateWindowUI[] = { &wxluatype_wxWindow, &wxluatype_wxUpdateUIEvent, NULL };
 static int LUACALL wxLua_wxWindow_DoUpdateWindowUI(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_DoUpdateWindowUI[1] = {{ wxLua_wxWindow_DoUpdateWindowUI, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_DoUpdateWindowUI }};
-//     %wxchkver_3_1_1 void DoUpdateWindowUI(wxUpdateUIEvent& event);
+//     %wxchkver_3_0_0 void DoUpdateWindowUI(wxUpdateUIEvent& event);
 static int LUACALL wxLua_wxWindow_DoUpdateWindowUI(lua_State *L)
 {
     // wxUpdateUIEvent event
@@ -1080,7 +1080,7 @@ static int LUACALL wxLua_wxWindow_DoUpdateWindowUI(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if defined(__WXMSW__)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_DragAcceptFiles[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
@@ -1118,11 +1118,11 @@ static int LUACALL wxLua_wxWindow_Enable(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_EndRepositioningChildren[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_EndRepositioningChildren(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_EndRepositioningChildren[1] = {{ wxLua_wxWindow_EndRepositioningChildren, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_EndRepositioningChildren }};
-//     %wxchkver_3_1_1 void EndRepositioningChildren();
+//     %wxchkver_3_0_0 void EndRepositioningChildren();
 static int LUACALL wxLua_wxWindow_EndRepositioningChildren(lua_State *L)
 {
     // get this
@@ -1133,7 +1133,7 @@ static int LUACALL wxLua_wxWindow_EndRepositioningChildren(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static int LUACALL wxLua_wxWindow_FindFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindFocus[1] = {{ wxLua_wxWindow_FindFocus, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
@@ -1185,11 +1185,11 @@ static int LUACALL wxLua_wxWindow_FindWindow1(lua_State *L)
 }
 
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_FindWindowById1[] = { &wxluatype_TNUMBER, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_FindWindowById1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowById1[1] = {{ wxLua_wxWindow_FindWindowById1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowById1 }};
-//     !%wxchkver_3_1_1 static wxWindow* FindWindowById(long id, wxWindow* parent = NULL);
+//     !%wxchkver_3_0_0 static wxWindow* FindWindowById(long id, wxWindow* parent = NULL);
 static int LUACALL wxLua_wxWindow_FindWindowById1(lua_State *L)
 {
     // get number of arguments
@@ -1206,13 +1206,13 @@ static int LUACALL wxLua_wxWindow_FindWindowById1(lua_State *L)
     return 1;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_FindWindowById[] = { &wxluatype_TNUMBER, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_FindWindowById(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowById[1] = {{ wxLua_wxWindow_FindWindowById, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowById }};
-//     %wxchkver_3_1_1 static wxWindow* FindWindowById(long id, const wxWindow* parent = 0);
+//     %wxchkver_3_0_0 static wxWindow* FindWindowById(long id, const wxWindow* parent = 0);
 static int LUACALL wxLua_wxWindow_FindWindowById(lua_State *L)
 {
     // get number of arguments
@@ -1229,13 +1229,13 @@ static int LUACALL wxLua_wxWindow_FindWindowById(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_FindWindowByLabel1[] = { &wxluatype_TSTRING, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_FindWindowByLabel1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowByLabel1[1] = {{ wxLua_wxWindow_FindWindowByLabel1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByLabel1 }};
-//     !%wxchkver_3_1_1 static wxWindow* FindWindowByLabel(const wxString& label, wxWindow* parent = NULL);
+//     !%wxchkver_3_0_0 static wxWindow* FindWindowByLabel(const wxString& label, wxWindow* parent = NULL);
 static int LUACALL wxLua_wxWindow_FindWindowByLabel1(lua_State *L)
 {
     // get number of arguments
@@ -1252,13 +1252,13 @@ static int LUACALL wxLua_wxWindow_FindWindowByLabel1(lua_State *L)
     return 1;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_FindWindowByLabel[] = { &wxluatype_TSTRING, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_FindWindowByLabel(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowByLabel[1] = {{ wxLua_wxWindow_FindWindowByLabel, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByLabel }};
-//     %wxchkver_3_1_1 static wxWindow* FindWindowByLabel(const wxString& label, const wxWindow* parent = 0);
+//     %wxchkver_3_0_0 static wxWindow* FindWindowByLabel(const wxString& label, const wxWindow* parent = 0);
 static int LUACALL wxLua_wxWindow_FindWindowByLabel(lua_State *L)
 {
     // get number of arguments
@@ -1275,13 +1275,13 @@ static int LUACALL wxLua_wxWindow_FindWindowByLabel(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_FindWindowByName1[] = { &wxluatype_TSTRING, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_FindWindowByName1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowByName1[1] = {{ wxLua_wxWindow_FindWindowByName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByName1 }};
-//     !%wxchkver_3_1_1 static wxWindow* FindWindowByName(const wxString& name, wxWindow* parent = NULL);
+//     !%wxchkver_3_0_0 static wxWindow* FindWindowByName(const wxString& name, wxWindow* parent = NULL);
 static int LUACALL wxLua_wxWindow_FindWindowByName1(lua_State *L)
 {
     // get number of arguments
@@ -1298,13 +1298,13 @@ static int LUACALL wxLua_wxWindow_FindWindowByName1(lua_State *L)
     return 1;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_FindWindowByName[] = { &wxluatype_TSTRING, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_FindWindowByName(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowByName[1] = {{ wxLua_wxWindow_FindWindowByName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByName }};
-//     %wxchkver_3_1_1 static wxWindow* FindWindowByName(const wxString& name, const wxWindow* parent = 0);
+//     %wxchkver_3_0_0 static wxWindow* FindWindowByName(const wxString& name, const wxWindow* parent = 0);
 static int LUACALL wxLua_wxWindow_FindWindowByName(lua_State *L)
 {
     // get number of arguments
@@ -1321,7 +1321,7 @@ static int LUACALL wxLua_wxWindow_FindWindowByName(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Fit[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_Fit(lua_State *L);
@@ -1518,11 +1518,11 @@ static int LUACALL wxLua_wxWindow_GetAdjustedBestSize(lua_State *L)
 
 #endif // (!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetAutoLayout[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetAutoLayout(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetAutoLayout[1] = {{ wxLua_wxWindow_GetAutoLayout, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetAutoLayout }};
-//     %wxchkver_3_1_1 bool GetAutoLayout() const;
+//     %wxchkver_3_0_0 bool GetAutoLayout() const;
 static int LUACALL wxLua_wxWindow_GetAutoLayout(lua_State *L)
 {
     // get this
@@ -1535,7 +1535,7 @@ static int LUACALL wxLua_wxWindow_GetAutoLayout(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxColourPenBrush
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBackgroundColour[] = { &wxluatype_wxWindow, NULL };
@@ -1576,11 +1576,11 @@ static int LUACALL wxLua_wxWindow_GetBackgroundStyle(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBestFittingSize[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetBestFittingSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetBestFittingSize[1] = {{ wxLua_wxWindow_GetBestFittingSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetBestFittingSize }};
-//     !%wxchkver_3_1_1 wxSize GetBestFittingSize() const;
+//     !%wxchkver_3_0_0 wxSize GetBestFittingSize() const;
 static int LUACALL wxLua_wxWindow_GetBestFittingSize(lua_State *L)
 {
     // get this
@@ -1596,13 +1596,13 @@ static int LUACALL wxLua_wxWindow_GetBestFittingSize(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBestHeight[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_GetBestHeight(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetBestHeight[1] = {{ wxLua_wxWindow_GetBestHeight, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_GetBestHeight }};
-//     %wxchkver_3_1_1 int GetBestHeight(int width) const;
+//     %wxchkver_3_0_0 int GetBestHeight(int width) const;
 static int LUACALL wxLua_wxWindow_GetBestHeight(lua_State *L)
 {
     // int width
@@ -1617,7 +1617,7 @@ static int LUACALL wxLua_wxWindow_GetBestHeight(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBestSize[] = { &wxluatype_wxWindow, NULL };
@@ -1663,11 +1663,11 @@ static int LUACALL wxLua_wxWindow_GetBestVirtualSize(lua_State *L)
 
 #endif // (wxCHECK_VERSION(2,9,4)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBestWidth[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_GetBestWidth(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetBestWidth[1] = {{ wxLua_wxWindow_GetBestWidth, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_GetBestWidth }};
-//     %wxchkver_3_1_1 int GetBestWidth(int height) const;
+//     %wxchkver_3_0_0 int GetBestWidth(int height) const;
 static int LUACALL wxLua_wxWindow_GetBestWidth(lua_State *L)
 {
     // int height
@@ -1685,7 +1685,7 @@ static int LUACALL wxLua_wxWindow_GetBestWidth(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBorder1[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetBorder1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetBorder1[1] = {{ wxLua_wxWindow_GetBorder1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetBorder1 }};
-//     %wxchkver_3_1_1 wxBorder GetBorder() const;
+//     %wxchkver_3_0_0 wxBorder GetBorder() const;
 static int LUACALL wxLua_wxWindow_GetBorder1(lua_State *L)
 {
     // get this
@@ -1701,7 +1701,7 @@ static int LUACALL wxLua_wxWindow_GetBorder1(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetBorder[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_GetBorder(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetBorder[1] = {{ wxLua_wxWindow_GetBorder, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_GetBorder }};
-//     %wxchkver_3_1_1 wxBorder GetBorder(long flags) const;
+//     %wxchkver_3_0_0 wxBorder GetBorder(long flags) const;
 static int LUACALL wxLua_wxWindow_GetBorder(lua_State *L)
 {
     // long flags
@@ -1716,7 +1716,7 @@ static int LUACALL wxLua_wxWindow_GetBorder(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static int LUACALL wxLua_wxWindow_GetCapture(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetCapture[1] = {{ wxLua_wxWindow_GetCapture, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 0, g_wxluaargtypeArray_None }};
@@ -1803,11 +1803,11 @@ static int LUACALL wxLua_wxWindow_GetChildren(lua_State *L)
 
 #endif // wxLUA_USE_wxWindowList && !wxUSE_STL
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetClassDefaultAttributes[] = { &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxWindow_GetClassDefaultAttributes(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetClassDefaultAttributes[1] = {{ wxLua_wxWindow_GetClassDefaultAttributes, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 1, s_wxluatypeArray_wxLua_wxWindow_GetClassDefaultAttributes }};
-//     %wxchkver_3_1_1 static wxVisualAttributes GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
+//     %wxchkver_3_0_0 static wxVisualAttributes GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 static int LUACALL wxLua_wxWindow_GetClassDefaultAttributes(lua_State *L)
 {
     // get number of arguments
@@ -1825,13 +1825,13 @@ static int LUACALL wxLua_wxWindow_GetClassDefaultAttributes(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetClientAreaOrigin[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetClientAreaOrigin(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetClientAreaOrigin[1] = {{ wxLua_wxWindow_GetClientAreaOrigin, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetClientAreaOrigin }};
-//     %wxchkver_3_1_1 wxPoint GetClientAreaOrigin() const;
+//     %wxchkver_3_0_0 wxPoint GetClientAreaOrigin() const;
 static int LUACALL wxLua_wxWindow_GetClientAreaOrigin(lua_State *L)
 {
     // get this
@@ -1850,7 +1850,7 @@ static int LUACALL wxLua_wxWindow_GetClientAreaOrigin(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetClientRect[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetClientRect(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetClientRect[1] = {{ wxLua_wxWindow_GetClientRect, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetClientRect }};
-//     %wxchkver_3_1_1 wxRect GetClientRect() const;
+//     %wxchkver_3_0_0 wxRect GetClientRect() const;
 static int LUACALL wxLua_wxWindow_GetClientRect(lua_State *L)
 {
     // get this
@@ -1866,7 +1866,7 @@ static int LUACALL wxLua_wxWindow_GetClientRect(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetClientSize[] = { &wxluatype_wxWindow, NULL };
@@ -1908,11 +1908,11 @@ static int LUACALL wxLua_wxWindow_GetClientSizeWH(lua_State *L)
 
 
 
-#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetConstraints[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetConstraints(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetConstraints[1] = {{ wxLua_wxWindow_GetConstraints, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetConstraints }};
-//     %wxchkver_3_1_1 wxLayoutConstraints* GetConstraints() const;
+//     %wxchkver_3_0_0 wxLayoutConstraints* GetConstraints() const;
 static int LUACALL wxLua_wxWindow_GetConstraints(lua_State *L)
 {
     // get this
@@ -1925,7 +1925,7 @@ static int LUACALL wxLua_wxWindow_GetConstraints(lua_State *L)
     return 1;
 }
 
-#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxSizer)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetContainingSizer[] = { &wxluatype_wxWindow, NULL };
@@ -2045,11 +2045,11 @@ static int LUACALL wxLua_wxWindow_GetDropTarget(lua_State *L)
 
 #endif // wxLUA_USE_wxDragDrop && wxUSE_DRAG_AND_DROP
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetEffectiveMinSize[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetEffectiveMinSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetEffectiveMinSize[1] = {{ wxLua_wxWindow_GetEffectiveMinSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetEffectiveMinSize }};
-//     %wxchkver_3_1_1 wxSize GetEffectiveMinSize() const;
+//     %wxchkver_3_0_0 wxSize GetEffectiveMinSize() const;
 static int LUACALL wxLua_wxWindow_GetEffectiveMinSize(lua_State *L)
 {
     // get this
@@ -2065,7 +2065,7 @@ static int LUACALL wxLua_wxWindow_GetEffectiveMinSize(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetEventHandler[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetEventHandler(lua_State *L);
@@ -2195,11 +2195,11 @@ static int LUACALL wxLua_wxWindow_GetHelpText(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetHelpTextAtPoint[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxWindow_GetHelpTextAtPoint(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetHelpTextAtPoint[1] = {{ wxLua_wxWindow_GetHelpTextAtPoint, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxWindow_GetHelpTextAtPoint }};
-//     %wxchkver_3_1_1 wxString GetHelpTextAtPoint(const wxPoint& point, wxHelpEvent::Origin origin) const;
+//     %wxchkver_3_0_0 wxString GetHelpTextAtPoint(const wxPoint& point, wxHelpEvent::Origin origin) const;
 static int LUACALL wxLua_wxWindow_GetHelpTextAtPoint(lua_State *L)
 {
     // wxHelpEvent::Origin origin
@@ -2216,7 +2216,7 @@ static int LUACALL wxLua_wxWindow_GetHelpTextAtPoint(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetId[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetId(lua_State *L);
@@ -2251,11 +2251,11 @@ static int LUACALL wxLua_wxWindow_GetLabel(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetLayoutDirection[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetLayoutDirection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetLayoutDirection[1] = {{ wxLua_wxWindow_GetLayoutDirection, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetLayoutDirection }};
-//     %wxchkver_3_1_1 wxLayoutDirection GetLayoutDirection() const;
+//     %wxchkver_3_0_0 wxLayoutDirection GetLayoutDirection() const;
 static int LUACALL wxLua_wxWindow_GetLayoutDirection(lua_State *L)
 {
     // get this
@@ -2268,13 +2268,13 @@ static int LUACALL wxLua_wxWindow_GetLayoutDirection(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMaxClientSize[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetMaxClientSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetMaxClientSize[1] = {{ wxLua_wxWindow_GetMaxClientSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetMaxClientSize }};
-//     %wxchkver_3_1_1 wxSize GetMaxClientSize() const;
+//     %wxchkver_3_0_0 wxSize GetMaxClientSize() const;
 static int LUACALL wxLua_wxWindow_GetMaxClientSize(lua_State *L)
 {
     // get this
@@ -2290,13 +2290,13 @@ static int LUACALL wxLua_wxWindow_GetMaxClientSize(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMaxHeight[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetMaxHeight(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetMaxHeight[1] = {{ wxLua_wxWindow_GetMaxHeight, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetMaxHeight }};
-//     %wxchkver_3_1_1 int GetMaxHeight() const;
+//     %wxchkver_3_0_0 int GetMaxHeight() const;
 static int LUACALL wxLua_wxWindow_GetMaxHeight(lua_State *L)
 {
     // get this
@@ -2309,7 +2309,7 @@ static int LUACALL wxLua_wxWindow_GetMaxHeight(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMaxSize[] = { &wxluatype_wxWindow, NULL };
@@ -2333,11 +2333,11 @@ static int LUACALL wxLua_wxWindow_GetMaxSize(lua_State *L)
 
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMaxWidth[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetMaxWidth(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetMaxWidth[1] = {{ wxLua_wxWindow_GetMaxWidth, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetMaxWidth }};
-//     %wxchkver_3_1_1 int GetMaxWidth() const;
+//     %wxchkver_3_0_0 int GetMaxWidth() const;
 static int LUACALL wxLua_wxWindow_GetMaxWidth(lua_State *L)
 {
     // get this
@@ -2350,13 +2350,13 @@ static int LUACALL wxLua_wxWindow_GetMaxWidth(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMinClientSize[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetMinClientSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetMinClientSize[1] = {{ wxLua_wxWindow_GetMinClientSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetMinClientSize }};
-//     %wxchkver_3_1_1 wxSize GetMinClientSize() const;
+//     %wxchkver_3_0_0 wxSize GetMinClientSize() const;
 static int LUACALL wxLua_wxWindow_GetMinClientSize(lua_State *L)
 {
     // get this
@@ -2372,13 +2372,13 @@ static int LUACALL wxLua_wxWindow_GetMinClientSize(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMinHeight[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetMinHeight(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetMinHeight[1] = {{ wxLua_wxWindow_GetMinHeight, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetMinHeight }};
-//     %wxchkver_3_1_1 int GetMinHeight() const;
+//     %wxchkver_3_0_0 int GetMinHeight() const;
 static int LUACALL wxLua_wxWindow_GetMinHeight(lua_State *L)
 {
     // get this
@@ -2391,7 +2391,7 @@ static int LUACALL wxLua_wxWindow_GetMinHeight(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMinSize[] = { &wxluatype_wxWindow, NULL };
@@ -2415,11 +2415,11 @@ static int LUACALL wxLua_wxWindow_GetMinSize(lua_State *L)
 
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetMinWidth[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetMinWidth(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetMinWidth[1] = {{ wxLua_wxWindow_GetMinWidth, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetMinWidth }};
-//     %wxchkver_3_1_1 int GetMinWidth() const;
+//     %wxchkver_3_0_0 int GetMinWidth() const;
 static int LUACALL wxLua_wxWindow_GetMinWidth(lua_State *L)
 {
     // get this
@@ -2432,7 +2432,7 @@ static int LUACALL wxLua_wxWindow_GetMinWidth(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetName[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetName(lua_State *L);
@@ -2451,11 +2451,11 @@ static int LUACALL wxLua_wxWindow_GetName(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetNextSibling[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetNextSibling(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetNextSibling[1] = {{ wxLua_wxWindow_GetNextSibling, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetNextSibling }};
-//     %wxchkver_3_1_1 wxWindow* GetNextSibling() const;
+//     %wxchkver_3_0_0 wxWindow* GetNextSibling() const;
 static int LUACALL wxLua_wxWindow_GetNextSibling(lua_State *L)
 {
     // get this
@@ -2468,7 +2468,7 @@ static int LUACALL wxLua_wxWindow_GetNextSibling(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetParent[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetParent(lua_State *L);
@@ -2487,11 +2487,11 @@ static int LUACALL wxLua_wxWindow_GetParent(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetPopupMenuSelectionFromUser1[] = { &wxluatype_wxWindow, &wxluatype_wxMenu, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_GetPopupMenuSelectionFromUser1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser1[1] = {{ wxLua_wxWindow_GetPopupMenuSelectionFromUser1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxWindow_GetPopupMenuSelectionFromUser1 }};
-//     %wxchkver_3_1_1 int GetPopupMenuSelectionFromUser(wxMenu& menu, int x, int y);
+//     %wxchkver_3_0_0 int GetPopupMenuSelectionFromUser(wxMenu& menu, int x, int y);
 static int LUACALL wxLua_wxWindow_GetPopupMenuSelectionFromUser1(lua_State *L)
 {
     // int y
@@ -2510,13 +2510,13 @@ static int LUACALL wxLua_wxWindow_GetPopupMenuSelectionFromUser1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetPopupMenuSelectionFromUser[] = { &wxluatype_wxWindow, &wxluatype_wxMenu, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxWindow_GetPopupMenuSelectionFromUser(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser[1] = {{ wxLua_wxWindow_GetPopupMenuSelectionFromUser, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_GetPopupMenuSelectionFromUser }};
-//     %wxchkver_3_1_1 int GetPopupMenuSelectionFromUser(wxMenu& menu, const wxPoint& pos = wxDefaultPosition);
+//     %wxchkver_3_0_0 int GetPopupMenuSelectionFromUser(wxMenu& menu, const wxPoint& pos = wxDefaultPosition);
 static int LUACALL wxLua_wxWindow_GetPopupMenuSelectionFromUser(lua_State *L)
 {
     // get number of arguments
@@ -2535,7 +2535,7 @@ static int LUACALL wxLua_wxWindow_GetPopupMenuSelectionFromUser(lua_State *L)
     return 1;
 }
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetPosition[] = { &wxluatype_wxWindow, NULL };
@@ -2581,11 +2581,11 @@ static int LUACALL wxLua_wxWindow_GetPositionXY(lua_State *L)
 
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetPrevSibling[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetPrevSibling(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetPrevSibling[1] = {{ wxLua_wxWindow_GetPrevSibling, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetPrevSibling }};
-//     %wxchkver_3_1_1 wxWindow* GetPrevSibling() const;
+//     %wxchkver_3_0_0 wxWindow* GetPrevSibling() const;
 static int LUACALL wxLua_wxWindow_GetPrevSibling(lua_State *L)
 {
     // get this
@@ -2598,7 +2598,7 @@ static int LUACALL wxLua_wxWindow_GetPrevSibling(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetRect[] = { &wxluatype_wxWindow, NULL };
@@ -2836,11 +2836,11 @@ static int LUACALL wxLua_wxWindow_GetTextExtent(lua_State *L)
 
 #endif // wxLUA_USE_wxFont
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetThemeEnabled[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetThemeEnabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetThemeEnabled[1] = {{ wxLua_wxWindow_GetThemeEnabled, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetThemeEnabled }};
-//     %wxchkver_3_1_1 bool GetThemeEnabled() const;
+//     %wxchkver_3_0_0 bool GetThemeEnabled() const;
 static int LUACALL wxLua_wxWindow_GetThemeEnabled(lua_State *L)
 {
     // get this
@@ -2853,7 +2853,7 @@ static int LUACALL wxLua_wxWindow_GetThemeEnabled(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if !wxCHECK_VERSION(2,8,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetTitle[] = { &wxluatype_wxWindow, NULL };
@@ -2893,11 +2893,11 @@ static int LUACALL wxLua_wxWindow_GetToolTip(lua_State *L)
 
 #endif // wxLUA_USE_wxTooltip && wxUSE_TOOLTIPS
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetToolTipText[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetToolTipText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetToolTipText[1] = {{ wxLua_wxWindow_GetToolTipText, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetToolTipText }};
-//     %wxchkver_3_1_1 wxString GetToolTipText() const;
+//     %wxchkver_3_0_0 wxString GetToolTipText() const;
 static int LUACALL wxLua_wxWindow_GetToolTipText(lua_State *L)
 {
     // get this
@@ -2910,13 +2910,13 @@ static int LUACALL wxLua_wxWindow_GetToolTipText(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetUpdateClientRect[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetUpdateClientRect(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetUpdateClientRect[1] = {{ wxLua_wxWindow_GetUpdateClientRect, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetUpdateClientRect }};
-//     %wxchkver_3_1_1 wxRect GetUpdateClientRect() const;
+//     %wxchkver_3_0_0 wxRect GetUpdateClientRect() const;
 static int LUACALL wxLua_wxWindow_GetUpdateClientRect(lua_State *L)
 {
     // get this
@@ -2932,7 +2932,7 @@ static int LUACALL wxLua_wxWindow_GetUpdateClientRect(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxRegion
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetUpdateRegion[] = { &wxluatype_wxWindow, NULL };
@@ -3019,11 +3019,11 @@ static int LUACALL wxLua_wxWindow_GetVirtualSizeWH(lua_State *L)
 
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetWindowBorderSize[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetWindowBorderSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetWindowBorderSize[1] = {{ wxLua_wxWindow_GetWindowBorderSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetWindowBorderSize }};
-//     %wxchkver_3_1_1 wxSize GetWindowBorderSize() const;
+//     %wxchkver_3_0_0 wxSize GetWindowBorderSize() const;
 static int LUACALL wxLua_wxWindow_GetWindowBorderSize(lua_State *L)
 {
     // get this
@@ -3039,13 +3039,13 @@ static int LUACALL wxLua_wxWindow_GetWindowBorderSize(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetWindowStyle[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetWindowStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetWindowStyle[1] = {{ wxLua_wxWindow_GetWindowStyle, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetWindowStyle }};
-//     %wxchkver_3_1_1 long GetWindowStyle() const;
+//     %wxchkver_3_0_0 long GetWindowStyle() const;
 static int LUACALL wxLua_wxWindow_GetWindowStyle(lua_State *L)
 {
     // get this
@@ -3058,7 +3058,7 @@ static int LUACALL wxLua_wxWindow_GetWindowStyle(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_GetWindowStyleFlag[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_GetWindowStyleFlag(lua_State *L);
@@ -3093,11 +3093,11 @@ static int LUACALL wxLua_wxWindow_GetWindowVariant(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HandleAsNavigationKey[] = { &wxluatype_wxWindow, &wxluatype_wxKeyEvent, NULL };
 static int LUACALL wxLua_wxWindow_HandleAsNavigationKey(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HandleAsNavigationKey[1] = {{ wxLua_wxWindow_HandleAsNavigationKey, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_HandleAsNavigationKey }};
-//     %wxchkver_3_1_1 bool HandleAsNavigationKey(const wxKeyEvent& event);
+//     %wxchkver_3_0_0 bool HandleAsNavigationKey(const wxKeyEvent& event);
 static int LUACALL wxLua_wxWindow_HandleAsNavigationKey(lua_State *L)
 {
     // const wxKeyEvent event
@@ -3115,7 +3115,7 @@ static int LUACALL wxLua_wxWindow_HandleAsNavigationKey(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HandleWindowEvent[] = { &wxluatype_wxWindow, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxWindow_HandleWindowEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HandleWindowEvent[1] = {{ wxLua_wxWindow_HandleWindowEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_HandleWindowEvent }};
-//     %wxchkver_3_1_1 bool HandleWindowEvent(wxEvent& event) const;
+//     %wxchkver_3_0_0 bool HandleWindowEvent(wxEvent& event) const;
 static int LUACALL wxLua_wxWindow_HandleWindowEvent(lua_State *L)
 {
     // wxEvent event
@@ -3130,7 +3130,7 @@ static int LUACALL wxLua_wxWindow_HandleWindowEvent(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(2,4,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HasCapture[] = { &wxluatype_wxWindow, NULL };
@@ -3151,11 +3151,11 @@ static int LUACALL wxLua_wxWindow_HasCapture(lua_State *L)
 
 #endif // wxCHECK_VERSION(2,4,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HasExtraStyle[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_HasExtraStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HasExtraStyle[1] = {{ wxLua_wxWindow_HasExtraStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_HasExtraStyle }};
-//     %wxchkver_3_1_1 bool HasExtraStyle(int exFlag) const;
+//     %wxchkver_3_0_0 bool HasExtraStyle(int exFlag) const;
 static int LUACALL wxLua_wxWindow_HasExtraStyle(lua_State *L)
 {
     // int exFlag
@@ -3173,7 +3173,7 @@ static int LUACALL wxLua_wxWindow_HasExtraStyle(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HasFlag[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_HasFlag(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HasFlag[1] = {{ wxLua_wxWindow_HasFlag, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_HasFlag }};
-//     %wxchkver_3_1_1 bool HasFlag(int flag) const;
+//     %wxchkver_3_0_0 bool HasFlag(int flag) const;
 static int LUACALL wxLua_wxWindow_HasFlag(lua_State *L)
 {
     // int flag
@@ -3191,7 +3191,7 @@ static int LUACALL wxLua_wxWindow_HasFlag(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HasFocus[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_HasFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HasFocus[1] = {{ wxLua_wxWindow_HasFocus, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_HasFocus }};
-//     %wxchkver_3_1_1 bool HasFocus() const;
+//     %wxchkver_3_0_0 bool HasFocus() const;
 static int LUACALL wxLua_wxWindow_HasFocus(lua_State *L)
 {
     // get this
@@ -3207,7 +3207,7 @@ static int LUACALL wxLua_wxWindow_HasFocus(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HasMultiplePages[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_HasMultiplePages(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HasMultiplePages[1] = {{ wxLua_wxWindow_HasMultiplePages, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_HasMultiplePages }};
-//     %wxchkver_3_1_1 bool HasMultiplePages() const;
+//     %wxchkver_3_0_0 bool HasMultiplePages() const;
 static int LUACALL wxLua_wxWindow_HasMultiplePages(lua_State *L)
 {
     // get this
@@ -3220,7 +3220,7 @@ static int LUACALL wxLua_wxWindow_HasMultiplePages(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HasScrollbar[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_HasScrollbar(lua_State *L);
@@ -3273,11 +3273,11 @@ static int LUACALL wxLua_wxWindow_Hide(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HideWithEffect[] = { &wxluatype_wxWindow, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxWindow_HideWithEffect(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HideWithEffect[1] = {{ wxLua_wxWindow_HideWithEffect, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_HideWithEffect }};
-//     %wxchkver_3_1_1 bool HideWithEffect(wxShowEffect effect, unsigned int timeout = 0);
+//     %wxchkver_3_0_0 bool HideWithEffect(wxShowEffect effect, unsigned int timeout = 0);
 static int LUACALL wxLua_wxWindow_HideWithEffect(lua_State *L)
 {
     // get number of arguments
@@ -3296,13 +3296,13 @@ static int LUACALL wxLua_wxWindow_HideWithEffect(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HitTest1[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxWindow_HitTest1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HitTest1[1] = {{ wxLua_wxWindow_HitTest1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_HitTest1 }};
-//     %wxchkver_3_1_1 wxHitTest HitTest(const wxPoint& pt) const;
+//     %wxchkver_3_0_0 wxHitTest HitTest(const wxPoint& pt) const;
 static int LUACALL wxLua_wxWindow_HitTest1(lua_State *L)
 {
     // const wxPoint pt
@@ -3317,13 +3317,13 @@ static int LUACALL wxLua_wxWindow_HitTest1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_HitTest[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_HitTest(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HitTest[1] = {{ wxLua_wxWindow_HitTest, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxWindow_HitTest }};
-//     %wxchkver_3_1_1 wxHitTest HitTest(wxCoord x, wxCoord y) const;
+//     %wxchkver_3_0_0 wxHitTest HitTest(wxCoord x, wxCoord y) const;
 static int LUACALL wxLua_wxWindow_HitTest(lua_State *L)
 {
     // wxCoord y
@@ -3343,7 +3343,7 @@ static int LUACALL wxLua_wxWindow_HitTest(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_InformFirstDirection[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_InformFirstDirection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_InformFirstDirection[1] = {{ wxLua_wxWindow_InformFirstDirection, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxWindow_InformFirstDirection }};
-//     %wxchkver_3_1_1 bool InformFirstDirection(int direction, int size, int availableOtherDir);
+//     %wxchkver_3_0_0 bool InformFirstDirection(int direction, int size, int availableOtherDir);
 static int LUACALL wxLua_wxWindow_InformFirstDirection(lua_State *L)
 {
     // int availableOtherDir
@@ -3362,7 +3362,7 @@ static int LUACALL wxLua_wxWindow_InformFirstDirection(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_InheritAttributes[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_InheritAttributes(lua_State *L);
@@ -3379,11 +3379,11 @@ static int LUACALL wxLua_wxWindow_InheritAttributes(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_InheritsBackgroundColour[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_InheritsBackgroundColour(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_InheritsBackgroundColour[1] = {{ wxLua_wxWindow_InheritsBackgroundColour, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_InheritsBackgroundColour }};
-//     %wxchkver_3_1_1 bool InheritsBackgroundColour() const;
+//     %wxchkver_3_0_0 bool InheritsBackgroundColour() const;
 static int LUACALL wxLua_wxWindow_InheritsBackgroundColour(lua_State *L)
 {
     // get this
@@ -3396,7 +3396,7 @@ static int LUACALL wxLua_wxWindow_InheritsBackgroundColour(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_InitDialog[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_InitDialog(lua_State *L);
@@ -3427,11 +3427,11 @@ static int LUACALL wxLua_wxWindow_InvalidateBestSize(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsBeingDeleted[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsBeingDeleted(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsBeingDeleted[1] = {{ wxLua_wxWindow_IsBeingDeleted, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_IsBeingDeleted }};
-//     %wxchkver_3_1_1 bool IsBeingDeleted() const;
+//     %wxchkver_3_0_0 bool IsBeingDeleted() const;
 static int LUACALL wxLua_wxWindow_IsBeingDeleted(lua_State *L)
 {
     // get this
@@ -3447,7 +3447,7 @@ static int LUACALL wxLua_wxWindow_IsBeingDeleted(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsDescendant[] = { &wxluatype_wxWindow, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsDescendant(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsDescendant[1] = {{ wxLua_wxWindow_IsDescendant, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsDescendant }};
-//     %wxchkver_3_1_1 bool IsDescendant(wxWindow* win) const; // %override wxWindow* instead of wxWindowBase* as the latter is not in public interface
+//     %wxchkver_3_0_0 bool IsDescendant(wxWindow* win) const; // %override wxWindow* instead of wxWindowBase* as the latter is not in public interface
 static int LUACALL wxLua_wxWindow_IsDescendant(lua_State *L)
 {
     // wxWindow win
@@ -3465,7 +3465,7 @@ static int LUACALL wxLua_wxWindow_IsDescendant(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsDoubleBuffered[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsDoubleBuffered(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsDoubleBuffered[1] = {{ wxLua_wxWindow_IsDoubleBuffered, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_IsDoubleBuffered }};
-//     %wxchkver_3_1_1 bool IsDoubleBuffered() const;
+//     %wxchkver_3_0_0 bool IsDoubleBuffered() const;
 static int LUACALL wxLua_wxWindow_IsDoubleBuffered(lua_State *L)
 {
     // get this
@@ -3478,7 +3478,7 @@ static int LUACALL wxLua_wxWindow_IsDoubleBuffered(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsEnabled[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsEnabled(lua_State *L);
@@ -3497,11 +3497,11 @@ static int LUACALL wxLua_wxWindow_IsEnabled(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsExposed5[] = { &wxluatype_wxWindow, &wxluatype_wxRect, NULL };
 static int LUACALL wxLua_wxWindow_IsExposed5(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsExposed5[1] = {{ wxLua_wxWindow_IsExposed5, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed5 }};
-//     !%wxchkver_3_1_1 bool IsExposed(const wxRect &rect) const;
+//     !%wxchkver_3_0_0 bool IsExposed(const wxRect &rect) const;
 static int LUACALL wxLua_wxWindow_IsExposed5(lua_State *L)
 {
     // const wxRect rect
@@ -3519,7 +3519,7 @@ static int LUACALL wxLua_wxWindow_IsExposed5(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsExposed4[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxWindow_IsExposed4(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsExposed4[1] = {{ wxLua_wxWindow_IsExposed4, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed4 }};
-//     !%wxchkver_3_1_1 bool IsExposed(const wxPoint &pt) const;
+//     !%wxchkver_3_0_0 bool IsExposed(const wxPoint &pt) const;
 static int LUACALL wxLua_wxWindow_IsExposed4(lua_State *L)
 {
     // const wxPoint pt
@@ -3534,13 +3534,13 @@ static int LUACALL wxLua_wxWindow_IsExposed4(lua_State *L)
     return 1;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsExposed3[] = { &wxluatype_wxWindow, &wxluatype_wxRect, NULL };
 static int LUACALL wxLua_wxWindow_IsExposed3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsExposed3[1] = {{ wxLua_wxWindow_IsExposed3, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed3 }};
-//     %wxchkver_3_1_1 bool IsExposed(wxRect& rect) const;
+//     %wxchkver_3_0_0 bool IsExposed(wxRect& rect) const;
 static int LUACALL wxLua_wxWindow_IsExposed3(lua_State *L)
 {
     // wxRect rect
@@ -3558,7 +3558,7 @@ static int LUACALL wxLua_wxWindow_IsExposed3(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsExposed1[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxWindow_IsExposed1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsExposed1[1] = {{ wxLua_wxWindow_IsExposed1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed1 }};
-//     %wxchkver_3_1_1 bool IsExposed(wxPoint& pt) const;
+//     %wxchkver_3_0_0 bool IsExposed(wxPoint& pt) const;
 static int LUACALL wxLua_wxWindow_IsExposed1(lua_State *L)
 {
     // wxPoint pt
@@ -3573,7 +3573,7 @@ static int LUACALL wxLua_wxWindow_IsExposed1(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsExposed[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_IsExposed(lua_State *L);
@@ -3620,11 +3620,11 @@ static int LUACALL wxLua_wxWindow_IsExposed2(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsFocusable[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsFocusable(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsFocusable[1] = {{ wxLua_wxWindow_IsFocusable, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_IsFocusable }};
-//     %wxchkver_3_1_1 bool IsFocusable() const;
+//     %wxchkver_3_0_0 bool IsFocusable() const;
 static int LUACALL wxLua_wxWindow_IsFocusable(lua_State *L)
 {
     // get this
@@ -3640,7 +3640,7 @@ static int LUACALL wxLua_wxWindow_IsFocusable(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsFrozen[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsFrozen(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsFrozen[1] = {{ wxLua_wxWindow_IsFrozen, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_IsFrozen }};
-//     %wxchkver_3_1_1 bool IsFrozen() const;
+//     %wxchkver_3_0_0 bool IsFrozen() const;
 static int LUACALL wxLua_wxWindow_IsFrozen(lua_State *L)
 {
     // get this
@@ -3653,7 +3653,7 @@ static int LUACALL wxLua_wxWindow_IsFrozen(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsRetained[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsRetained(lua_State *L);
@@ -3672,11 +3672,11 @@ static int LUACALL wxLua_wxWindow_IsRetained(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsScrollbarAlwaysShown[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_IsScrollbarAlwaysShown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsScrollbarAlwaysShown[1] = {{ wxLua_wxWindow_IsScrollbarAlwaysShown, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsScrollbarAlwaysShown }};
-//     %wxchkver_3_1_1 bool IsScrollbarAlwaysShown(int orient) const;
+//     %wxchkver_3_0_0 bool IsScrollbarAlwaysShown(int orient) const;
 static int LUACALL wxLua_wxWindow_IsScrollbarAlwaysShown(lua_State *L)
 {
     // int orient
@@ -3691,7 +3691,7 @@ static int LUACALL wxLua_wxWindow_IsScrollbarAlwaysShown(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsShown[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsShown(lua_State *L);
@@ -3710,11 +3710,11 @@ static int LUACALL wxLua_wxWindow_IsShown(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsShownOnScreen[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsShownOnScreen(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsShownOnScreen[1] = {{ wxLua_wxWindow_IsShownOnScreen, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_IsShownOnScreen }};
-//     %wxchkver_3_1_1 bool IsShownOnScreen() const;
+//     %wxchkver_3_0_0 bool IsShownOnScreen() const;
 static int LUACALL wxLua_wxWindow_IsShownOnScreen(lua_State *L)
 {
     // get this
@@ -3730,7 +3730,7 @@ static int LUACALL wxLua_wxWindow_IsShownOnScreen(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsThisEnabled[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsThisEnabled(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsThisEnabled[1] = {{ wxLua_wxWindow_IsThisEnabled, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_IsThisEnabled }};
-//     %wxchkver_3_1_1 bool IsThisEnabled() const;
+//     %wxchkver_3_0_0 bool IsThisEnabled() const;
 static int LUACALL wxLua_wxWindow_IsThisEnabled(lua_State *L)
 {
     // get this
@@ -3743,7 +3743,7 @@ static int LUACALL wxLua_wxWindow_IsThisEnabled(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsTopLevel[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_IsTopLevel(lua_State *L);
@@ -3762,11 +3762,11 @@ static int LUACALL wxLua_wxWindow_IsTopLevel(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_IsTransparentBackgroundSupported[] = { &wxluatype_wxWindow, &wxluatype_TLIGHTUSERDATA, NULL };
 static int LUACALL wxLua_wxWindow_IsTransparentBackgroundSupported(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsTransparentBackgroundSupported[1] = {{ wxLua_wxWindow_IsTransparentBackgroundSupported, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxWindow_IsTransparentBackgroundSupported }};
-//     %wxchkver_3_1_1 bool IsTransparentBackgroundSupported(wxString *reason = NULL) const;
+//     %wxchkver_3_0_0 bool IsTransparentBackgroundSupported(wxString *reason = NULL) const;
 static int LUACALL wxLua_wxWindow_IsTransparentBackgroundSupported(lua_State *L)
 {
     // get number of arguments
@@ -3783,7 +3783,7 @@ static int LUACALL wxLua_wxWindow_IsTransparentBackgroundSupported(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Layout[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_Layout(lua_State *L);
@@ -3800,11 +3800,11 @@ static int LUACALL wxLua_wxWindow_Layout(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_LineDown[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_LineDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_LineDown[1] = {{ wxLua_wxWindow_LineDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_LineDown }};
-//     %wxchkver_3_1_1 bool LineDown();
+//     %wxchkver_3_0_0 bool LineDown();
 static int LUACALL wxLua_wxWindow_LineDown(lua_State *L)
 {
     // get this
@@ -3820,7 +3820,7 @@ static int LUACALL wxLua_wxWindow_LineDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_LineUp[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_LineUp(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_LineUp[1] = {{ wxLua_wxWindow_LineUp, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_LineUp }};
-//     %wxchkver_3_1_1 bool LineUp();
+//     %wxchkver_3_0_0 bool LineUp();
 static int LUACALL wxLua_wxWindow_LineUp(lua_State *L)
 {
     // get this
@@ -3833,7 +3833,7 @@ static int LUACALL wxLua_wxWindow_LineUp(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Lower[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_Lower(lua_State *L);
@@ -3850,11 +3850,11 @@ static int LUACALL wxLua_wxWindow_Lower(lua_State *L)
 }
 
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_MakeModal[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_MakeModal(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_MakeModal[1] = {{ wxLua_wxWindow_MakeModal, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_MakeModal }};
-//     !%wxchkver_3_1_1 virtual void MakeModal(bool flag);
+//     !%wxchkver_3_0_0 virtual void MakeModal(bool flag);
 static int LUACALL wxLua_wxWindow_MakeModal(lua_State *L)
 {
     // bool flag
@@ -3870,7 +3870,7 @@ static int LUACALL wxLua_wxWindow_MakeModal(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Move3[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_Move3(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_Move3[1] = {{ wxLua_wxWindow_Move3, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxWindow_Move3 }};
-//     !%wxchkver_3_1_1 void Move(int x, int y);
+//     !%wxchkver_3_0_0 void Move(int x, int y);
 static int LUACALL wxLua_wxWindow_Move3(lua_State *L)
 {
     // int y
@@ -3885,13 +3885,13 @@ static int LUACALL wxLua_wxWindow_Move3(lua_State *L)
     return 0;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Move2[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxWindow_Move2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_Move2[1] = {{ wxLua_wxWindow_Move2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_Move2 }};
-//     !%wxchkver_3_1_1 void Move(const wxPoint& pt);
+//     !%wxchkver_3_0_0 void Move(const wxPoint& pt);
 static int LUACALL wxLua_wxWindow_Move2(lua_State *L)
 {
     // const wxPoint pt
@@ -3904,13 +3904,13 @@ static int LUACALL wxLua_wxWindow_Move2(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Move1[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_Move1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_Move1[1] = {{ wxLua_wxWindow_Move1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_Move1 }};
-//     %wxchkver_3_1_1 void Move(const wxPoint& pt, int flags = wxSIZE_USE_EXISTING);
+//     %wxchkver_3_0_0 void Move(const wxPoint& pt, int flags = wxSIZE_USE_EXISTING);
 static int LUACALL wxLua_wxWindow_Move1(lua_State *L)
 {
     // get number of arguments
@@ -3927,13 +3927,13 @@ static int LUACALL wxLua_wxWindow_Move1(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Move[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_Move(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_Move[1] = {{ wxLua_wxWindow_Move, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxWindow_Move }};
-//     %wxchkver_3_1_1 void Move(int x, int y, int flags = wxSIZE_USE_EXISTING);
+//     %wxchkver_3_0_0 void Move(int x, int y, int flags = wxSIZE_USE_EXISTING);
 static int LUACALL wxLua_wxWindow_Move(lua_State *L)
 {
     // get number of arguments
@@ -3952,7 +3952,7 @@ static int LUACALL wxLua_wxWindow_Move(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_MoveAfterInTabOrder[] = { &wxluatype_wxWindow, &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_MoveAfterInTabOrder(lua_State *L);
@@ -4007,11 +4007,11 @@ static int LUACALL wxLua_wxWindow_Navigate(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_NavigateIn[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_NavigateIn(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_NavigateIn[1] = {{ wxLua_wxWindow_NavigateIn, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxWindow_NavigateIn }};
-//     %wxchkver_3_1_1 bool NavigateIn(int flags = wxNavigationKeyEvent::IsForward);
+//     %wxchkver_3_0_0 bool NavigateIn(int flags = wxNavigationKeyEvent::IsForward);
 static int LUACALL wxLua_wxWindow_NavigateIn(lua_State *L)
 {
     // get number of arguments
@@ -4031,7 +4031,7 @@ static int LUACALL wxLua_wxWindow_NavigateIn(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_NewControlId[] = { &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_NewControlId(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_NewControlId[1] = {{ wxLua_wxWindow_NewControlId, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 0, 1, s_wxluatypeArray_wxLua_wxWindow_NewControlId }};
-//     %wxchkver_3_1_1 static wxWindowID NewControlId(int count = 1);
+//     %wxchkver_3_0_0 static wxWindowID NewControlId(int count = 1);
 static int LUACALL wxLua_wxWindow_NewControlId(lua_State *L)
 {
     // get number of arguments
@@ -4049,7 +4049,7 @@ static int LUACALL wxLua_wxWindow_NewControlId(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_OnInternalIdle[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_OnInternalIdle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_OnInternalIdle[1] = {{ wxLua_wxWindow_OnInternalIdle, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_OnInternalIdle }};
-//     %wxchkver_3_1_1 void OnInternalIdle();
+//     %wxchkver_3_0_0 void OnInternalIdle();
 static int LUACALL wxLua_wxWindow_OnInternalIdle(lua_State *L)
 {
     // get this
@@ -4063,7 +4063,7 @@ static int LUACALL wxLua_wxWindow_OnInternalIdle(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_PageDown[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_PageDown(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_PageDown[1] = {{ wxLua_wxWindow_PageDown, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_PageDown }};
-//     %wxchkver_3_1_1 bool PageDown();
+//     %wxchkver_3_0_0 bool PageDown();
 static int LUACALL wxLua_wxWindow_PageDown(lua_State *L)
 {
     // get this
@@ -4079,7 +4079,7 @@ static int LUACALL wxLua_wxWindow_PageDown(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_PageUp[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_PageUp(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_PageUp[1] = {{ wxLua_wxWindow_PageUp, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_PageUp }};
-//     %wxchkver_3_1_1 bool PageUp();
+//     %wxchkver_3_0_0 bool PageUp();
 static int LUACALL wxLua_wxWindow_PageUp(lua_State *L)
 {
     // get this
@@ -4092,7 +4092,7 @@ static int LUACALL wxLua_wxWindow_PageUp(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_PopEventHandler[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_PopEventHandler(lua_State *L);
@@ -4165,11 +4165,11 @@ static int LUACALL wxLua_wxWindow_PopupMenu(lua_State *L)
 
 #endif // (wxLUA_USE_wxMenu && wxUSE_MENUS) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_PostSizeEvent[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_PostSizeEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_PostSizeEvent[1] = {{ wxLua_wxWindow_PostSizeEvent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_PostSizeEvent }};
-//     %wxchkver_3_1_1 void PostSizeEvent();
+//     %wxchkver_3_0_0 void PostSizeEvent();
 static int LUACALL wxLua_wxWindow_PostSizeEvent(lua_State *L)
 {
     // get this
@@ -4183,7 +4183,7 @@ static int LUACALL wxLua_wxWindow_PostSizeEvent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_PostSizeEventToParent[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_PostSizeEventToParent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_PostSizeEventToParent[1] = {{ wxLua_wxWindow_PostSizeEventToParent, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_PostSizeEventToParent }};
-//     %wxchkver_3_1_1 void PostSizeEventToParent();
+//     %wxchkver_3_0_0 void PostSizeEventToParent();
 static int LUACALL wxLua_wxWindow_PostSizeEventToParent(lua_State *L)
 {
     // get this
@@ -4197,7 +4197,7 @@ static int LUACALL wxLua_wxWindow_PostSizeEventToParent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_ProcessWindowEvent[] = { &wxluatype_wxWindow, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxWindow_ProcessWindowEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_ProcessWindowEvent[1] = {{ wxLua_wxWindow_ProcessWindowEvent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_ProcessWindowEvent }};
-//     %wxchkver_3_1_1 bool ProcessWindowEvent(wxEvent& event);
+//     %wxchkver_3_0_0 bool ProcessWindowEvent(wxEvent& event);
 static int LUACALL wxLua_wxWindow_ProcessWindowEvent(lua_State *L)
 {
     // wxEvent event
@@ -4215,7 +4215,7 @@ static int LUACALL wxLua_wxWindow_ProcessWindowEvent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_ProcessWindowEventLocally[] = { &wxluatype_wxWindow, &wxluatype_wxEvent, NULL };
 static int LUACALL wxLua_wxWindow_ProcessWindowEventLocally(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_ProcessWindowEventLocally[1] = {{ wxLua_wxWindow_ProcessWindowEventLocally, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_ProcessWindowEventLocally }};
-//     %wxchkver_3_1_1 bool ProcessWindowEventLocally(wxEvent& event);
+//     %wxchkver_3_0_0 bool ProcessWindowEventLocally(wxEvent& event);
 static int LUACALL wxLua_wxWindow_ProcessWindowEventLocally(lua_State *L)
 {
     // wxEvent event
@@ -4230,7 +4230,7 @@ static int LUACALL wxLua_wxWindow_ProcessWindowEventLocally(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_PushEventHandler[] = { &wxluatype_wxWindow, &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxWindow_PushEventHandler(lua_State *L);
@@ -4286,11 +4286,11 @@ static int LUACALL wxLua_wxWindow_Refresh(lua_State *L)
 
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_RefreshRect[] = { &wxluatype_wxWindow, &wxluatype_wxRect, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_RefreshRect(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_RefreshRect[1] = {{ wxLua_wxWindow_RefreshRect, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_RefreshRect }};
-//     %wxchkver_3_1_1 void RefreshRect(const wxRect& rect, bool eraseBackground = true);
+//     %wxchkver_3_0_0 void RefreshRect(const wxRect& rect, bool eraseBackground = true);
 static int LUACALL wxLua_wxWindow_RefreshRect(lua_State *L)
 {
     // get number of arguments
@@ -4307,7 +4307,7 @@ static int LUACALL wxLua_wxWindow_RefreshRect(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxUSE_HOTKEY
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_RegisterHotKey[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
@@ -4508,11 +4508,11 @@ static int LUACALL wxLua_wxWindow_ScrollWindow(lua_State *L)
 
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SendIdleEvents[] = { &wxluatype_wxWindow, &wxluatype_wxIdleEvent, NULL };
 static int LUACALL wxLua_wxWindow_SendIdleEvents(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SendIdleEvents[1] = {{ wxLua_wxWindow_SendIdleEvents, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SendIdleEvents }};
-//     %wxchkver_3_1_1 bool SendIdleEvents(wxIdleEvent& event);
+//     %wxchkver_3_0_0 bool SendIdleEvents(wxIdleEvent& event);
 static int LUACALL wxLua_wxWindow_SendIdleEvents(lua_State *L)
 {
     // wxIdleEvent event
@@ -4530,7 +4530,7 @@ static int LUACALL wxLua_wxWindow_SendIdleEvents(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SendSizeEvent[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SendSizeEvent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SendSizeEvent[1] = {{ wxLua_wxWindow_SendSizeEvent, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxWindow_SendSizeEvent }};
-//     %wxchkver_3_1_1 void SendSizeEvent(int flags = 0);
+//     %wxchkver_3_0_0 void SendSizeEvent(int flags = 0);
 static int LUACALL wxLua_wxWindow_SendSizeEvent(lua_State *L)
 {
     // get number of arguments
@@ -4548,7 +4548,7 @@ static int LUACALL wxLua_wxWindow_SendSizeEvent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SendSizeEventToParent[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SendSizeEventToParent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SendSizeEventToParent[1] = {{ wxLua_wxWindow_SendSizeEventToParent, WXLUAMETHOD_METHOD, 1, 2, s_wxluatypeArray_wxLua_wxWindow_SendSizeEventToParent }};
-//     %wxchkver_3_1_1 void SendSizeEventToParent(int flags = 0);
+//     %wxchkver_3_0_0 void SendSizeEventToParent(int flags = 0);
 static int LUACALL wxLua_wxWindow_SendSizeEventToParent(lua_State *L)
 {
     // get number of arguments
@@ -4563,7 +4563,7 @@ static int LUACALL wxLua_wxWindow_SendSizeEventToParent(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxAcceleratorTable && wxUSE_ACCEL
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetAcceleratorTable[] = { &wxluatype_wxWindow, &wxluatype_wxAcceleratorTable, NULL };
@@ -4637,11 +4637,11 @@ static int LUACALL wxLua_wxWindow_SetBackgroundStyle(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetCanFocus[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_SetCanFocus(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetCanFocus[1] = {{ wxLua_wxWindow_SetCanFocus, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetCanFocus }};
-//     %wxchkver_3_1_1 void SetCanFocus(bool canFocus);
+//     %wxchkver_3_0_0 void SetCanFocus(bool canFocus);
 static int LUACALL wxLua_wxWindow_SetCanFocus(lua_State *L)
 {
     // bool canFocus
@@ -4654,7 +4654,7 @@ static int LUACALL wxLua_wxWindow_SetCanFocus(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxCaret && wxUSE_CARET
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetCaret[] = { &wxluatype_wxWindow, &wxluatype_wxCaret, NULL };
@@ -4675,11 +4675,11 @@ static int LUACALL wxLua_wxWindow_SetCaret(lua_State *L)
 
 #endif // wxLUA_USE_wxCaret && wxUSE_CARET
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetClientSize2[] = { &wxluatype_wxWindow, &wxluatype_wxRect, NULL };
 static int LUACALL wxLua_wxWindow_SetClientSize2(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetClientSize2[1] = {{ wxLua_wxWindow_SetClientSize2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetClientSize2 }};
-//     %wxchkver_3_1_1 void SetClientSize(const wxRect& rect);
+//     %wxchkver_3_0_0 void SetClientSize(const wxRect& rect);
 static int LUACALL wxLua_wxWindow_SetClientSize2(lua_State *L)
 {
     // const wxRect rect
@@ -4692,7 +4692,7 @@ static int LUACALL wxLua_wxWindow_SetClientSize2(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetClientSize1[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
@@ -4732,11 +4732,11 @@ static int LUACALL wxLua_wxWindow_SetClientSize(lua_State *L)
 }
 
 
-#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetConstraints[] = { &wxluatype_wxWindow, &wxluatype_wxLayoutConstraints, NULL };
 static int LUACALL wxLua_wxWindow_SetConstraints(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetConstraints[1] = {{ wxLua_wxWindow_SetConstraints, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetConstraints }};
-//     %wxchkver_3_1_1 void SetConstraints(wxLayoutConstraints* constraints);
+//     %wxchkver_3_0_0 void SetConstraints(wxLayoutConstraints* constraints);
 static int LUACALL wxLua_wxWindow_SetConstraints(lua_State *L)
 {
     // wxLayoutConstraints constraints
@@ -4749,7 +4749,7 @@ static int LUACALL wxLua_wxWindow_SetConstraints(lua_State *L)
     return 0;
 }
 
-#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxSizer)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetContainingSizer[] = { &wxluatype_wxWindow, &wxluatype_wxSizer, NULL };
@@ -4810,11 +4810,11 @@ static int LUACALL wxLua_wxWindow_SetDefaultItem(lua_State *L)
 
 #endif // !wxCHECK_VERSION(2,8,0)
 
-#if wxCHECK_VERSION(3,1,1) && !defined(__WXMAC__)
+#if wxCHECK_VERSION(3,0,0) && !defined(__WXMAC__)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetDoubleBuffered[] = { &wxluatype_wxWindow, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_SetDoubleBuffered(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetDoubleBuffered[1] = {{ wxLua_wxWindow_SetDoubleBuffered, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetDoubleBuffered }};
-//     %wxchkver_3_1_1 && !%mac void SetDoubleBuffered(bool on); // %override doesn't exist on OSX
+//     %wxchkver_3_0_0 && !%mac void SetDoubleBuffered(bool on); // %override doesn't exist on OSX
 static int LUACALL wxLua_wxWindow_SetDoubleBuffered(lua_State *L)
 {
     // bool on
@@ -4827,7 +4827,7 @@ static int LUACALL wxLua_wxWindow_SetDoubleBuffered(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1) && !defined(__WXMAC__)
+#endif // wxCHECK_VERSION(3,0,0) && !defined(__WXMAC__)
 
 #if wxLUA_USE_wxDragDrop && wxUSE_DRAG_AND_DROP
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetDropTarget[] = { &wxluatype_wxWindow, &wxluatype_wxDropTarget, NULL };
@@ -4896,11 +4896,11 @@ static int LUACALL wxLua_wxWindow_SetFocus(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetFocusFromKbd[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_SetFocusFromKbd(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetFocusFromKbd[1] = {{ wxLua_wxWindow_SetFocusFromKbd, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_SetFocusFromKbd }};
-//     %wxchkver_3_1_1 void SetFocusFromKbd();
+//     %wxchkver_3_0_0 void SetFocusFromKbd();
 static int LUACALL wxLua_wxWindow_SetFocusFromKbd(lua_State *L)
 {
     // get this
@@ -4911,7 +4911,7 @@ static int LUACALL wxLua_wxWindow_SetFocusFromKbd(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxFont
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetFont[] = { &wxluatype_wxWindow, &wxluatype_wxFont, NULL };
@@ -4968,11 +4968,11 @@ static int LUACALL wxLua_wxWindow_SetHelpText(lua_State *L)
 }
 
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetId1[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SetId1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetId1[1] = {{ wxLua_wxWindow_SetId1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetId1 }};
-//     !%wxchkver_3_1_1 void SetId(int id);
+//     !%wxchkver_3_0_0 void SetId(int id);
 static int LUACALL wxLua_wxWindow_SetId1(lua_State *L)
 {
     // int id
@@ -4985,13 +4985,13 @@ static int LUACALL wxLua_wxWindow_SetId1(lua_State *L)
     return 0;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetId[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SetId(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetId[1] = {{ wxLua_wxWindow_SetId, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetId }};
-//     %wxchkver_3_1_1 void SetId(wxWindowID winid);
+//     %wxchkver_3_0_0 void SetId(wxWindowID winid);
 static int LUACALL wxLua_wxWindow_SetId(lua_State *L)
 {
     // wxWindowID winid
@@ -5004,7 +5004,7 @@ static int LUACALL wxLua_wxWindow_SetId(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetInitialSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
@@ -5044,11 +5044,11 @@ static int LUACALL wxLua_wxWindow_SetLabel(lua_State *L)
 }
 
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetLayoutDirection[] = { &wxluatype_wxWindow, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxWindow_SetLayoutDirection(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetLayoutDirection[1] = {{ wxLua_wxWindow_SetLayoutDirection, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetLayoutDirection }};
-//     %wxchkver_3_1_1 void SetLayoutDirection(wxLayoutDirection dir);
+//     %wxchkver_3_0_0 void SetLayoutDirection(wxLayoutDirection dir);
 static int LUACALL wxLua_wxWindow_SetLayoutDirection(lua_State *L)
 {
     // wxLayoutDirection dir
@@ -5061,13 +5061,13 @@ static int LUACALL wxLua_wxWindow_SetLayoutDirection(lua_State *L)
     return 0;
 }
 
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetMaxClientSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxWindow_SetMaxClientSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetMaxClientSize[1] = {{ wxLua_wxWindow_SetMaxClientSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetMaxClientSize }};
-//     %wxchkver_3_1_1 void SetMaxClientSize(const wxSize& size);
+//     %wxchkver_3_0_0 void SetMaxClientSize(const wxSize& size);
 static int LUACALL wxLua_wxWindow_SetMaxClientSize(lua_State *L)
 {
     // const wxSize size
@@ -5080,7 +5080,7 @@ static int LUACALL wxLua_wxWindow_SetMaxClientSize(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetMaxSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
@@ -5101,11 +5101,11 @@ static int LUACALL wxLua_wxWindow_SetMaxSize(lua_State *L)
 
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetMinClientSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxWindow_SetMinClientSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetMinClientSize[1] = {{ wxLua_wxWindow_SetMinClientSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetMinClientSize }};
-//     %wxchkver_3_1_1 void SetMinClientSize(const wxSize& size);
+//     %wxchkver_3_0_0 void SetMinClientSize(const wxSize& size);
 static int LUACALL wxLua_wxWindow_SetMinClientSize(lua_State *L)
 {
     // const wxSize size
@@ -5118,7 +5118,7 @@ static int LUACALL wxLua_wxWindow_SetMinClientSize(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetMinSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
@@ -5156,11 +5156,11 @@ static int LUACALL wxLua_wxWindow_SetName(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetNextHandler[] = { &wxluatype_wxWindow, &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxWindow_SetNextHandler(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetNextHandler[1] = {{ wxLua_wxWindow_SetNextHandler, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetNextHandler }};
-//     %wxchkver_3_1_1 void SetNextHandler(wxEvtHandler* handler);
+//     %wxchkver_3_0_0 void SetNextHandler(wxEvtHandler* handler);
 static int LUACALL wxLua_wxWindow_SetNextHandler(lua_State *L)
 {
     // wxEvtHandler handler
@@ -5173,7 +5173,7 @@ static int LUACALL wxLua_wxWindow_SetNextHandler(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxColourPenBrush
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetOwnBackgroundColour[] = { &wxluatype_wxWindow, &wxluatype_wxColour, NULL };
@@ -5232,11 +5232,11 @@ static int LUACALL wxLua_wxWindow_SetOwnForegroundColour(lua_State *L)
 
 #endif // wxLUA_USE_wxColourPenBrush
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetPalette[] = { &wxluatype_wxWindow, &wxluatype_wxPalette, NULL };
 static int LUACALL wxLua_wxWindow_SetPalette(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetPalette[1] = {{ wxLua_wxWindow_SetPalette, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetPalette }};
-//     %wxchkver_3_1_1 void SetPalette(const wxPalette& pal);
+//     %wxchkver_3_0_0 void SetPalette(const wxPalette& pal);
 static int LUACALL wxLua_wxWindow_SetPalette(lua_State *L)
 {
     // const wxPalette pal
@@ -5249,13 +5249,13 @@ static int LUACALL wxLua_wxWindow_SetPalette(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetPosition[] = { &wxluatype_wxWindow, &wxluatype_wxPoint, NULL };
 static int LUACALL wxLua_wxWindow_SetPosition(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetPosition[1] = {{ wxLua_wxWindow_SetPosition, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetPosition }};
-//     %wxchkver_3_1_1 void SetPosition(const wxPoint& pt);
+//     %wxchkver_3_0_0 void SetPosition(const wxPoint& pt);
 static int LUACALL wxLua_wxWindow_SetPosition(lua_State *L)
 {
     // const wxPoint pt
@@ -5268,13 +5268,13 @@ static int LUACALL wxLua_wxWindow_SetPosition(lua_State *L)
     return 0;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetPreviousHandler[] = { &wxluatype_wxWindow, &wxluatype_wxEvtHandler, NULL };
 static int LUACALL wxLua_wxWindow_SetPreviousHandler(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetPreviousHandler[1] = {{ wxLua_wxWindow_SetPreviousHandler, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetPreviousHandler }};
-//     %wxchkver_3_1_1 void SetPreviousHandler(wxEvtHandler* handler);
+//     %wxchkver_3_0_0 void SetPreviousHandler(wxEvtHandler* handler);
 static int LUACALL wxLua_wxWindow_SetPreviousHandler(lua_State *L)
 {
     // wxEvtHandler handler
@@ -5287,7 +5287,7 @@ static int LUACALL wxLua_wxWindow_SetPreviousHandler(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetScrollPos[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxWindow_SetScrollPos(lua_State *L);
@@ -5588,11 +5588,11 @@ static int LUACALL wxLua_wxWindow_SetToolTip(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetTransparent[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SetTransparent(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetTransparent[1] = {{ wxLua_wxWindow_SetTransparent, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetTransparent }};
-//     %wxchkver_3_1_1 bool SetTransparent(wxByte alpha);
+//     %wxchkver_3_0_0 bool SetTransparent(wxByte alpha);
 static int LUACALL wxLua_wxWindow_SetTransparent(lua_State *L)
 {
     // wxByte alpha
@@ -5607,7 +5607,7 @@ static int LUACALL wxLua_wxWindow_SetTransparent(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxValidator && wxUSE_VALIDATORS
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetValidator[] = { &wxluatype_wxWindow, &wxluatype_wxValidator, NULL };
@@ -5666,11 +5666,11 @@ static int LUACALL wxLua_wxWindow_SetVirtualSize(lua_State *L)
 }
 
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetVirtualSizeHints1[] = { &wxluatype_wxWindow, &wxluatype_wxSize, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxWindow_SetVirtualSizeHints1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints1[1] = {{ wxLua_wxWindow_SetVirtualSizeHints1, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxWindow_SetVirtualSizeHints1 }};
-//     !%wxchkver_3_1_1 void SetVirtualSizeHints(const wxSize& minSize=wxDefaultSize, const wxSize& maxSize=wxDefaultSize);
+//     !%wxchkver_3_0_0 void SetVirtualSizeHints(const wxSize& minSize=wxDefaultSize, const wxSize& maxSize=wxDefaultSize);
 static int LUACALL wxLua_wxWindow_SetVirtualSizeHints1(lua_State *L)
 {
     // get number of arguments
@@ -5687,13 +5687,13 @@ static int LUACALL wxLua_wxWindow_SetVirtualSizeHints1(lua_State *L)
     return 0;
 }
 
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetVirtualSizeHints[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SetVirtualSizeHints(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints[1] = {{ wxLua_wxWindow_SetVirtualSizeHints, WXLUAMETHOD_METHOD, 3, 5, s_wxluatypeArray_wxLua_wxWindow_SetVirtualSizeHints }};
-//     !%wxchkver_3_1_1 virtual void SetVirtualSizeHints(int minW,int minH, int maxW=-1, int maxH=-1);
+//     !%wxchkver_3_0_0 virtual void SetVirtualSizeHints(int minW,int minH, int maxW=-1, int maxH=-1);
 static int LUACALL wxLua_wxWindow_SetVirtualSizeHints(lua_State *L)
 {
     // get number of arguments
@@ -5714,7 +5714,7 @@ static int LUACALL wxLua_wxWindow_SetVirtualSizeHints(lua_State *L)
     return 0;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_SetWindowStyle[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_SetWindowStyle(lua_State *L);
@@ -5801,11 +5801,11 @@ static int LUACALL wxLua_wxWindow_Show(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_ShowWithEffect[] = { &wxluatype_wxWindow, &wxluatype_TINTEGER, &wxluatype_TINTEGER, NULL };
 static int LUACALL wxLua_wxWindow_ShowWithEffect(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_ShowWithEffect[1] = {{ wxLua_wxWindow_ShowWithEffect, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_ShowWithEffect }};
-//     %wxchkver_3_1_1 bool ShowWithEffect(wxShowEffect effect, unsigned int timeout = 0);
+//     %wxchkver_3_0_0 bool ShowWithEffect(wxShowEffect effect, unsigned int timeout = 0);
 static int LUACALL wxLua_wxWindow_ShowWithEffect(lua_State *L)
 {
     // get number of arguments
@@ -5824,7 +5824,7 @@ static int LUACALL wxLua_wxWindow_ShowWithEffect(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Thaw[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_Thaw(lua_State *L);
@@ -5952,11 +5952,11 @@ static int LUACALL wxLua_wxWindow_ToDIP(lua_State *L)
 
 #endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_ToggleWindowStyle[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_ToggleWindowStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_ToggleWindowStyle[1] = {{ wxLua_wxWindow_ToggleWindowStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_ToggleWindowStyle }};
-//     %wxchkver_3_1_1 bool ToggleWindowStyle(int flag);
+//     %wxchkver_3_0_0 bool ToggleWindowStyle(int flag);
 static int LUACALL wxLua_wxWindow_ToggleWindowStyle(lua_State *L)
 {
     // int flag
@@ -5971,7 +5971,7 @@ static int LUACALL wxLua_wxWindow_ToggleWindowStyle(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_TransferDataFromWindow[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_TransferDataFromWindow(lua_State *L);
@@ -6027,11 +6027,11 @@ static int LUACALL wxLua_wxWindow_UnregisterHotKey(lua_State *L)
 
 #endif // wxUSE_HOTKEY
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_UnreserveControlId[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxWindow_UnreserveControlId(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_UnreserveControlId[1] = {{ wxLua_wxWindow_UnreserveControlId, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_UnreserveControlId }};
-//     %wxchkver_3_1_1 static void UnreserveControlId(wxWindowID id, int count = 1);
+//     %wxchkver_3_0_0 static void UnreserveControlId(wxWindowID id, int count = 1);
 static int LUACALL wxLua_wxWindow_UnreserveControlId(lua_State *L)
 {
     // get number of arguments
@@ -6049,7 +6049,7 @@ static int LUACALL wxLua_wxWindow_UnreserveControlId(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_UnsetToolTip[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_UnsetToolTip(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_UnsetToolTip[1] = {{ wxLua_wxWindow_UnsetToolTip, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_UnsetToolTip }};
-//     %wxchkver_3_1_1 void UnsetToolTip();
+//     %wxchkver_3_0_0 void UnsetToolTip();
 static int LUACALL wxLua_wxWindow_UnsetToolTip(lua_State *L)
 {
     // get this
@@ -6060,7 +6060,7 @@ static int LUACALL wxLua_wxWindow_UnsetToolTip(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Update[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_Update(lua_State *L);
@@ -6095,11 +6095,11 @@ static int LUACALL wxLua_wxWindow_UpdateWindowUI(lua_State *L)
 }
 
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_UseBgCol[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_UseBgCol(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_UseBgCol[1] = {{ wxLua_wxWindow_UseBgCol, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_UseBgCol }};
-//     %wxchkver_3_1_1 bool UseBgCol() const;
+//     %wxchkver_3_0_0 bool UseBgCol() const;
 static int LUACALL wxLua_wxWindow_UseBgCol(lua_State *L)
 {
     // get this
@@ -6112,7 +6112,7 @@ static int LUACALL wxLua_wxWindow_UseBgCol(lua_State *L)
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_Validate[] = { &wxluatype_wxWindow, NULL };
 static int LUACALL wxLua_wxWindow_Validate(lua_State *L);
@@ -6149,11 +6149,11 @@ static int LUACALL wxLua_wxWindow_WarpPointer(lua_State *L)
 }
 
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_WindowToClientSize[] = { &wxluatype_wxWindow, &wxluatype_wxSize, NULL };
 static int LUACALL wxLua_wxWindow_WindowToClientSize(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_WindowToClientSize[1] = {{ wxLua_wxWindow_WindowToClientSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_WindowToClientSize }};
-//     %wxchkver_3_1_1 wxSize WindowToClientSize(const wxSize& size) const;
+//     %wxchkver_3_0_0 wxSize WindowToClientSize(const wxSize& size) const;
 static int LUACALL wxLua_wxWindow_WindowToClientSize(lua_State *L)
 {
     // const wxSize size
@@ -6171,7 +6171,7 @@ static int LUACALL wxLua_wxWindow_WindowToClientSize(lua_State *L)
     return 1;
 }
 
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
 static wxLuaArgType s_wxluatypeArray_wxLua_wxWindow_constructor1[] = { &wxluatype_wxWindow, &wxluatype_TNUMBER, &wxluatype_wxPoint, &wxluatype_wxSize, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
@@ -6274,18 +6274,18 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindow_overload[] =
 static int s_wxluafunc_wxLua_wxWindow_FindWindow_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_FindWindow_overload)/sizeof(wxLuaBindCFunc);
 
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowById_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_FindWindowById1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowById1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_FindWindowById, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowById },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_FindWindowById_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_FindWindowById_overload)/sizeof(wxLuaBindCFunc);
 
@@ -6293,13 +6293,13 @@ static int s_wxluafunc_wxLua_wxWindow_FindWindowById_overload_count = sizeof(s_w
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowByLabel_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_FindWindowByLabel1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByLabel1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_FindWindowByLabel, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByLabel },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_FindWindowByLabel_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_FindWindowByLabel_overload)/sizeof(wxLuaBindCFunc);
 
@@ -6307,17 +6307,17 @@ static int s_wxluafunc_wxLua_wxWindow_FindWindowByLabel_overload_count = sizeof(
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_FindWindowByName_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_FindWindowByName1, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByName1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_FindWindowByName, WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, 1, 2, s_wxluatypeArray_wxLua_wxWindow_FindWindowByName },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_FindWindowByName_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_FindWindowByName_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 #if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
 // function overload table
@@ -6348,108 +6348,108 @@ static int s_wxluafunc_wxLua_wxWindow_FromDIP_overload_count = sizeof(s_wxluafun
 
 #endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
 
-#if (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetBorder_overload[] =
 {
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_GetBorder1, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxWindow_GetBorder1 },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_GetBorder, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_GetBorder },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_GetBorder_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_GetBorder_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(3,0,0))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
     { wxLua_wxWindow_GetPopupMenuSelectionFromUser1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxWindow_GetPopupMenuSelectionFromUser1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_GetPopupMenuSelectionFromUser, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_GetPopupMenuSelectionFromUser },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect)
 };
 static int s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_HitTest_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_HitTest1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_HitTest1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_HitTest, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxWindow_HitTest },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_HitTest_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_HitTest_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_IsExposed_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_IsExposed5, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed5 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_IsExposed4, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed4 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_IsExposed3, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed3 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_IsExposed1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_IsExposed1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_IsExposed, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxWindow_IsExposed },
     { wxLua_wxWindow_IsExposed2, WXLUAMETHOD_METHOD, 5, 5, s_wxluatypeArray_wxLua_wxWindow_IsExposed2 },
 };
 static int s_wxluafunc_wxLua_wxWindow_IsExposed_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_IsExposed_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))
 
-#if (!wxCHECK_VERSION(3,1,1))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_Move_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_Move3, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxWindow_Move3 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_Move2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_Move2 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_Move1, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxWindow_Move1 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_Move, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxWindow_Move },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_Move_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_Move_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
 
 #if (wxLUA_USE_wxMenu && wxUSE_MENUS)||((wxLUA_USE_wxMenu && wxUSE_MENUS) && (wxLUA_USE_wxPointSizeRect))
 // function overload table
@@ -6482,14 +6482,14 @@ static int s_wxluafunc_wxLua_wxWindow_ScreenToClient_overload_count = sizeof(s_w
 
 #endif // (wxLUA_USE_wxPointSizeRect)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetClientSize_overload[] =
 {
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_SetClientSize2, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetClientSize2 },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
     { wxLua_wxWindow_SetClientSize1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetClientSize1 },
@@ -6498,24 +6498,24 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetClientSize_overload[] =
 };
 static int s_wxluafunc_wxLua_wxWindow_SetClientSize_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_SetClientSize_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetId_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_SetId1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetId1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_SetId, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxWindow_SetId },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_SetId_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_SetId_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 #if (wxLUA_USE_wxPointSizeRect)
 // function overload table
@@ -6575,22 +6575,22 @@ static int s_wxluafunc_wxLua_wxWindow_SetVirtualSize_overload_count = sizeof(s_w
 
 #endif // (wxLUA_USE_wxPointSizeRect)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,1,1))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints_overload[] =
 {
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { wxLua_wxWindow_SetVirtualSizeHints1, WXLUAMETHOD_METHOD, 1, 3, s_wxluatypeArray_wxLua_wxWindow_SetVirtualSizeHints1 },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxWindow_SetVirtualSizeHints, WXLUAMETHOD_METHOD, 3, 5, s_wxluatypeArray_wxLua_wxWindow_SetVirtualSizeHints },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints_overload_count = sizeof(s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,1,1))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,0,0))
 
 #if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
 // function overload table
@@ -6643,30 +6643,30 @@ void wxLua_wxWindow_delete_function(void** p)
 
 // Map Lua Class Methods to C Binding Functions
 wxLuaBindMethod wxWindow_methods[] = {
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "AcceptsFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_AcceptsFocus, 1, NULL },
     { "AcceptsFocusFromKeyboard", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_AcceptsFocusFromKeyboard, 1, NULL },
     { "AcceptsFocusRecursively", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_AcceptsFocusRecursively, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "AddChild", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_AddChild, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "AdjustForLayoutDirection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_AdjustForLayoutDirection, 1, NULL },
     { "AlwaysShowScrollbars", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_AlwaysShowScrollbars, 1, NULL },
     { "BeginRepositioningChildren", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_BeginRepositioningChildren, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
     { "CacheBestSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_CacheBestSize, 1, NULL },
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "CanAcceptFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_CanAcceptFocus, 1, NULL },
     { "CanAcceptFocusFromKeyboard", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_CanAcceptFocusFromKeyboard, 1, NULL },
     { "CanScroll", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_CanScroll, 1, NULL },
     { "CanSetTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_CanSetTransparent, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "CaptureMouse", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_CaptureMouse, 1, NULL },
     { "Center", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Center, 1, NULL },
@@ -6695,9 +6695,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "ClientToScreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ClientToScreen_overload, s_wxluafunc_wxLua_wxWindow_ClientToScreen_overload_count, 0 },
 #endif // (wxLUA_USE_wxPointSizeRect)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "ClientToWindowSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ClientToWindowSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
     { "Close", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Close, 1, NULL },
 
@@ -6714,9 +6714,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "DestroyChildren", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_DestroyChildren, 1, NULL },
     { "Disable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Disable, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "DoUpdateWindowUI", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_DoUpdateWindowUI, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if defined(__WXMSW__)
     { "DragAcceptFiles", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_DragAcceptFiles, 1, NULL },
@@ -6724,19 +6724,19 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "Enable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Enable, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "EndRepositioningChildren", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_EndRepositioningChildren, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "FindFocus", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_FindFocus, 1, NULL },
 
     { "FindWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_FindWindow_overload, s_wxluafunc_wxLua_wxWindow_FindWindow_overload_count, 0 },
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
     { "FindWindowById", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_FindWindowById_overload, s_wxluafunc_wxLua_wxWindow_FindWindowById_overload_count, 0 },
     { "FindWindowByLabel", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_FindWindowByLabel_overload, s_wxluafunc_wxLua_wxWindow_FindWindowByLabel_overload_count, 0 },
     { "FindWindowByName", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_FindWindowByName_overload, s_wxluafunc_wxLua_wxWindow_FindWindowByName_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
     { "Fit", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Fit, 1, NULL },
     { "FitInside", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_FitInside, 1, NULL },
@@ -6754,9 +6754,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetAdjustedBestSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetAdjustedBestSize, 1, NULL },
 #endif // (!wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetAutoLayout", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetAutoLayout, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxColourPenBrush
     { "GetBackgroundColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBackgroundColour, 1, NULL },
@@ -6764,13 +6764,13 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "GetBackgroundStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBackgroundStyle, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetBestFittingSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBestFittingSize, 1, NULL },
-#endif // (!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetBestHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBestHeight, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
     { "GetBestSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBestSize, 1, NULL },
@@ -6780,13 +6780,13 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetBestVirtualSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBestVirtualSize, 1, NULL },
 #endif // (wxCHECK_VERSION(2,9,4)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetBestWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBestWidth, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1))
+#if (wxCHECK_VERSION(3,0,0))
     { "GetBorder", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetBorder_overload, s_wxluafunc_wxLua_wxWindow_GetBorder_overload_count, 0 },
-#endif // (wxCHECK_VERSION(3,1,1))
+#endif // (wxCHECK_VERSION(3,0,0))
 
     { "GetCapture", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_GetCapture, 1, NULL },
 
@@ -6801,14 +6801,14 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetChildren", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetChildren, 1, NULL },
 #endif // wxLUA_USE_wxWindowList && !wxUSE_STL
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetClassDefaultAttributes", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_GetClassDefaultAttributes, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetClientAreaOrigin", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetClientAreaOrigin, 1, NULL },
     { "GetClientRect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetClientRect, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
     { "GetClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetClientSize, 1, NULL },
@@ -6816,9 +6816,9 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "GetClientSizeWH", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetClientSizeWH, 1, NULL },
 
-#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
     { "GetConstraints", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetConstraints, 1, NULL },
-#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxSizer)
     { "GetContainingSizer", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetContainingSizer, 1, NULL },
@@ -6842,9 +6842,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetDropTarget", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetDropTarget, 1, NULL },
 #endif // wxLUA_USE_wxDragDrop && wxUSE_DRAG_AND_DROP
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetEffectiveMinSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetEffectiveMinSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
     { "GetEventHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetEventHandler, 1, NULL },
     { "GetExtraStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetExtraStyle, 1, NULL },
@@ -6861,60 +6861,60 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetHandle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetHandle, 1, NULL },
     { "GetHelpText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetHelpText, 1, NULL },
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
     { "GetHelpTextAtPoint", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetHelpTextAtPoint, 1, NULL },
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,1,1))) && (wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxCHECK_VERSION(3,0,0))) && (wxLUA_USE_wxPointSizeRect)
 
     { "GetId", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetId, 1, NULL },
     { "GetLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetLabel, 1, NULL },
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
     { "GetLayoutDirection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetLayoutDirection, 1, NULL },
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetMaxClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMaxClientSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetMaxHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMaxHeight, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
     { "GetMaxSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMaxSize, 1, NULL },
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetMaxWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMaxWidth, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetMinClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMinClientSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetMinHeight", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMinHeight, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
     { "GetMinSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMinSize, 1, NULL },
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetMinWidth", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetMinWidth, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "GetName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetName, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetNextSibling", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetNextSibling, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "GetParent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetParent, 1, NULL },
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
     { "GetPopupMenuSelectionFromUser", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser_overload, s_wxluafunc_wxLua_wxWindow_GetPopupMenuSelectionFromUser_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS))||(((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxMenu && wxUSE_MENUS)) && (wxLUA_USE_wxPointSizeRect))
 
 #if wxLUA_USE_wxPointSizeRect
     { "GetPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetPosition, 1, NULL },
@@ -6922,9 +6922,9 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "GetPositionXY", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetPositionXY, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetPrevSibling", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetPrevSibling, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxPointSizeRect
     { "GetRect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetRect, 1, NULL },
@@ -6955,9 +6955,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetTextExtent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetTextExtent, 1, NULL },
 #endif // wxLUA_USE_wxFont
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetThemeEnabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetThemeEnabled, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if !wxCHECK_VERSION(2,8,0)
     { "GetTitle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetTitle, 1, NULL },
@@ -6967,13 +6967,13 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "GetToolTip", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetToolTip, 1, NULL },
 #endif // wxLUA_USE_wxTooltip && wxUSE_TOOLTIPS
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetToolTipText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetToolTipText, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetUpdateClientRect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetUpdateClientRect, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxRegion
     { "GetUpdateRegion", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetUpdateRegion, 1, NULL },
@@ -6989,122 +6989,122 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "GetVirtualSizeWH", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetVirtualSizeWH, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "GetWindowBorderSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetWindowBorderSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "GetWindowStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetWindowStyle, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "GetWindowStyleFlag", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetWindowStyleFlag, 1, NULL },
     { "GetWindowVariant", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_GetWindowVariant, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "HandleAsNavigationKey", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HandleAsNavigationKey, 1, NULL },
     { "HandleWindowEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HandleWindowEvent, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(2,4,0)
     { "HasCapture", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasCapture, 1, NULL },
 #endif // wxCHECK_VERSION(2,4,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "HasExtraStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasExtraStyle, 1, NULL },
     { "HasFlag", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasFlag, 1, NULL },
     { "HasFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasFocus, 1, NULL },
     { "HasMultiplePages", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasMultiplePages, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "HasScrollbar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasScrollbar, 1, NULL },
     { "HasTransparentBackground", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HasTransparentBackground, 1, NULL },
     { "Hide", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Hide, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "HideWithEffect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HideWithEffect, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
     { "HitTest", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_HitTest_overload, s_wxluafunc_wxLua_wxWindow_HitTest_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "InformFirstDirection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_InformFirstDirection, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "InheritAttributes", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_InheritAttributes, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "InheritsBackgroundColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_InheritsBackgroundColour, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "InitDialog", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_InitDialog, 1, NULL },
     { "InvalidateBestSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_InvalidateBestSize, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "IsBeingDeleted", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsBeingDeleted, 1, NULL },
     { "IsDescendant", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsDescendant, 1, NULL },
     { "IsDoubleBuffered", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsDoubleBuffered, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "IsEnabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsEnabled, 1, NULL },
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))
     { "IsExposed", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsExposed_overload, s_wxluafunc_wxLua_wxWindow_IsExposed_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "IsFocusable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsFocusable, 1, NULL },
     { "IsFrozen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsFrozen, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "IsRetained", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsRetained, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "IsScrollbarAlwaysShown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsScrollbarAlwaysShown, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "IsShown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsShown, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "IsShownOnScreen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsShownOnScreen, 1, NULL },
     { "IsThisEnabled", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsThisEnabled, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "IsTopLevel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsTopLevel, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "IsTransparentBackgroundSupported", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_IsTransparentBackgroundSupported, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "Layout", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Layout, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "LineDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_LineDown, 1, NULL },
     { "LineUp", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_LineUp, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "Lower", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Lower, 1, NULL },
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { "MakeModal", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_MakeModal, 1, NULL },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if (!wxCHECK_VERSION(3,1,1))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
     { "Move", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Move_overload, s_wxluafunc_wxLua_wxWindow_Move_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,0,0))
 
     { "MoveAfterInTabOrder", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_MoveAfterInTabOrder, 1, NULL },
     { "MoveBeforeInTabOrder", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_MoveBeforeInTabOrder, 1, NULL },
     { "Navigate", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Navigate, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "NavigateIn", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_NavigateIn, 1, NULL },
     { "NewControlId", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_NewControlId, 1, NULL },
     { "OnInternalIdle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_OnInternalIdle, 1, NULL },
     { "PageDown", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PageDown, 1, NULL },
     { "PageUp", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PageUp, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "PopEventHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PopEventHandler, 1, NULL },
 
@@ -7112,12 +7112,12 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "PopupMenu", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PopupMenu_overload, s_wxluafunc_wxLua_wxWindow_PopupMenu_overload_count, 0 },
 #endif // (wxLUA_USE_wxMenu && wxUSE_MENUS)||((wxLUA_USE_wxMenu && wxUSE_MENUS) && (wxLUA_USE_wxPointSizeRect))
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "PostSizeEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PostSizeEvent, 1, NULL },
     { "PostSizeEventToParent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PostSizeEventToParent, 1, NULL },
     { "ProcessWindowEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ProcessWindowEvent, 1, NULL },
     { "ProcessWindowEventLocally", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ProcessWindowEventLocally, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "PushEventHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_PushEventHandler, 1, NULL },
     { "Raise", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Raise, 1, NULL },
@@ -7126,9 +7126,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "Refresh", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Refresh, 1, NULL },
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "RefreshRect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_RefreshRect, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxUSE_HOTKEY
     { "RegisterHotKey", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_RegisterHotKey, 1, NULL },
@@ -7150,11 +7150,11 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "ScrollWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ScrollWindow, 1, NULL },
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "SendIdleEvents", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SendIdleEvents, 1, NULL },
     { "SendSizeEvent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SendSizeEvent, 1, NULL },
     { "SendSizeEventToParent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SendSizeEventToParent, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxAcceleratorTable && wxUSE_ACCEL
     { "SetAcceleratorTable", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetAcceleratorTable, 1, NULL },
@@ -7168,21 +7168,21 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "SetBackgroundStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetBackgroundStyle, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "SetCanFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetCanFocus, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxCaret && wxUSE_CARET
     { "SetCaret", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetCaret, 1, NULL },
 #endif // wxLUA_USE_wxCaret && wxUSE_CARET
 
-#if ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
+#if ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
     { "SetClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetClientSize_overload, s_wxluafunc_wxLua_wxWindow_SetClientSize_overload_count, 0 },
-#endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
+#endif // ((wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(wxLUA_USE_wxPointSizeRect)
 
-#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
     { "SetConstraints", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetConstraints, 1, NULL },
-#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxLUA_USE_wxLayoutConstraints && (!wxCHECK_VERSION(2,6,0))) && (wxLUA_USE_wxSizer)) && (wxCHECK_VERSION(3,0,0))
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxSizer)
     { "SetContainingSizer", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetContainingSizer, 1, NULL },
@@ -7196,9 +7196,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "SetDefaultItem", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetDefaultItem, 1, NULL },
 #endif // !wxCHECK_VERSION(2,8,0)
 
-#if wxCHECK_VERSION(3,1,1) && !defined(__WXMAC__)
+#if wxCHECK_VERSION(3,0,0) && !defined(__WXMAC__)
     { "SetDoubleBuffered", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetDoubleBuffered, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1) && !defined(__WXMAC__)
+#endif // wxCHECK_VERSION(3,0,0) && !defined(__WXMAC__)
 
 #if wxLUA_USE_wxDragDrop && wxUSE_DRAG_AND_DROP
     { "SetDropTarget", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetDropTarget, 1, NULL },
@@ -7208,9 +7208,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "SetExtraStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetExtraStyle, 1, NULL },
     { "SetFocus", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetFocus, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "SetFocusFromKbd", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetFocusFromKbd, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxFont
     { "SetFont", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetFont, 1, NULL },
@@ -7222,9 +7222,9 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "SetHelpText", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetHelpText, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
     { "SetId", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetId_overload, s_wxluafunc_wxLua_wxWindow_SetId_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 #if (wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxPointSizeRect)
     { "SetInitialSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetInitialSize, 1, NULL },
@@ -7232,21 +7232,21 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "SetLabel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetLabel, 1, NULL },
 
-#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#if ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
     { "SetLayoutDirection", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetLayoutDirection, 1, NULL },
-#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,1,1))
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxUSE_INTL)) && (wxCHECK_VERSION(3,0,0))
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "SetMaxClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetMaxClientSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
     { "SetMaxSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetMaxSize, 1, NULL },
 #endif // wxLUA_USE_wxPointSizeRect
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "SetMinClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetMinClientSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if wxLUA_USE_wxPointSizeRect
     { "SetMinSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetMinSize, 1, NULL },
@@ -7254,9 +7254,9 @@ wxLuaBindMethod wxWindow_methods[] = {
 
     { "SetName", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetName, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "SetNextHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetNextHandler, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxColourPenBrush
     { "SetOwnBackgroundColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetOwnBackgroundColour, 1, NULL },
@@ -7270,17 +7270,17 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "SetOwnForegroundColour", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetOwnForegroundColour, 1, NULL },
 #endif // wxLUA_USE_wxColourPenBrush
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
     { "SetPalette", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetPalette, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPalette && wxUSE_PALETTE)
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "SetPosition", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetPosition, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "SetPreviousHandler", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetPreviousHandler, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "SetScrollPos", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetScrollPos, 1, NULL },
     { "SetScrollbar", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetScrollbar, 1, NULL },
@@ -7305,9 +7305,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "SetToolTip", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetToolTip_overload, s_wxluafunc_wxLua_wxWindow_SetToolTip_overload_count, 0 },
 #endif // (wxLUA_USE_wxTooltip && wxUSE_TOOLTIPS)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "SetTransparent", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetTransparent, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxValidator && wxUSE_VALIDATORS
     { "SetValidator", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetValidator, 1, NULL },
@@ -7317,9 +7317,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "SetVirtualSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetVirtualSize_overload, s_wxluafunc_wxLua_wxWindow_SetVirtualSize_overload_count, 0 },
 #endif // (wxLUA_USE_wxPointSizeRect)
 
-#if ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,1,1))
+#if ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,0,0))
     { "SetVirtualSizeHints", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints_overload, s_wxluafunc_wxLua_wxWindow_SetVirtualSizeHints_overload_count, 0 },
-#endif // ((!wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,1,1))
+#endif // ((!wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect))||(!wxCHECK_VERSION(3,0,0))
 
     { "SetWindowStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetWindowStyle, 1, NULL },
     { "SetWindowStyleFlag", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_SetWindowStyleFlag, 1, NULL },
@@ -7327,9 +7327,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "ShouldInheritColours", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ShouldInheritColours, 1, NULL },
     { "Show", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Show, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "ShowWithEffect", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ShowWithEffect, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "Thaw", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Thaw, 1, NULL },
 
@@ -7337,9 +7337,9 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "ToDIP", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_ToDIP_overload, s_wxluafunc_wxLua_wxWindow_ToDIP_overload_count, 0 },
 #endif // ((wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect))||(wxCHECK_VERSION(3,1,1))
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "ToggleWindowStyle", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_ToggleWindowStyle, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "TransferDataFromWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_TransferDataFromWindow, 1, NULL },
     { "TransferDataToWindow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_TransferDataToWindow, 1, NULL },
@@ -7348,24 +7348,24 @@ wxLuaBindMethod wxWindow_methods[] = {
     { "UnregisterHotKey", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_UnregisterHotKey, 1, NULL },
 #endif // wxUSE_HOTKEY
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "UnreserveControlId", WXLUAMETHOD_METHOD|WXLUAMETHOD_STATIC, s_wxluafunc_wxLua_wxWindow_UnreserveControlId, 1, NULL },
     { "UnsetToolTip", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_UnsetToolTip, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "Update", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Update, 1, NULL },
     { "UpdateWindowUI", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_UpdateWindowUI, 1, NULL },
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { "UseBgCol", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_UseBgCol, 1, NULL },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
     { "Validate", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_Validate, 1, NULL },
     { "WarpPointer", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_WarpPointer, 1, NULL },
 
-#if (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
     { "WindowToClientSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxWindow_WindowToClientSize, 1, NULL },
-#endif // (wxCHECK_VERSION(3,1,1)) && (wxLUA_USE_wxPointSizeRect)
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxPointSizeRect)
 
 #if (wxLUA_USE_wxPointSizeRect)
     { "wxWindow", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxWindow_constructor_overload, s_wxluafunc_wxLua_wxWindow_constructor_overload_count, 0 },

--- a/wxLua/modules/wxbind/src/wxstc_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxstc_bind.cpp
@@ -598,7 +598,7 @@ static int LUACALL wxLua_wxStyledTextCtrl_AutoCompGetCurrent(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_AutoCompGetCurrentText[] = { &wxluatype_wxStyledTextCtrl, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_AutoCompGetCurrentText(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_AutoCompGetCurrentText[1] = {{ wxLua_wxStyledTextCtrl_AutoCompGetCurrentText, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxStyledTextCtrl_AutoCompGetCurrentText }};
-//     %wxchkver_3_1_1 wxString AutoCompGetCurrentText() const;
+//     %wxchkver_3_0_0 wxString AutoCompGetCurrentText() const;
 static int LUACALL wxLua_wxStyledTextCtrl_AutoCompGetCurrentText(lua_State *L)
 {
     // get this
@@ -1133,11 +1133,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_BraceHighlightIndicator(lua_State *L)
 
 #endif // wxCHECK_VERSION(2,9,5)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_BraceMatch1[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_BraceMatch1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch1[1] = {{ wxLua_wxStyledTextCtrl_BraceMatch1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_BraceMatch1 }};
-//     !%wxchkver_3_1_1 int BraceMatch(int pos);
+//     !%wxchkver_3_0_0 int BraceMatch(int pos);
 static int LUACALL wxLua_wxStyledTextCtrl_BraceMatch1(lua_State *L)
 {
     // int pos
@@ -1152,13 +1152,13 @@ static int LUACALL wxLua_wxStyledTextCtrl_BraceMatch1(lua_State *L)
     return 1;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_BraceMatch[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_BraceMatch(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch[1] = {{ wxLua_wxStyledTextCtrl_BraceMatch, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxStyledTextCtrl_BraceMatch }};
-//     %wxchkver_3_1_1 int BraceMatch(int pos, int maxReStyle=0);
+//     %wxchkver_3_0_0 int BraceMatch(int pos, int maxReStyle=0);
 static int LUACALL wxLua_wxStyledTextCtrl_BraceMatch(lua_State *L)
 {
     // get number of arguments
@@ -1170,14 +1170,18 @@ static int LUACALL wxLua_wxStyledTextCtrl_BraceMatch(lua_State *L)
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call BraceMatch
+#if (wxCHECK_VERSION(3,1,1))
     int returns = (self->BraceMatch(pos, maxReStyle));
+#else
+    int returns = (self->BraceMatch(pos));
+#endif
     // push the result number
     lua_pushnumber(L, returns);
 
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_CallTipActive[] = { &wxluatype_wxStyledTextCtrl, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_CallTipActive(lua_State *L);
@@ -2484,7 +2488,7 @@ static int LUACALL wxLua_wxStyledTextCtrl_FoldChildren(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_FoldDisplayTextSetStyle[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_FoldDisplayTextSetStyle(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_FoldDisplayTextSetStyle[1] = {{ wxLua_wxStyledTextCtrl_FoldDisplayTextSetStyle, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_FoldDisplayTextSetStyle }};
-//     %wxchkver_3_1_1 void FoldDisplayTextSetStyle(int style);
+//     %wxchkver_3_0_0 void FoldDisplayTextSetStyle(int style);
 static int LUACALL wxLua_wxStyledTextCtrl_FoldDisplayTextSetStyle(lua_State *L)
 {
     // int style
@@ -4523,11 +4527,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyExpanded(lua_State *L)
 }
 
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPropertyInt1[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyInt1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt1[1] = {{ wxLua_wxStyledTextCtrl_GetPropertyInt1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPropertyInt1 }};
-//     !%wxchkver_3_1_1 int GetPropertyInt(const wxString& key) const;
+//     !%wxchkver_3_0_0 int GetPropertyInt(const wxString& key) const;
 static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyInt1(lua_State *L)
 {
     // const wxString key
@@ -4542,13 +4546,13 @@ static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyInt1(lua_State *L)
     return 1;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPropertyInt[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TSTRING, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyInt(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt[1] = {{ wxLua_wxStyledTextCtrl_GetPropertyInt, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPropertyInt }};
-//     %wxchkver_3_1_1 int GetPropertyInt(const wxString &key, int defaultValue=0) const;
+//     %wxchkver_3_0_0 int GetPropertyInt(const wxString &key, int defaultValue=0) const;
 static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyInt(lua_State *L)
 {
     // get number of arguments
@@ -4560,14 +4564,18 @@ static int LUACALL wxLua_wxStyledTextCtrl_GetPropertyInt(lua_State *L)
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call GetPropertyInt
+#if (wxCHECK_VERSION(3,1,1))
     int returns = (self->GetPropertyInt(key, defaultValue));
+#else
+    int returns = (self->GetPropertyInt(key));
+#endif
     // push the result number
     lua_pushnumber(L, returns);
 
     return 1;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(2,9,5)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPunctuationChars[] = { &wxluatype_wxStyledTextCtrl, NULL };
@@ -12202,11 +12210,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_UpperCase(lua_State *L)
 }
 
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_UsePopUp1[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TBOOLEAN, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_UsePopUp1(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp1[1] = {{ wxLua_wxStyledTextCtrl_UsePopUp1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_UsePopUp1 }};
-//     !%wxchkver_3_1_1 void UsePopUp(bool allowPopUp);
+//     !%wxchkver_3_0_0 void UsePopUp(bool allowPopUp);
 static int LUACALL wxLua_wxStyledTextCtrl_UsePopUp1(lua_State *L)
 {
     // bool allowPopUp
@@ -12219,13 +12227,13 @@ static int LUACALL wxLua_wxStyledTextCtrl_UsePopUp1(lua_State *L)
     return 0;
 }
 
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_UsePopUp[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_UsePopUp(lua_State *L);
 // static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp[1] = {{ wxLua_wxStyledTextCtrl_UsePopUp, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_UsePopUp }};
-//     %wxchkver_3_1_1 void UsePopUp(int popUpMode);
+//     %wxchkver_3_0_0 void UsePopUp(int popUpMode);
 static int LUACALL wxLua_wxStyledTextCtrl_UsePopUp(lua_State *L)
 {
     // int popUpMode
@@ -12238,7 +12246,7 @@ static int LUACALL wxLua_wxStyledTextCtrl_UsePopUp(lua_State *L)
     return 0;
 }
 
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxStyledTextCtrl_UserListShow[] = { &wxluatype_wxStyledTextCtrl, &wxluatype_TNUMBER, &wxluatype_TSTRING, NULL };
 static int LUACALL wxLua_wxStyledTextCtrl_UserListShow(lua_State *L);
@@ -12686,22 +12694,22 @@ static int LUACALL wxLua_wxStyledTextCtrl_constructor(lua_State *L)
 
 
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxStyledTextCtrl_BraceMatch1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_BraceMatch1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxStyledTextCtrl_BraceMatch, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxStyledTextCtrl_BraceMatch },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch_overload_count = sizeof(s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 #if (!wxCHECK_VERSION(2,9,5))
 // function overload table
@@ -12720,22 +12728,22 @@ static int s_wxluafunc_wxLua_wxStyledTextCtrl_GetIndentationGuides_overload_coun
 
 #endif // (!wxCHECK_VERSION(2,9,5))
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxStyledTextCtrl_GetPropertyInt1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPropertyInt1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxStyledTextCtrl_GetPropertyInt, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxStyledTextCtrl_GetPropertyInt },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt_overload_count = sizeof(s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 #if (!wxCHECK_VERSION(3,1,0))
 // function overload table
@@ -12819,22 +12827,22 @@ static int s_wxluafunc_wxLua_wxStyledTextCtrl_SetUseAntiAliasing_overload_count 
 
 #endif // (!wxCHECK_VERSION(3,1,0))
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp_overload[] =
 {
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
     { wxLua_wxStyledTextCtrl_UsePopUp1, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_UsePopUp1 },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if wxCHECK_VERSION(3,1,1)
+#if wxCHECK_VERSION(3,0,0)
     { wxLua_wxStyledTextCtrl_UsePopUp, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxStyledTextCtrl_UsePopUp },
-#endif // wxCHECK_VERSION(3,1,1)
+#endif // wxCHECK_VERSION(3,0,0)
 };
 static int s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp_overload_count = sizeof(s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 void wxLua_wxStyledTextCtrl_delete_function(void** p)
 {
@@ -12954,9 +12962,9 @@ wxLuaBindMethod wxStyledTextCtrl_methods[] = {
     { "BraceHighlightIndicator", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_BraceHighlightIndicator, 1, NULL },
 #endif // wxCHECK_VERSION(2,9,5)
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
     { "BraceMatch", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch_overload, s_wxluafunc_wxLua_wxStyledTextCtrl_BraceMatch_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
     { "CallTipActive", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_CallTipActive, 1, NULL },
     { "CallTipCancel", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_CallTipCancel, 1, NULL },
@@ -13357,9 +13365,9 @@ wxLuaBindMethod wxStyledTextCtrl_methods[] = {
     { "GetProperty", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_GetProperty, 1, NULL },
     { "GetPropertyExpanded", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyExpanded, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
     { "GetPropertyInt", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt_overload, s_wxluafunc_wxLua_wxStyledTextCtrl_GetPropertyInt_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
 #if wxCHECK_VERSION(2,9,5)
     { "GetPunctuationChars", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_GetPunctuationChars, 1, NULL },
@@ -14233,9 +14241,9 @@ wxLuaBindMethod wxStyledTextCtrl_methods[] = {
     { "Undo", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_Undo, 1, NULL },
     { "UpperCase", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_UpperCase, 1, NULL },
 
-#if (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#if (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
     { "UsePopUp", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp_overload, s_wxluafunc_wxLua_wxStyledTextCtrl_UsePopUp_overload_count, 0 },
-#endif // (!wxCHECK_VERSION(3,1,1))||(wxCHECK_VERSION(3,1,1))
+#endif // (!wxCHECK_VERSION(3,0,0))||(wxCHECK_VERSION(3,0,0))
 
     { "UserListShow", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_UserListShow, 1, NULL },
     { "VCHome", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxStyledTextCtrl_VCHome, 1, NULL },
@@ -15336,7 +15344,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxstc(size_t &count)
 {
     static wxLuaBindNumber numberList[] =
     {
-#if !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#if !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
         { "wxSTC_4GL_BLOCK", wxSTC_4GL_BLOCK },
         { "wxSTC_4GL_BLOCK_", wxSTC_4GL_BLOCK_ },
         { "wxSTC_4GL_CHARACTER", wxSTC_4GL_CHARACTER },
@@ -15369,7 +15377,7 @@ wxLuaBindNumber* wxLuaGetDefineList_wxstc(size_t &count)
         { "wxSTC_4GL_STRING_", wxSTC_4GL_STRING_ },
         { "wxSTC_4GL_WORD", wxSTC_4GL_WORD },
         { "wxSTC_4GL_WORD_", wxSTC_4GL_WORD_ },
-#endif // !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#endif // !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
 
 #if wxCHECK_VERSION(2,9,5)
         { "wxSTC_A68K_COMMENT", wxSTC_A68K_COMMENT },
@@ -16689,19 +16697,19 @@ wxLuaBindNumber* wxLuaGetDefineList_wxstc(size_t &count)
         { "wxSTC_IME_WINDOWED", wxSTC_IME_WINDOWED },
 #endif // wxCHECK_VERSION(3,1,0)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
         { "wxSTC_INDIC0_MASK", wxSTC_INDIC0_MASK },
         { "wxSTC_INDIC1_MASK", wxSTC_INDIC1_MASK },
         { "wxSTC_INDIC2_MASK", wxSTC_INDIC2_MASK },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(3,1,0)
         { "wxSTC_INDICFLAG_VALUEFORE", wxSTC_INDICFLAG_VALUEFORE },
 #endif // wxCHECK_VERSION(3,1,0)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
         { "wxSTC_INDICS_MASK", wxSTC_INDICS_MASK },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
 #if wxCHECK_VERSION(3,1,0)
         { "wxSTC_INDICVALUEBIT", wxSTC_INDICVALUEBIT },
@@ -18031,23 +18039,23 @@ wxLuaBindNumber* wxLuaGetDefineList_wxstc(size_t &count)
         { "wxSTC_R_STRING2", wxSTC_R_STRING2 },
 #endif // wxCHECK_VERSION(2,9,5)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
         { "wxSTC_SCMOD_ALT", wxSTC_SCMOD_ALT },
         { "wxSTC_SCMOD_CTRL", wxSTC_SCMOD_CTRL },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#if !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
         { "wxSTC_SCMOD_META", wxSTC_SCMOD_META },
-#endif // !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#endif // !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
 
-#if !wxCHECK_VERSION(3,1,1)
+#if !wxCHECK_VERSION(3,0,0)
         { "wxSTC_SCMOD_NORM", wxSTC_SCMOD_NORM },
         { "wxSTC_SCMOD_SHIFT", wxSTC_SCMOD_SHIFT },
-#endif // !wxCHECK_VERSION(3,1,1)
+#endif // !wxCHECK_VERSION(3,0,0)
 
-#if !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#if !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
         { "wxSTC_SCMOD_SUPER", wxSTC_SCMOD_SUPER },
-#endif // !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#endif // !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
 
         { "wxSTC_SCRIPTOL_CHARACTER", wxSTC_SCRIPTOL_CHARACTER },
         { "wxSTC_SCRIPTOL_CLASSNAME", wxSTC_SCRIPTOL_CLASSNAME },
@@ -18066,11 +18074,11 @@ wxLuaBindNumber* wxLuaGetDefineList_wxstc(size_t &count)
         { "wxSTC_SCRIPTOL_TRIPLE", wxSTC_SCRIPTOL_TRIPLE },
         { "wxSTC_SCRIPTOL_WHITE", wxSTC_SCRIPTOL_WHITE },
 
-#if !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#if !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
         { "wxSTC_SCVS_NONE", wxSTC_SCVS_NONE },
         { "wxSTC_SCVS_RECTANGULARSELECTION", wxSTC_SCVS_RECTANGULARSELECTION },
         { "wxSTC_SCVS_USERACCESSIBLE", wxSTC_SCVS_USERACCESSIBLE },
-#endif // !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(2,9,5)
+#endif // !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(2,9,5)
 
         { "wxSTC_SEL_LINES", wxSTC_SEL_LINES },
         { "wxSTC_SEL_RECTANGLE", wxSTC_SEL_RECTANGLE },
@@ -18325,10 +18333,10 @@ wxLuaBindNumber* wxLuaGetDefineList_wxstc(size_t &count)
         { "wxSTC_TECHNOLOGY_DIRECTWRITE", wxSTC_TECHNOLOGY_DIRECTWRITE },
 #endif // wxCHECK_VERSION(2,9,5)
 
-#if !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(3,1,0)
+#if !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(3,1,0)
         { "wxSTC_TECHNOLOGY_DIRECTWRITEDC", wxSTC_TECHNOLOGY_DIRECTWRITEDC },
         { "wxSTC_TECHNOLOGY_DIRECTWRITERETAIN", wxSTC_TECHNOLOGY_DIRECTWRITERETAIN },
-#endif // !wxCHECK_VERSION(3,1,1) && wxCHECK_VERSION(3,1,0)
+#endif // !wxCHECK_VERSION(3,0,0) && wxCHECK_VERSION(3,1,0)
 
         { "wxSTC_TEX_COMMAND", wxSTC_TEX_COMMAND },
         { "wxSTC_TEX_DEFAULT", wxSTC_TEX_DEFAULT },

--- a/wxLua/modules/wxlua/lbitlib.c
+++ b/wxLua/modules/wxlua/lbitlib.c
@@ -46,6 +46,14 @@
 @@ LUA_UNSIGNED is the integral type used by lua_pushunsigned/lua_tounsigned.
 ** It must have at least 32 bits.
 */
+#if !defined(LUAI_INT32)
+#if INT_MAX <= 32767
+#define LUAI_INT32 long
+#else
+#define LUAI_INT32 int
+#endif
+#endif
+
 #define LUA_UNSIGNED    unsigned LUAI_INT32
 
 #if defined(LUA_NUMBER_DOUBLE) && !defined(LUA_ANSI)    /* { */


### PR DESCRIPTION
I tried to build wxLua with LuaJIT 2.0.5 and wxWidgets 3.0 (on Mac OS X and MinGW i686), and found some modification should be made (first two commits).
- Definition of LUAI_INT32 should be added.
- The MinGW workaround in wxcore_bind.cpp should be removed when a newer gcc is used (I use 4.9 and there is no 'internal compiler error', but I am not sure which version of gcc fixed this).
In addition, I have made the following two improvements.
- wxCHECK_VERSION is reviewed and modified. Some features are available in wxWidgets 3.0.x but not in wxLua, because wxCHECK_VERSION requires 3.1.1. For these features, wxCHECK_VERSION are changed to 3.0.0.
- wx.wxSize and wx.wxRect are modified to have properties 'width', 'height' and 'x', 'y' (for wxRect only), like wx.wxPoint having properties 'x' and 'y'.
I would be happy if you can spare your time reviewing these changes, and merge to your project whichever you think is useful.