### PR TITLE
Proposal: change of handling 'char *' type arguments, especially for wxImage etc.

### DIFF
--- a/wxLua/bindings/genwxbind.lua
+++ b/wxLua/bindings/genwxbind.lua
@@ -3812,12 +3812,12 @@ if ((double)(lua_Integer)(%s) == (double)(%s)) {
                         elseif argType == "char" then
                             overload_argList = overload_argList.."&wxluatype_TSTRING, "
                             argItem = "wxlua_getstringtype(L, "..argNum..")"
-
-                            argTypeWithAttrib = "wxCharBuffer"
-                            if (origArgTypeWithAttrib ~= "const char") then
-                                argCast = "("..origArgTypeWithAttrib.."*)(const char*)"
-                            else
-                                argCast = origArgTypeWithAttrib.."*"
+                            argTypeWithAttrib = "const char *"
+                            if (origArgTypeWithAttrib == "unsigned char" or origArgTypeWithAttrib == "const unsigned char") then
+                                argTypeWithAttrib = origArgTypeWithAttrib .. " *"
+                                argItem = "("..argTypeWithAttrib..")"..argItem
+                            elseif (origArgTypeWithAttrib ~= "const char") then
+                                argCast = "("..origArgTypeWithAttrib.."*)"
                             end
                         else
                             if isTranslated and (origIndirectionCount == 0) then

--- a/wxLua/bindings/wxwidgets/wx_datatypes.lua
+++ b/wxLua/bindings/wxwidgets/wx_datatypes.lua
@@ -3564,6 +3564,12 @@ wx_dataTypeTable =
     Name = "wxMediaState",
     ValueType = "enum",
   },
+  wxMemoryBuffer = {
+    Condition = "wxLUA_USE_wxMemoryBuffer",
+    IsNumber = false,
+    Name = "wxMemoryBuffer",
+    ValueType = "class",
+  },
   wxMemoryConfig = {
     BaseClasses = {
       [1] = "wxFileConfig",

--- a/wxLua/bindings/wxwidgets/wxbase_data.i
+++ b/wxLua/bindings/wxwidgets/wxbase_data.i
@@ -487,3 +487,59 @@ class %delete wxULongLong
 };
 
 #endif wxUSE_LONGLONG
+
+#if wxLUA_USE_wxMemoryBuffer
+
+class %delete wxMemoryBuffer
+{
+public:
+    // ctor and dtor
+    wxMemoryBuffer(size_t size = wxMemoryBufferData::DefBufSize);
+
+    // copy and assignment
+    wxMemoryBuffer(const wxMemoryBuffer& src);
+
+    // Accessors
+    void  *GetData() const;
+    size_t GetBufSize() const;
+    size_t GetDataLen() const;
+
+    bool IsEmpty() const;
+
+    void   SetBufSize(size_t size);
+    void   SetDataLen(size_t len);
+
+    void Clear();
+
+    // Ensure the buffer is big enough and return a pointer to it
+    void *GetWriteBuf(size_t sizeNeeded);
+
+    // Update the length after the write
+    void  UngetWriteBuf(size_t sizeUsed);
+
+    // Like the above, but appends to the buffer
+    void *GetAppendBuf(size_t sizeNeeded);
+
+    // Update the length after the append
+    void  UngetAppendBuf(size_t sizeUsed);
+
+    // Other ways to append to the buffer
+    void  AppendByte(char data);
+
+    void  AppendData(const void *data, size_t len);
+
+    // gives up ownership of data, returns the pointer; after this call,
+    // data isn't freed by the buffer and its content is resent to empty
+    void *release();
+    
+    // wxLua specific
+    //  Get the data at the given index. If length > 1, then multiple values are returned.
+    unsigned char Byte(int index, size_t length = 1);
+    //  Set the data at the given index. If multiple data are given, the following values are
+    //  set at the subsequent positions. Data length and buffer size are updated if necessary.
+    void SetByte(int index, unsigned char data);
+    //  Set the same byte to the specified range. Data length and buffer size are updated if necessary.
+    void Fill(unsigned char data, int start_index, size_t length);
+};
+
+#endif

--- a/wxLua/bindings/wxwidgets/wxcore_override.hpp
+++ b/wxLua/bindings/wxwidgets/wxcore_override.hpp
@@ -1836,7 +1836,7 @@ static int LUACALL wxLua_wxImageFromData_constructor(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 4 ? wxlua_getbooleantype(L, 4) : false);
     // unsigned char* data
-    unsigned char *data = (unsigned char *)lua_tostring(L, 3);
+    unsigned char *data = (unsigned char *)wxlua_getstringtype(L, 3);
     // int height
     int height = (int)wxlua_getintegertype(L, 2);
     // int width
@@ -1998,7 +1998,7 @@ static int LUACALL wxLua_wxImage_SetAlphaData(lua_State *L)
 {
     // unsigned char *data
     size_t len = 0;
-    unsigned char *data = (unsigned char *)lua_tolstring(L, 2, &len);
+    unsigned char *data = (unsigned char *)wxlua_getstringtypelen(L, 2, &len);
     // get this
     wxImage *self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call SetData
@@ -2019,7 +2019,7 @@ static int LUACALL wxLua_wxImage_SetData(lua_State *L)
 {
     // unsigned char *data
     size_t len = 0;
-    unsigned char *data = (unsigned char *)lua_tolstring(L, 2, &len);
+    unsigned char *data = (unsigned char *)wxlua_getstringtypelen(L, 2, &len);
     // get this
     wxImage *self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call SetData

--- a/wxLua/modules/wxbind/include/wxbase_bind.h
+++ b/wxLua/modules/wxbind/include/wxbase_bind.h
@@ -299,6 +299,10 @@ extern WXDLLIMPEXP_DATA_BINDWXBASE(int) wxluatype_wxStringTokenizer;
     extern WXDLLIMPEXP_DATA_BINDWXBASE(int) wxluatype_wxLogPassThrough;
 #endif // wxLUA_USE_wxLog && wxUSE_LOG
 
+#if wxLUA_USE_wxMemoryBuffer
+    extern WXDLLIMPEXP_DATA_BINDWXBASE(int) wxluatype_wxMemoryBuffer;
+#endif // wxLUA_USE_wxMemoryBuffer
+
 #if wxLUA_USE_wxObject
     extern WXDLLIMPEXP_DATA_BINDWXBASE(int) wxluatype_wxObject;
     extern WXDLLIMPEXP_DATA_BINDWXBASE(int) wxluatype_wxObjectRefData;

--- a/wxLua/modules/wxbind/setup/wxluasetup.h
+++ b/wxLua/modules/wxbind/setup/wxluasetup.h
@@ -105,6 +105,7 @@
 #define wxLUA_USE_wxLuaPrintout                 1
 #define wxLUA_USE_wxMask                        1
 #define wxLUA_USE_wxMediaCtrl                   1 // must link to lib, also wxUSE_MEDIACTRL
+#define wxLUA_USE_wxMemoryBuffer                1
 #define wxLUA_USE_wxMenu                        1
 #define wxLUA_USE_wxMessageDialog               1
 #define wxLUA_USE_wxMetafile                    1

--- a/wxLua/modules/wxbind/src/wxbase_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxbase_bind.cpp
@@ -2403,6 +2403,7 @@ static const char* wxluaclassname_wxLogChain = "wxLogChain";
 static const char* wxluaclassname_wxLogNull = "wxLogNull";
 static const char* wxluaclassname_wxLogPassThrough = "wxLogPassThrough";
 static const char* wxluaclassname_wxLongLong = "wxLongLong";
+static const char* wxluaclassname_wxMemoryBuffer = "wxMemoryBuffer";
 static const char* wxluaclassname_wxMemoryConfig = "wxMemoryConfig";
 static const char* wxluaclassname_wxMemoryInputStream = "wxMemoryInputStream";
 static const char* wxluaclassname_wxMimeTypesManager = "wxMimeTypesManager";
@@ -2731,6 +2732,12 @@ extern void wxLua_wxStringTokenizer_delete_function(void** p);
     extern void wxLua_wxLogPassThrough_delete_function(void** p);
 #endif // wxLUA_USE_wxLog && wxUSE_LOG
 
+#if wxLUA_USE_wxMemoryBuffer
+    extern wxLuaBindMethod wxMemoryBuffer_methods[];
+    extern int wxMemoryBuffer_methodCount;
+    extern void wxLua_wxMemoryBuffer_delete_function(void** p);
+#endif // wxLUA_USE_wxMemoryBuffer
+
 #if wxLUA_USE_wxObject
     extern wxLuaBindMethod wxObject_methods[];
     extern int wxObject_methodCount;
@@ -2984,6 +2991,10 @@ wxLuaBindClass* wxLuaGetClassList_wxbase(size_t &count)
 #if wxUSE_LONGLONG
         { wxluaclassname_wxLongLong, wxLongLong_methods, wxLongLong_methodCount, NULL, &wxluatype_wxLongLong, NULL, NULL, NULL, NULL, NULL, 0, &wxLua_wxLongLong_delete_function, }, 
 #endif // wxUSE_LONGLONG
+
+#if wxLUA_USE_wxMemoryBuffer
+        { wxluaclassname_wxMemoryBuffer, wxMemoryBuffer_methods, wxMemoryBuffer_methodCount, NULL, &wxluatype_wxMemoryBuffer, NULL, NULL, NULL, NULL, NULL, 0, &wxLua_wxMemoryBuffer_delete_function, }, 
+#endif // wxLUA_USE_wxMemoryBuffer
 
 #if wxLUA_USE_wxConfig && wxUSE_CONFIG
         { wxluaclassname_wxMemoryConfig, wxMemoryConfig_methods, wxMemoryConfig_methodCount, NULL, &wxluatype_wxMemoryConfig, wxluabaseclassnames_wxMemoryConfig, wxluabaseclassbinds_wxMemoryConfig, NULL, NULL, NULL, 0, &wxLua_wxMemoryConfig_delete_function, }, 

--- a/wxLua/modules/wxbind/src/wxbase_data.cpp
+++ b/wxLua/modules/wxbind/src/wxbase_data.cpp
@@ -114,9 +114,9 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxString_From8BitData[1] = {{ wxLua_wxSt
 static int LUACALL wxLua_wxString_From8BitData(lua_State *L)
 {
     // const char s
-    wxCharBuffer s = wxlua_getstringtype(L, 1);
+    const char * s = wxlua_getstringtype(L, 1);
     // call From8BitData
-    wxString returns = (wxString::From8BitData((const char*)s));
+    wxString returns = (wxString::From8BitData(s));
     // push the result string
     wxlua_pushwxString(L, returns);
 
@@ -130,9 +130,9 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxString_FromUTF8[1] = {{ wxLua_wxString
 static int LUACALL wxLua_wxString_FromUTF8(lua_State *L)
 {
     // const char s
-    wxCharBuffer s = wxlua_getstringtype(L, 1);
+    const char * s = wxlua_getstringtype(L, 1);
     // call FromUTF8
-    wxString returns = (wxString::FromUTF8((const char*)s));
+    wxString returns = (wxString::FromUTF8(s));
     // push the result string
     wxlua_pushwxString(L, returns);
 
@@ -146,9 +146,9 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxString_FromUTF8Unchecked[1] = {{ wxLua
 static int LUACALL wxLua_wxString_FromUTF8Unchecked(lua_State *L)
 {
     // const char s
-    wxCharBuffer s = wxlua_getstringtype(L, 1);
+    const char * s = wxlua_getstringtype(L, 1);
     // call FromUTF8Unchecked
-    wxString returns = (wxString::FromUTF8Unchecked((const char*)s));
+    wxString returns = (wxString::FromUTF8Unchecked(s));
     // push the result string
     wxlua_pushwxString(L, returns);
 
@@ -3598,4 +3598,433 @@ wxLuaBindMethod wxULongLong_methods[] = {
 int wxULongLong_methodCount = sizeof(wxULongLong_methods)/sizeof(wxLuaBindMethod) - 1;
 
 #endif  // wxUSE_LONGLONG
+
+
+#if wxLUA_USE_wxMemoryBuffer
+// ---------------------------------------------------------------------------
+// Bind class wxMemoryBuffer
+// ---------------------------------------------------------------------------
+
+// Lua MetaTable Tag for Class 'wxMemoryBuffer'
+int wxluatype_wxMemoryBuffer = WXLUA_TUNKNOWN;
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_AppendByte[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TNUMBER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_AppendByte(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_AppendByte[1] = {{ wxLua_wxMemoryBuffer_AppendByte, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_AppendByte }};
+//     void  AppendByte(char data);
+static int LUACALL wxLua_wxMemoryBuffer_AppendByte(lua_State *L)
+{
+    // char data
+    char data = (char)wxlua_getnumbertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call AppendByte
+    self->AppendByte(data);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_AppendData[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TLIGHTUSERDATA, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_AppendData(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_AppendData[1] = {{ wxLua_wxMemoryBuffer_AppendData, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxMemoryBuffer_AppendData }};
+//     void  AppendData(const void *data, size_t len);
+static int LUACALL wxLua_wxMemoryBuffer_AppendData(lua_State *L)
+{
+    // size_t len
+    size_t len = (size_t)wxlua_getuintegertype(L, 3);
+    // const void data
+    const void * data = (const void *)wxlua_touserdata(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call AppendData
+    self->AppendData(data, len);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_Byte[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_Byte(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_Byte[1] = {{ wxLua_wxMemoryBuffer_Byte, WXLUAMETHOD_METHOD, 2, 3, s_wxluatypeArray_wxLua_wxMemoryBuffer_Byte }};
+// %override wxLua_wxMemoryBuffer_Byte
+//     unsigned char Byte(int index, size_t length = 1);
+static int LUACALL wxLua_wxMemoryBuffer_Byte(lua_State *L)
+{
+    // int index
+    int index = (int)wxlua_getnumbertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // int length (optional)
+    int length = 1;
+    if (lua_gettop(L) >= 3)
+        length = (size_t)wxlua_getnumbertype(L, 3);
+    if (index + length > self->GetDataLen())
+        length = self->GetDataLen() - index;
+    if (index < 0 || length <= 0)
+        return 0;
+    int count = 0;
+    while (count < length) {
+        unsigned char returns = ((unsigned char *)(self->GetData()))[index + count];
+        lua_pushnumber(L, returns);
+        count++;
+    }
+    return length;
+}
+
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_Clear[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_Clear(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_Clear[1] = {{ wxLua_wxMemoryBuffer_Clear, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_Clear }};
+//     void Clear();
+static int LUACALL wxLua_wxMemoryBuffer_Clear(lua_State *L)
+{
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call Clear
+    self->Clear();
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_Fill[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_Fill(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_Fill[1] = {{ wxLua_wxMemoryBuffer_Fill, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxMemoryBuffer_Fill }};
+// %override wxLua_wxMemoryBuffer_Fill
+//     void Fill(unsigned char data, int start_index, size_t length);
+static int LUACALL wxLua_wxMemoryBuffer_Fill(lua_State *L)
+{
+    // size_t length
+    size_t length = (size_t)wxlua_getnumbertype(L, 4);
+    // int start_index
+    int start_index = (int)wxlua_getnumbertype(L, 3);
+    // unsigned char data
+    int data = (unsigned char)wxlua_getnumbertype(L, 2);
+    wxASSERT_MSG(start_index >= 0, "index out of range");
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    if (length <= 0)
+        return 0;  //  Do nothing
+    // get data pointer
+    unsigned char *dptr = (unsigned char *)self->GetWriteBuf(start_index + length);
+    wxASSERT_MSG(dptr != NULL, "cannot reallocate buffer");
+    memset(dptr + start_index, data, length);
+    if (self->GetDataLen() < start_index + length)
+        self->SetDataLen(start_index + length);
+    return 0;
+}
+
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_GetAppendBuf[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_GetAppendBuf(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_GetAppendBuf[1] = {{ wxLua_wxMemoryBuffer_GetAppendBuf, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_GetAppendBuf }};
+//     void *GetAppendBuf(size_t sizeNeeded);
+static int LUACALL wxLua_wxMemoryBuffer_GetAppendBuf(lua_State *L)
+{
+    // size_t sizeNeeded
+    size_t sizeNeeded = (size_t)wxlua_getuintegertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call GetAppendBuf
+    void* returns = (void*)self->GetAppendBuf(sizeNeeded);
+    // push the result pointer
+    lua_pushlightuserdata(L, (void *)returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_GetBufSize[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_GetBufSize(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_GetBufSize[1] = {{ wxLua_wxMemoryBuffer_GetBufSize, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_GetBufSize }};
+//     size_t GetBufSize() const;
+static int LUACALL wxLua_wxMemoryBuffer_GetBufSize(lua_State *L)
+{
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call GetBufSize
+    size_t returns = (self->GetBufSize());
+    // push the result number
+#if LUA_VERSION_NUM >= 503
+if ((double)(lua_Integer)returns == (double)returns) {
+    // Exactly representable as lua_Integer
+    lua_pushinteger(L, returns);
+} else
+#endif
+    lua_pushnumber(L, returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_GetData[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_GetData(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_GetData[1] = {{ wxLua_wxMemoryBuffer_GetData, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_GetData }};
+//     void  *GetData() const;
+static int LUACALL wxLua_wxMemoryBuffer_GetData(lua_State *L)
+{
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call GetData
+    void* returns = (void*)self->GetData();
+    // push the result pointer
+    lua_pushlightuserdata(L, (void *)returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_GetDataLen[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_GetDataLen(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_GetDataLen[1] = {{ wxLua_wxMemoryBuffer_GetDataLen, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_GetDataLen }};
+//     size_t GetDataLen() const;
+static int LUACALL wxLua_wxMemoryBuffer_GetDataLen(lua_State *L)
+{
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call GetDataLen
+    size_t returns = (self->GetDataLen());
+    // push the result number
+#if LUA_VERSION_NUM >= 503
+if ((double)(lua_Integer)returns == (double)returns) {
+    // Exactly representable as lua_Integer
+    lua_pushinteger(L, returns);
+} else
+#endif
+    lua_pushnumber(L, returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_GetWriteBuf[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_GetWriteBuf(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_GetWriteBuf[1] = {{ wxLua_wxMemoryBuffer_GetWriteBuf, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_GetWriteBuf }};
+//     void *GetWriteBuf(size_t sizeNeeded);
+static int LUACALL wxLua_wxMemoryBuffer_GetWriteBuf(lua_State *L)
+{
+    // size_t sizeNeeded
+    size_t sizeNeeded = (size_t)wxlua_getuintegertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call GetWriteBuf
+    void* returns = (void*)self->GetWriteBuf(sizeNeeded);
+    // push the result pointer
+    lua_pushlightuserdata(L, (void *)returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_IsEmpty[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_IsEmpty(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_IsEmpty[1] = {{ wxLua_wxMemoryBuffer_IsEmpty, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_IsEmpty }};
+//     bool IsEmpty() const;
+static int LUACALL wxLua_wxMemoryBuffer_IsEmpty(lua_State *L)
+{
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call IsEmpty
+    bool returns = (self->IsEmpty());
+    // push the result flag
+    lua_pushboolean(L, returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_SetBufSize[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_SetBufSize(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_SetBufSize[1] = {{ wxLua_wxMemoryBuffer_SetBufSize, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_SetBufSize }};
+//     void   SetBufSize(size_t size);
+static int LUACALL wxLua_wxMemoryBuffer_SetBufSize(lua_State *L)
+{
+    // size_t size
+    size_t size = (size_t)wxlua_getuintegertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call SetBufSize
+    self->SetBufSize(size);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_SetByte[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TNUMBER, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_SetByte(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_SetByte[1] = {{ wxLua_wxMemoryBuffer_SetByte, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxMemoryBuffer_SetByte }};
+// %override wxLua_wxMemoryBuffer_SetByte
+//     void SetByte(int index, unsigned char data);
+static int LUACALL wxLua_wxMemoryBuffer_SetByte(lua_State *L)
+{
+    // int index
+    int index = (int)wxlua_getnumbertype(L, 2);
+    wxASSERT_MSG(index >= 0, "index out of range");
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // more data? (optional)
+    int length = lua_gettop(L) - 2;
+    if (length <= 0)
+        return 0;  //  Do nothing
+    // get data pointer
+    unsigned char *dptr = (unsigned char *)self->GetWriteBuf(index + length);
+    wxASSERT_MSG(dptr != NULL, "cannot reallocate buffer");
+    int count = 0;
+    while (count < length) {
+        ((unsigned char *)(self->GetData()))[index + count] = (unsigned char)wxlua_getnumbertype(L, 3 + count);
+        count++;
+    }
+    if (self->GetDataLen() < index + length)
+        self->SetDataLen(index + length);
+    return 0;
+}
+
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_SetDataLen[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_SetDataLen(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_SetDataLen[1] = {{ wxLua_wxMemoryBuffer_SetDataLen, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_SetDataLen }};
+//     void   SetDataLen(size_t len);
+static int LUACALL wxLua_wxMemoryBuffer_SetDataLen(lua_State *L)
+{
+    // size_t len
+    size_t len = (size_t)wxlua_getuintegertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call SetDataLen
+    self->SetDataLen(len);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_UngetAppendBuf[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_UngetAppendBuf(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_UngetAppendBuf[1] = {{ wxLua_wxMemoryBuffer_UngetAppendBuf, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_UngetAppendBuf }};
+//     void  UngetAppendBuf(size_t sizeUsed);
+static int LUACALL wxLua_wxMemoryBuffer_UngetAppendBuf(lua_State *L)
+{
+    // size_t sizeUsed
+    size_t sizeUsed = (size_t)wxlua_getuintegertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call UngetAppendBuf
+    self->UngetAppendBuf(sizeUsed);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_UngetWriteBuf[] = { &wxluatype_wxMemoryBuffer, &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_UngetWriteBuf(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_UngetWriteBuf[1] = {{ wxLua_wxMemoryBuffer_UngetWriteBuf, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxMemoryBuffer_UngetWriteBuf }};
+//     void  UngetWriteBuf(size_t sizeUsed);
+static int LUACALL wxLua_wxMemoryBuffer_UngetWriteBuf(lua_State *L)
+{
+    // size_t sizeUsed
+    size_t sizeUsed = (size_t)wxlua_getuintegertype(L, 2);
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call UngetWriteBuf
+    self->UngetWriteBuf(sizeUsed);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_delete[] = { &wxluatype_wxMemoryBuffer, NULL };
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_delete }};
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_release[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_release(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_release[1] = {{ wxLua_wxMemoryBuffer_release, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_release }};
+//     void *release();
+static int LUACALL wxLua_wxMemoryBuffer_release(lua_State *L)
+{
+    // get this
+    wxMemoryBuffer * self = (wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call release
+    void* returns = (void*)self->release();
+    // push the result pointer
+    lua_pushlightuserdata(L, (void *)returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_constructor1[] = { &wxluatype_wxMemoryBuffer, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_constructor1(lua_State *L);
+// static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_constructor1[1] = {{ wxLua_wxMemoryBuffer_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_constructor1 }};
+//     wxMemoryBuffer(const wxMemoryBuffer& src);
+static int LUACALL wxLua_wxMemoryBuffer_constructor1(lua_State *L)
+{
+    // const wxMemoryBuffer src
+    const wxMemoryBuffer * src = (const wxMemoryBuffer *)wxluaT_getuserdatatype(L, 1, wxluatype_wxMemoryBuffer);
+    // call constructor
+    wxMemoryBuffer* returns = new wxMemoryBuffer(*src);
+    // add to tracked memory list
+    wxluaO_addgcobject(L, returns, wxluatype_wxMemoryBuffer);
+    // push the constructed class pointer
+    wxluaT_pushuserdatatype(L, returns, wxluatype_wxMemoryBuffer);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxMemoryBuffer_constructor[] = { &wxluatype_TINTEGER, NULL };
+static int LUACALL wxLua_wxMemoryBuffer_constructor(lua_State *L);
+// static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_constructor[1] = {{ wxLua_wxMemoryBuffer_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_constructor }};
+//     wxMemoryBuffer(size_t size = wxMemoryBufferData::DefBufSize);
+static int LUACALL wxLua_wxMemoryBuffer_constructor(lua_State *L)
+{
+    // get number of arguments
+    int argCount = lua_gettop(L);
+    // size_t size = wxMemoryBufferData::DefBufSize
+    size_t size = (argCount >= 1 ? (size_t)wxlua_getuintegertype(L, 1) : wxMemoryBufferData::DefBufSize);
+    // call constructor
+    wxMemoryBuffer* returns = new wxMemoryBuffer(size);
+    // add to tracked memory list
+    wxluaO_addgcobject(L, returns, wxluatype_wxMemoryBuffer);
+    // push the constructed class pointer
+    wxluaT_pushuserdatatype(L, returns, wxluatype_wxMemoryBuffer);
+
+    return 1;
+}
+
+
+
+
+#if (wxLUA_USE_wxMemoryBuffer)
+// function overload table
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxMemoryBuffer_constructor_overload[] =
+{
+    { wxLua_wxMemoryBuffer_constructor1, WXLUAMETHOD_CONSTRUCTOR, 1, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_constructor1 },
+    { wxLua_wxMemoryBuffer_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 1, s_wxluatypeArray_wxLua_wxMemoryBuffer_constructor },
+};
+static int s_wxluafunc_wxLua_wxMemoryBuffer_constructor_overload_count = sizeof(s_wxluafunc_wxLua_wxMemoryBuffer_constructor_overload)/sizeof(wxLuaBindCFunc);
+
+#endif // (wxLUA_USE_wxMemoryBuffer)
+
+void wxLua_wxMemoryBuffer_delete_function(void** p)
+{
+    wxMemoryBuffer* o = (wxMemoryBuffer*)(*p);
+    delete o;
+}
+
+// Map Lua Class Methods to C Binding Functions
+wxLuaBindMethod wxMemoryBuffer_methods[] = {
+    { "AppendByte", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_AppendByte, 1, NULL },
+    { "AppendData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_AppendData, 1, NULL },
+    { "Byte", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_Byte, 1, NULL },
+    { "Clear", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_Clear, 1, NULL },
+    { "Fill", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_Fill, 1, NULL },
+    { "GetAppendBuf", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_GetAppendBuf, 1, NULL },
+    { "GetBufSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_GetBufSize, 1, NULL },
+    { "GetData", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_GetData, 1, NULL },
+    { "GetDataLen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_GetDataLen, 1, NULL },
+    { "GetWriteBuf", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_GetWriteBuf, 1, NULL },
+    { "IsEmpty", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_IsEmpty, 1, NULL },
+    { "SetBufSize", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_SetBufSize, 1, NULL },
+    { "SetByte", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_SetByte, 1, NULL },
+    { "SetDataLen", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_SetDataLen, 1, NULL },
+    { "UngetAppendBuf", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_UngetAppendBuf, 1, NULL },
+    { "UngetWriteBuf", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_UngetWriteBuf, 1, NULL },
+    { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxMemoryBuffer_delete, 1, NULL },
+    { "release", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxMemoryBuffer_release, 1, NULL },
+
+#if (wxLUA_USE_wxMemoryBuffer)
+    { "wxMemoryBuffer", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxMemoryBuffer_constructor_overload, s_wxluafunc_wxLua_wxMemoryBuffer_constructor_overload_count, 0 },
+#endif // (wxLUA_USE_wxMemoryBuffer)
+
+    { 0, 0, 0, 0 },
+};
+
+int wxMemoryBuffer_methodCount = sizeof(wxMemoryBuffer_methods)/sizeof(wxLuaBindMethod) - 1;
+
+#endif  // wxLUA_USE_wxMemoryBuffer
 

--- a/wxLua/modules/wxbind/src/wxcore_gdi.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_gdi.cpp
@@ -10122,15 +10122,15 @@ static int LUACALL wxLua_wxPalette_constructor2(lua_State *L);
 static int LUACALL wxLua_wxPalette_constructor2(lua_State *L)
 {
     // const unsigned char blue
-    wxCharBuffer blue = wxlua_getstringtype(L, 4);
+    const unsigned char * blue = (const unsigned char *)wxlua_getstringtype(L, 4);
     // const unsigned char green
-    wxCharBuffer green = wxlua_getstringtype(L, 3);
+    const unsigned char * green = (const unsigned char *)wxlua_getstringtype(L, 3);
     // const unsigned char red
-    wxCharBuffer red = wxlua_getstringtype(L, 2);
+    const unsigned char * red = (const unsigned char *)wxlua_getstringtype(L, 2);
     // int n
     int n = (int)wxlua_getnumbertype(L, 1);
     // call constructor
-    wxPalette* returns = new wxPalette(n, (const unsigned char*)(const char*)red, (const unsigned char*)(const char*)green, (const unsigned char*)(const char*)blue);
+    wxPalette* returns = new wxPalette(n, red, green, blue);
     // add to tracked memory list
     wxluaO_addgcobject(L, returns, wxluatype_wxPalette);
     // push the constructed class pointer

--- a/wxLua/modules/wxbind/src/wxcore_image.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_image.cpp
@@ -391,15 +391,15 @@ static int LUACALL wxLua_wxImage_Create5(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 5 ? wxlua_getbooleantype(L, 5) : false);
     // unsigned char alpha
-    wxCharBuffer alpha = wxlua_getstringtype(L, 4);
+    unsigned char * alpha = (unsigned char *)wxlua_getstringtype(L, 4);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 3);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 3);
     // const wxSize sz
     const wxSize * sz = (const wxSize *)wxluaT_getuserdatatype(L, 2, wxluatype_wxSize);
     // get this
     wxImage * self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call Create
-    bool returns = (self->Create(*sz, (unsigned char*)(const char*)data, (unsigned char*)(const char*)alpha, static_data));
+    bool returns = (self->Create(*sz, data, alpha, static_data));
     // push the result flag
     lua_pushboolean(L, returns);
 
@@ -420,9 +420,9 @@ static int LUACALL wxLua_wxImage_Create4(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 6 ? wxlua_getbooleantype(L, 6) : false);
     // unsigned char alpha
-    wxCharBuffer alpha = wxlua_getstringtype(L, 5);
+    unsigned char * alpha = (unsigned char *)wxlua_getstringtype(L, 5);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 4);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 4);
     // int height
     int height = (int)wxlua_getnumbertype(L, 3);
     // int width
@@ -430,7 +430,7 @@ static int LUACALL wxLua_wxImage_Create4(lua_State *L)
     // get this
     wxImage * self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call Create
-    bool returns = (self->Create(width, height, (unsigned char*)(const char*)data, (unsigned char*)(const char*)alpha, static_data));
+    bool returns = (self->Create(width, height, data, alpha, static_data));
     // push the result flag
     lua_pushboolean(L, returns);
 
@@ -451,13 +451,13 @@ static int LUACALL wxLua_wxImage_Create3(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 4 ? wxlua_getbooleantype(L, 4) : false);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 3);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 3);
     // const wxSize sz
     const wxSize * sz = (const wxSize *)wxluaT_getuserdatatype(L, 2, wxluatype_wxSize);
     // get this
     wxImage * self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call Create
-    bool returns = (self->Create(*sz, (unsigned char*)(const char*)data, static_data));
+    bool returns = (self->Create(*sz, data, static_data));
     // push the result flag
     lua_pushboolean(L, returns);
 
@@ -478,7 +478,7 @@ static int LUACALL wxLua_wxImage_Create2(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 5 ? wxlua_getbooleantype(L, 5) : false);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 4);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 4);
     // int height
     int height = (int)wxlua_getnumbertype(L, 3);
     // int width
@@ -486,7 +486,7 @@ static int LUACALL wxLua_wxImage_Create2(lua_State *L)
     // get this
     wxImage * self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call Create
-    bool returns = (self->Create(width, height, (unsigned char*)(const char*)data, static_data));
+    bool returns = (self->Create(width, height, data, static_data));
     // push the result flag
     lua_pushboolean(L, returns);
 
@@ -2114,7 +2114,7 @@ static int LUACALL wxLua_wxImage_SetAlphaData(lua_State *L)
 {
     // unsigned char *data
     size_t len = 0;
-    unsigned char *data = (unsigned char *)lua_tolstring(L, 2, &len);
+    unsigned char *data = (unsigned char *)wxlua_getstringtypelen(L, 2, &len);
     // get this
     wxImage *self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call SetData
@@ -2162,11 +2162,11 @@ static int LUACALL wxLua_wxImage_SetAlpha(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 3 ? wxlua_getbooleantype(L, 3) : false);
     // unsigned char alpha = NULL
-    wxCharBuffer alpha = (argCount >= 2 ? wxlua_getstringtype(L, 2) : NULL);
+    unsigned char * alpha = (argCount >= 2 ? (unsigned char *)wxlua_getstringtype(L, 2) : NULL);
     // get this
     wxImage * self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call SetAlpha
-    self->SetAlpha((unsigned char*)(const char*)alpha, static_data);
+    self->SetAlpha(alpha, static_data);
 
     return 0;
 }
@@ -2182,7 +2182,7 @@ static int LUACALL wxLua_wxImage_SetData(lua_State *L)
 {
     // unsigned char *data
     size_t len = 0;
-    unsigned char *data = (unsigned char *)lua_tolstring(L, 2, &len);
+    unsigned char *data = (unsigned char *)wxlua_getstringtypelen(L, 2, &len);
     // get this
     wxImage *self = (wxImage *)wxluaT_getuserdatatype(L, 1, wxluatype_wxImage);
     // call SetData
@@ -2511,7 +2511,7 @@ static int LUACALL wxLua_wxImageFromData_constructor(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 4 ? wxlua_getbooleantype(L, 4) : false);
     // unsigned char* data
-    unsigned char *data = (unsigned char *)lua_tostring(L, 3);
+    unsigned char *data = (unsigned char *)wxlua_getstringtype(L, 3);
     // int height
     int height = (int)wxlua_getintegertype(L, 2);
     // int width
@@ -2709,13 +2709,13 @@ static int LUACALL wxLua_wxImage_constructor5(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 4 ? wxlua_getbooleantype(L, 4) : false);
     // unsigned char alpha
-    wxCharBuffer alpha = wxlua_getstringtype(L, 3);
+    unsigned char * alpha = (unsigned char *)wxlua_getstringtype(L, 3);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 2);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 2);
     // const wxSize sz
     const wxSize * sz = (const wxSize *)wxluaT_getuserdatatype(L, 1, wxluatype_wxSize);
     // call constructor
-    wxImage* returns = new wxImage(*sz, (unsigned char*)(const char*)data, (unsigned char*)(const char*)alpha, static_data);
+    wxImage* returns = new wxImage(*sz, data, alpha, static_data);
     // add to tracked memory list
     wxluaO_addgcobject(L, returns, wxluatype_wxImage);
     // push the constructed class pointer
@@ -2738,15 +2738,15 @@ static int LUACALL wxLua_wxImage_constructor4(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 5 ? wxlua_getbooleantype(L, 5) : false);
     // unsigned char alpha
-    wxCharBuffer alpha = wxlua_getstringtype(L, 4);
+    unsigned char * alpha = (unsigned char *)wxlua_getstringtype(L, 4);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 3);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 3);
     // int height
     int height = (int)wxlua_getnumbertype(L, 2);
     // int width
     int width = (int)wxlua_getnumbertype(L, 1);
     // call constructor
-    wxImage* returns = new wxImage(width, height, (unsigned char*)(const char*)data, (unsigned char*)(const char*)alpha, static_data);
+    wxImage* returns = new wxImage(width, height, data, alpha, static_data);
     // add to tracked memory list
     wxluaO_addgcobject(L, returns, wxluatype_wxImage);
     // push the constructed class pointer
@@ -2769,11 +2769,11 @@ static int LUACALL wxLua_wxImage_constructor3(lua_State *L)
     // bool static_data = false
     bool static_data = (argCount >= 3 ? wxlua_getbooleantype(L, 3) : false);
     // unsigned char data
-    wxCharBuffer data = wxlua_getstringtype(L, 2);
+    unsigned char * data = (unsigned char *)wxlua_getstringtype(L, 2);
     // const wxSize sz
     const wxSize * sz = (const wxSize *)wxluaT_getuserdatatype(L, 1, wxluatype_wxSize);
     // call constructor
-    wxImage* returns = new wxImage(*sz, (unsigned char*)(const char*)data, static_data);
+    wxImage* returns = new wxImage(*sz, data, static_data);
     // add to tracked memory list
     wxluaO_addgcobject(L, returns, wxluatype_wxImage);
     // push the constructed class pointer

--- a/wxLua/modules/wxbind/src/wxgl_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxgl_bind.cpp
@@ -71,9 +71,9 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxGLCanvas_IsExtensionSupported[1] = {{ 
 static int LUACALL wxLua_wxGLCanvas_IsExtensionSupported(lua_State *L)
 {
     // const char extension
-    wxCharBuffer extension = wxlua_getstringtype(L, 1);
+    const char * extension = wxlua_getstringtype(L, 1);
     // call IsExtensionSupported
-    bool returns = (wxGLCanvas::IsExtensionSupported((const char*)extension));
+    bool returns = (wxGLCanvas::IsExtensionSupported(extension));
     // push the result flag
     lua_pushboolean(L, returns);
 

--- a/wxLua/modules/wxbind/src/wxstc_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxstc_bind.cpp
@@ -123,11 +123,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_AddTextRaw(lua_State *L)
     // int length = -1
     int length = (argCount >= 3 ? (int)wxlua_getnumbertype(L, 3) : -1);
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 2);
+    const char * text = wxlua_getstringtype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call AddTextRaw
-    self->AddTextRaw((const char*)text, length);
+    self->AddTextRaw(text, length);
 
     return 0;
 }
@@ -498,11 +498,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_AppendTextRaw(lua_State *L)
     // int length = -1
     int length = (argCount >= 3 ? (int)wxlua_getnumbertype(L, 3) : -1);
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 2);
+    const char * text = wxlua_getstringtype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call AppendTextRaw
-    self->AppendTextRaw((const char*)text, length);
+    self->AppendTextRaw(text, length);
 
     return 0;
 }
@@ -7431,13 +7431,13 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_InsertTextRaw[1] = {{ w
 static int LUACALL wxLua_wxStyledTextCtrl_InsertTextRaw(lua_State *L)
 {
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 3);
+    const char * text = wxlua_getstringtype(L, 3);
     // int pos
     int pos = (int)wxlua_getnumbertype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call InsertTextRaw
-    self->InsertTextRaw(pos, (const char*)text);
+    self->InsertTextRaw(pos, text);
 
     return 0;
 }
@@ -8231,13 +8231,13 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_MarkerDefineRGBAImage[1
 static int LUACALL wxLua_wxStyledTextCtrl_MarkerDefineRGBAImage(lua_State *L)
 {
     // const unsigned char pixels
-    wxCharBuffer pixels = wxlua_getstringtype(L, 3);
+    const unsigned char * pixels = (const unsigned char *)wxlua_getstringtype(L, 3);
     // int markerNumber
     int markerNumber = (int)wxlua_getnumbertype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call MarkerDefineRGBAImage
-    self->MarkerDefineRGBAImage(markerNumber, (const unsigned char*)(const char*)pixels);
+    self->MarkerDefineRGBAImage(markerNumber, pixels);
 
     return 0;
 }
@@ -9195,13 +9195,13 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_RegisterRGBAImage[1] = 
 static int LUACALL wxLua_wxStyledTextCtrl_RegisterRGBAImage(lua_State *L)
 {
     // const unsigned char pixels
-    wxCharBuffer pixels = wxlua_getstringtype(L, 3);
+    const unsigned char * pixels = (const unsigned char *)wxlua_getstringtype(L, 3);
     // int type
     int type = (int)wxlua_getnumbertype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call RegisterRGBAImage
-    self->RegisterRGBAImage(type, (const unsigned char*)(const char*)pixels);
+    self->RegisterRGBAImage(type, pixels);
 
     return 0;
 }
@@ -9266,11 +9266,11 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_ReplaceSelectionRaw[1] 
 static int LUACALL wxLua_wxStyledTextCtrl_ReplaceSelectionRaw(lua_State *L)
 {
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 2);
+    const char * text = wxlua_getstringtype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call ReplaceSelectionRaw
-    self->ReplaceSelectionRaw((const char*)text);
+    self->ReplaceSelectionRaw(text);
 
     return 0;
 }
@@ -9338,11 +9338,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_ReplaceTargetRERaw(lua_State *L)
     // int length = -1
     int length = (argCount >= 3 ? (int)wxlua_getnumbertype(L, 3) : -1);
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 2);
+    const char * text = wxlua_getstringtype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call ReplaceTargetRERaw
-    int returns = (self->ReplaceTargetRERaw((const char*)text, length));
+    int returns = (self->ReplaceTargetRERaw(text, length));
     // push the result number
 #if LUA_VERSION_NUM >= 503
 if ((double)(lua_Integer)returns == (double)returns) {
@@ -9366,11 +9366,11 @@ static int LUACALL wxLua_wxStyledTextCtrl_ReplaceTargetRaw(lua_State *L)
     // int length = -1
     int length = (argCount >= 3 ? (int)wxlua_getnumbertype(L, 3) : -1);
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 2);
+    const char * text = wxlua_getstringtype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call ReplaceTargetRaw
-    int returns = (self->ReplaceTargetRaw((const char*)text, length));
+    int returns = (self->ReplaceTargetRaw(text, length));
     // push the result number
 #if LUA_VERSION_NUM >= 503
 if ((double)(lua_Integer)returns == (double)returns) {
@@ -12062,11 +12062,11 @@ static wxLuaBindCFunc s_wxluafunc_wxLua_wxStyledTextCtrl_SetTextRaw[1] = {{ wxLu
 static int LUACALL wxLua_wxStyledTextCtrl_SetTextRaw(lua_State *L)
 {
     // const char text
-    wxCharBuffer text = wxlua_getstringtype(L, 2);
+    const char * text = wxlua_getstringtype(L, 2);
     // get this
     wxStyledTextCtrl * self = (wxStyledTextCtrl *)wxluaT_getuserdatatype(L, 1, wxluatype_wxStyledTextCtrl);
     // call SetTextRaw
-    self->SetTextRaw((const char*)text);
+    self->SetTextRaw(text);
 
     return 0;
 }

--- a/wxLua/modules/wxlua/wxllua.h
+++ b/wxLua/modules/wxlua/wxllua.h
@@ -500,6 +500,7 @@ WXDLLIMPEXP_WXLUA bool wxlua_iswxstringtype(lua_State* L, int stack_idx);
 //   parameter to a function call. (These are used in the bindings)
 // Note: The function wxLuaState::GetwxStringType does automatic conversion
 //       of both a Lua string and a userdata wxString to a wxString.
+WXDLLIMPEXP_WXLUA const char* LUACALL wxlua_getstringtypelen(lua_State* L, int stack_idx, size_t *len);
 WXDLLIMPEXP_WXLUA const char* LUACALL wxlua_getstringtype(lua_State* L, int stack_idx);
 WXDLLIMPEXP_WXLUA wxString LUACALL    wxlua_getwxStringtype(lua_State* L, int stack_idx);
 WXDLLIMPEXP_WXLUA bool LUACALL        wxlua_getbooleantype(lua_State* L, int stack_idx);


### PR DESCRIPTION
Sorry, this is a very long post...

[[ Background ]]
I am trying to write a program which programatically creates a wxImage and display it by using wxPaintDC:DrawBitmap(). However, I am running into several problems:
(1) I cannot find a good way to allocate a block of memory, modify its content, and pass it to a constructor of wxImage. Maybe wxMemoryBuffer is the solution.
(2) There are several constructors of wxImage that accept RGB data on memory, but the handling of the data are different among the constructors. wxImage(int width, int height, unsigned char* data, bool static_data = false) retrieves 'data' by lua_string() (which means only a Lua string can be given), whereas other versions retrieve 'data' by wxlua_getstringtype() (which accepts a Lua string and a wxString, but not other types).
(3) Then I tried to implement wxMemoryBuffer, and modify wxlua_getstringtype() to accept wxMemoryBuffer as 'const char*' data block. However, the return value of wxlua_getstringtype() (which has a type of 'const char*') is casted into wxCharBuffer before use. This causes data loss after the first NULL byte, because wxCharBuffer internally copies the given data by wxStrdup(). To fix this, I need to modify genwxbind.lua.

After struggling for a while, I made into the following set of modifications. I am not at all sure whether this is a good (or even acceptable) solution, so I would like it to be reviewed carefully. Thank you for your time.

[[ Issue 1: Handling of "char *" type arguments are changed ]]
[genwxbind.lua]
Currently, arguments with "char *" type (char *, const char *, unsigned char *, const unsigned char *) are processed with wxlua_getstringtype(), and the return value (whose type is "const char *") is casted into wxCharBuffer, and then casted back to the requested type. This causes a problem when the given argument has a NULL character.
Proposed fix: stop casting to wxCharBuffer, and use the return value of wxlua_getstringtype() directly and directly cast it into the required pointer type.

[[ Issue 2: Add definition of wxMemoryBuffer ]]
[wxbase_data.i]
Add definition of wxMemoryBuffer. Three new methods are implemented:
Byte(index, length = 1) -> returns the byte value (unsigned char) at the given index (0-based). If length larger than 1 is given, then multiple values are returned.
SetByte(index, data[, data2, data3, ...]) -> Set the byte data at the given index (0-based). If more than one data are given, they are set at the subsequent slots. Data length and buffer size are updated if necessary.
Fill(data, start_index, length) -> Set the same byte in the given range of the buffer. Data length and buffer size are updated if necessary.
[wxbase_override.hpp]
Implementation of wxLua_wxMemoryBuffer_Byte(), wxLua_wxMemoryBuffer_SetByte(), and wxLua_wxMemoryBuffer_Fill() are written.
[wxluasetup.h]
#define wxLUA_USE_wxMemoryBuffer 1  is added.

[[ Issue 3: Make wxMemoryBuffer usable as a 'string-type' argument ]]
[wxllua.cpp]
wxlua_getstringtype() and wxluaT_isuserdatatype() are modified, so that wxMemoryBuffer is accepted as a string-type argument.
wxlua_getstringtypelen() is implemented, so that the length of the 'string-type' argument can be retrieved whenever necessary.
[wxllua.h]
Declaration of wxlua_getstringtypelen() is added.

[[ Issue 4: Some wxImage methods are modified to allow wxString and wxMemoryBuffer as arguments for unsigned char* ]]
[wxcore_override.hpp]
wxLua_wxImageFromData_constructor(), wxLua_wxImage_SetAlphaData(), and wxLua_wxImage_SetData() are modified, so that they use wxlua_getstringtype() or wxlua_getstringtypelen() instead of lua_string() or lua_lstring().
