### PR TITLE
Event type aliases (wxEVT_XXXX for wxEVT_COMMAND_XXXX)

### DIFF
--- a/wxLua/bindings/wxwidgets/wxadv_adv.i
+++ b/wxLua/bindings/wxwidgets/wxadv_adv.i
@@ -366,6 +366,7 @@ class wxHyperlinkCtrl : public wxControl
 class %delete wxHyperlinkEvent : public wxCommandEvent
 {
     %wxEventType wxEVT_COMMAND_HYPERLINK // EVT_HYPERLINK(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_HYPERLINK  // wx3.0 alias for wxEVT_COMMAND_HYPERLINK
 
     //wxHyperlinkEvent();
     wxHyperlinkEvent(wxObject *generator, wxWindowID id, const wxString& url);

--- a/wxLua/bindings/wxwidgets/wxaui_aui.i
+++ b/wxLua/bindings/wxwidgets/wxaui_aui.i
@@ -59,6 +59,12 @@ class wxAuiToolBarEvent : public wxNotifyEvent
     %wxEventType wxEVT_COMMAND_AUITOOLBAR_MIDDLE_CLICK    // EVT_AUITOOLBAR_MIDDLE_CLICK(winid, fn)
     %wxEventType wxEVT_COMMAND_AUITOOLBAR_BEGIN_DRAG      // EVT_AUITOOLBAR_BEGIN_DRAG(winid, fn)
 
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUITOOLBAR_TOOL_DROPDOWN  // wx3.0 alias for wxEVT_COMMAND_AUITOOLBAR_TOOL_DROPDOWN
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUITOOLBAR_OVERFLOW_CLICK // wx3.0 alias for wxEVT_COMMAND_AUITOOLBAR_OVERFLOW_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUITOOLBAR_RIGHT_CLICK    // wx3.0 alias for wxEVT_COMMAND_AUITOOLBAR_RIGHT_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUITOOLBAR_MIDDLE_CLICK   // wx3.0 alias for wxEVT_COMMAND_AUITOOLBAR_MIDDLE_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUITOOLBAR_BEGIN_DRAG     // wx3.0 alias for wxEVT_COMMAND_AUITOOLBAR_BEGIN_DRAG
+
     wxAuiToolBarEvent(wxEventType command_type = wxEVT_NULL, int win_id = 0);
     wxAuiToolBarEvent(const wxAuiToolBarEvent& c);
 
@@ -296,6 +302,15 @@ class %delete wxAuiNotebookEvent : public wxNotifyEvent
     %wxEventType wxEVT_COMMAND_AUINOTEBOOK_DRAG_MOTION     // EVT_AUINOTEBOOK_DRAG_MOTION(winid, fn);
     %wxEventType wxEVT_COMMAND_AUINOTEBOOK_ALLOW_DND       // EVT_AUINOTEBOOK_ALLOW_DND(winid, fn);
 
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_PAGE_CLOSE    // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_PAGE_CLOSE
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_PAGE_CHANGED  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_PAGE_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_PAGE_CHANGING // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_PAGE_CHANGING
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_BUTTON        // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_BUTTON
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_BEGIN_DRAG    // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_BEGIN_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_END_DRAG      // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_END_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_DRAG_MOTION   // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_DRAG_MOTION
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_ALLOW_DND     // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_ALLOW_DND
+
 #if %wxchkver_2_8_5
     %wxEventType wxEVT_COMMAND_AUINOTEBOOK_TAB_MIDDLE_DOWN // EVT_AUINOTEBOOK_TAB_MIDDLE_DOWN(winid, fn);
     %wxEventType wxEVT_COMMAND_AUINOTEBOOK_TAB_MIDDLE_UP   // EVT_AUINOTEBOOK_TAB_MIDDLE_UP(winid, fn);
@@ -305,6 +320,14 @@ class %delete wxAuiNotebookEvent : public wxNotifyEvent
     %wxEventType wxEVT_COMMAND_AUINOTEBOOK_DRAG_DONE       // EVT_AUINOTEBOOK_DRAG_DONE(winid, fn);
     %wxEventType wxEVT_COMMAND_AUINOTEBOOK_BG_DCLICK       // EVT_AUINOTEBOOK_BG_DCLICK(winid, fn);
 #endif //%wxchkver_2_8_5
+
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_TAB_MIDDLE_DOWN  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_TAB_MIDDLE_DOWN
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_TAB_MIDDLE_UP  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_TAB_MIDDLE_UP
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_TAB_RIGHT_DOWN
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_TAB_RIGHT_UP  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_TAB_RIGHT_UP
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_PAGE_CLOSED  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_PAGE_CLOSED
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_DRAG_DONE  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_DRAG_DONE
+    %wxchkver_3_0_0 %wxEventType wxEVT_AUINOTEBOOK_BG_DCLICK  // wx3.0 alias for wxEVT_COMMAND_AUINOTEBOOK_BG_DCLICK
 
     wxAuiNotebookEvent(wxEventType command_type = wxEVT_NULL, int win_id = 0);
     wxAuiNotebookEvent(const wxAuiNotebookEvent& c);

--- a/wxLua/bindings/wxwidgets/wxcore_clipdrag.i
+++ b/wxLua/bindings/wxwidgets/wxcore_clipdrag.i
@@ -56,6 +56,9 @@ class %delete wxClipboardTextEvent : public wxCommandEvent
     %wxEventType wxEVT_COMMAND_TEXT_COPY   // EVT_TEXT_COPY(winid, func);
     %wxEventType wxEVT_COMMAND_TEXT_CUT    // EVT_TEXT_CUT(winid, func);
     %wxEventType wxEVT_COMMAND_TEXT_PASTE  // EVT_TEXT_PASTE(winid, func);
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT_COPY  // wx3.0 alias for wxEVT_COMMAND_TEXT_COPY
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT_CUT   // wx3.0 alias for wxEVT_COMMAND_TEXT_CUT
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT_PASTE // wx3.0 alias for wxEVT_COMMAND_TEXT_PASTE
 
     wxClipboardTextEvent(wxEventType type = wxEVT_NULL, wxWindowID winid = 0);
 };

--- a/wxLua/bindings/wxwidgets/wxcore_controls.i
+++ b/wxLua/bindings/wxwidgets/wxcore_controls.i
@@ -663,6 +663,27 @@ class %delete wxListEvent : public wxNotifyEvent
     %wxEventType wxEVT_COMMAND_LIST_COL_END_DRAG           // EVT_LIST_COL_END_DRAG(id, fn);
     %wxEventType wxEVT_COMMAND_LIST_ITEM_FOCUSED           // EVT_LIST_ITEM_FOCUSED(id, fn);
 
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_BEGIN_DRAG       // wx3.0 alias for wxEVT_COMMAND_LIST_BEGIN_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_BEGIN_RDRAG      // wx3.0 alias for wxEVT_COMMAND_LIST_BEGIN_RDRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_BEGIN_LABEL_EDIT // wx3.0 alias for wxEVT_COMMAND_LIST_BEGIN_LABEL_EDIT
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_COL_CLICK        // wx3.0 alias for wxEVT_COMMAND_LIST_COL_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_DELETE_ALL_ITEMS // wx3.0 alias for wxEVT_COMMAND_LIST_DELETE_ALL_ITEMS
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_DELETE_ITEM      // wx3.0 alias for wxEVT_COMMAND_LIST_DELETE_ITEM
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_END_LABEL_EDIT   // wx3.0 alias for wxEVT_COMMAND_LIST_END_LABEL_EDIT
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_INSERT_ITEM      // wx3.0 alias for wxEVT_COMMAND_LIST_INSERT_ITEM
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_ITEM_ACTIVATED   // wx3.0 alias for wxEVT_COMMAND_LIST_ITEM_ACTIVATED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_ITEM_DESELECTED  // wx3.0 alias for wxEVT_COMMAND_LIST_ITEM_DESELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_ITEM_SELECTED    // wx3.0 alias for wxEVT_COMMAND_LIST_ITEM_SELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_KEY_DOWN         // wx3.0 alias for wxEVT_COMMAND_LIST_KEY_DOWN
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_CACHE_HINT       // wx3.0 alias for wxEVT_COMMAND_LIST_CACHE_HINT
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_COL_RIGHT_CLICK  // wx3.0 alias for wxEVT_COMMAND_LIST_COL_RIGHT_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_COL_BEGIN_DRAG   // wx3.0 alias for wxEVT_COMMAND_LIST_COL_BEGIN_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_COL_DRAGGING     // wx3.0 alias for wxEVT_COMMAND_LIST_COL_DRAGGING
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_COL_END_DRAG     // wx3.0 alias for wxEVT_COMMAND_LIST_COL_END_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_ITEM_FOCUSED     // wx3.0 alias for wxEVT_COMMAND_LIST_ITEM_FOCUSED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_ITEM_MIDDLE_CLICK // wx3.0 alias for wxEVT_COMMAND_LIST_ITEM_MIDDLE_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_LIST_ITEM_RIGHT_CLICK // wx3.0 alias for wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK
+
     wxListEvent(wxEventType commandType = 0, int id = 0);
 
     //long GetCacheFrom() const; // - only useful for virtual controls
@@ -1168,6 +1189,7 @@ class %delete wxTextAttr
 class %delete wxTextUrlEvent : public wxCommandEvent
 {
     %wxchkver_2_8_0 %wxEventType wxEVT_COMMAND_TEXT_URL        // EVT_TEXT_URL(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT_URL  // wx3.0 alias for wxEVT_COMMAND_TEXT_URL
 
     wxTextUrlEvent(int winid, const wxMouseEvent& evtMouse, long start, long end);
 
@@ -1461,6 +1483,28 @@ class %delete wxTreeEvent : public wxNotifyEvent
     %wxEventType wxEVT_COMMAND_TREE_ITEM_MENU         // EVT_TREE_ITEM_MENU(id, fn);
     %wxEventType wxEVT_COMMAND_TREE_STATE_IMAGE_CLICK // EVT_TREE_STATE_IMAGE_CLICK(id, fn);
     %wxEventType wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP   // EVT_TREE_ITEM_GETTOOLTIP(id, fn);
+
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_BEGIN_DRAG        // wx3.0 alias for wxEVT_COMMAND_TREE_BEGIN_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_BEGIN_LABEL_EDIT  // wx3.0 alias for wxEVT_COMMAND_TREE_BEGIN_LABEL_EDIT
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_BEGIN_RDRAG       // wx3.0 alias for wxEVT_COMMAND_TREE_BEGIN_RDRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_DELETE_ITEM       // wx3.0 alias for wxEVT_COMMAND_TREE_DELETE_ITEM
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_END_DRAG          // wx3.0 alias for wxEVT_COMMAND_TREE_END_DRAG
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_END_LABEL_EDIT    // wx3.0 alias for wxEVT_COMMAND_TREE_END_LABEL_EDIT
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_GET_INFO          // wx3.0 alias for wxEVT_COMMAND_TREE_GET_INFO
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_ACTIVATED    // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_ACTIVATED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_COLLAPSED    // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_COLLAPSED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_COLLAPSING   // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_COLLAPSING
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_EXPANDED     // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_EXPANDED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_EXPANDING    // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_EXPANDING
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_MIDDLE_CLICK // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_MIDDLE_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_RIGHT_CLICK  // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_RIGHT_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_KEY_DOWN          // wx3.0 alias for wxEVT_COMMAND_TREE_KEY_DOWN
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_SEL_CHANGED       // wx3.0 alias for wxEVT_COMMAND_TREE_SEL_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_SEL_CHANGING      // wx3.0 alias for wxEVT_COMMAND_TREE_SEL_CHANGING
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_SET_INFO          // wx3.0 alias for wxEVT_COMMAND_TREE_SET_INFO
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_MENU         // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_MENU
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_STATE_IMAGE_CLICK // wx3.0 alias for wxEVT_COMMAND_TREE_STATE_IMAGE_CLICK
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREE_ITEM_GETTOOLTIP   // wx3.0 alias for wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP
 
     wxTreeEvent(wxEventType commandType = wxEVT_NULL, int id = 0);
 

--- a/wxLua/bindings/wxwidgets/wxcore_dialogs.i
+++ b/wxLua/bindings/wxwidgets/wxcore_dialogs.i
@@ -442,6 +442,12 @@ class %delete wxFindDialogEvent : public wxCommandEvent
     %wxEventType wxEVT_COMMAND_FIND_REPLACE_ALL    // EVT_FIND_REPLACE_ALL(id, fn);
     %wxEventType wxEVT_COMMAND_FIND_CLOSE          // EVT_FIND_CLOSE(id, fn);
 
+    %wxchkver_3_0_0 %wxEventType wxEVT_FIND             // wx3.0 alias for wxEVT_COMMAND_FIND
+    %wxchkver_3_0_0 %wxEventType wxEVT_FIND_NEXT        // wx3.0 alias for wxEVT_COMMAND_FIND_NEXT
+    %wxchkver_3_0_0 %wxEventType wxEVT_FIND_REPLACE     // wx3.0 alias for wxEVT_COMMAND_FIND_REPLACE
+    %wxchkver_3_0_0 %wxEventType wxEVT_FIND_REPLACE_ALL // wx3.0 alias for wxEVT_COMMAND_FIND_REPLACE_ALL
+    %wxchkver_3_0_0 %wxEventType wxEVT_FIND_CLOSE       // wx3.0 alias for wxEVT_COMMAND_FIND_CLOSE
+
     wxFindDialogEvent(wxEventType commandType = wxEVT_NULL, int id = 0);
 
     int      GetFlags();

--- a/wxLua/bindings/wxwidgets/wxcore_event.i
+++ b/wxLua/bindings/wxwidgets/wxcore_event.i
@@ -49,18 +49,27 @@ class %delete wxCommandEvent : public wxEvent
     %wxEventType wxEVT_COMMAND_RIGHT_CLICK         // EVT_COMMAND_RIGHT_CLICK(winid, func);
     %wxEventType wxEVT_COMMAND_RIGHT_DCLICK        // EVT_COMMAND_RIGHT_DCLICK(winid, func);
     //%wxEventType wxEVT_COMMAND_SCROLLBAR_UPDATED // EVT_SCROLLBAR(winid, func) obsolete use wxEVT_SCROLL...
+    %wxchkver_3_0_0 %wxEventType wxEVT_SCROLLBAR   // wx3.0 alias for wxEVT_COMMAND_SCROLLBAR_UPDATED
     %wxEventType wxEVT_COMMAND_SET_FOCUS           // EVT_COMMAND_SET_FOCUS(winid, func);
     //%wxEventType wxEVT_COMMAND_VLBOX_SELECTED    // EVT_VLBOX(winid, func) unused?
+    %wxchkver_3_0_0 %wxEventType wxEVT_VLBOX       // wx3.0 alias for wxEVT_COMMAND_VLBOX_SELECTED
 
     %wxEventType wxEVT_COMMAND_MENU_SELECTED   // EVT_MENU(winid, func) EVT_MENU_RANGE(id1, id2, func);
-
+    %wxchkver_3_0_0 %wxEventType wxEVT_MENU    // wx3.0 alias for wxEVT_COMMAND_MENU_SELECTED
+    
     %wxEventType wxEVT_COMMAND_TOOL_CLICKED    // EVT_TOOL(winid, func) EVT_TOOL_RANGE(id1, id2, func);
     %wxEventType wxEVT_COMMAND_TOOL_ENTER      // EVT_TOOL_ENTER(winid, func);
     %wxEventType wxEVT_COMMAND_TOOL_RCLICKED   // EVT_TOOL_RCLICKED(winid, func) EVT_TOOL_RCLICKED_RANGE(id1, id2, func);
+    %wxchkver_3_0_0 %wxEventType wxEVT_TOOL           // wx3.0 alias for wxEVT_COMMAND_TOOL_CLICKED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TOOL_ENTER     // wx3.0 alias for wxEVT_COMMAND_TOOL_ENTER
+    %wxchkver_3_0_0 %wxEventType wxEVT_TOOL_RCLICKED  // wx3.0 alias for wxEVT_COMMAND_TOOL_RCLICKED
 
     %wxEventType wxEVT_COMMAND_TEXT_ENTER      // EVT_TEXT_ENTER(id, fn);
     %wxEventType wxEVT_COMMAND_TEXT_UPDATED    // EVT_TEXT(id, fn);
     %wxEventType wxEVT_COMMAND_TEXT_MAXLEN     // EVT_TEXT_MAXLEN(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT_ENTER  // wx3.0 alias for wxEVT_COMMAND_TEXT_ENTER
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT        // wx3.0 alias for wxEVT_COMMAND_TEXT_UPDATED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TEXT_MAXLEN // wx3.0 alias for wxEVT_COMMAND_TEXT_MAXLEN
     !%wxchkver_2_8_0 %wxEventType wxEVT_COMMAND_TEXT_URL        // EVT_TEXT_URL(id, fn);
 
     %wxEventType wxEVT_COMMAND_SPINCTRL_UPDATED        // EVT_SPINCTRL(id, fn);
@@ -75,6 +84,18 @@ class %delete wxCommandEvent : public wxEvent
     %wxEventType wxEVT_COMMAND_CHECKBOX_CLICKED        // EVT_CHECKBOX(winid, func);
     %wxEventType wxEVT_COMMAND_BUTTON_CLICKED          // EVT_BUTTON(winid, func);
     %wxchkver_2_4 %wxEventType wxEVT_COMMAND_TOGGLEBUTTON_CLICKED // EVT_TOGGLEBUTTON(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_SPINCTRL          // wx3.0 alias for wxEVT_COMMAND_SPINCTRL_UPDATED
+    %wxchkver_3_0_0 %wxEventType wxEVT_SLIDER            // wx3.0 alias for wxEVT_COMMAND_SLIDER_UPDATED
+    %wxchkver_3_0_0 %wxEventType wxEVT_RADIOBUTTON       // wx3.0 alias for wxEVT_COMMAND_RADIOBUTTON_SELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_RADIOBOX          // wx3.0 alias for wxEVT_COMMAND_RADIOBOX_SELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_CHECKLISTBOX      // wx3.0 alias for wxEVT_COMMAND_CHECKLISTBOX_TOGGLED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LISTBOX_DCLICK    // wx3.0 alias for wxEVT_COMMAND_LISTBOX_DOUBLECLICKED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LISTBOX           // wx3.0 alias for wxEVT_COMMAND_LISTBOX_SELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_COMBOBOX          // wx3.0 alias for wxEVT_COMMAND_COMBOBOX_SELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_CHOICE            // wx3.0 alias for wxEVT_COMMAND_CHOICE_SELECTED
+    %wxchkver_3_0_0 %wxEventType wxEVT_CHECKBOX          // wx3.0 alias for wxEVT_COMMAND_CHECKBOX_CLICKED
+    %wxchkver_3_0_0 %wxEventType wxEVT_BUTTON            // wx3.0 alias for wxEVT_COMMAND_BUTTON_CLICKED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TOGGLEBUTTON      // wx3.0 alias for wxEVT_COMMAND_TOGGLEBUTTON_CLICKED
 
     wxCommandEvent(wxEventType commandEventType = wxEVT_NULL, int id = 0);
 

--- a/wxLua/bindings/wxwidgets/wxcore_picker.i
+++ b/wxLua/bindings/wxwidgets/wxcore_picker.i
@@ -80,6 +80,7 @@ class wxColourPickerCtrl : public wxPickerBase
 class %delete wxColourPickerEvent : public wxCommandEvent
 {
     %wxEventType wxEVT_COMMAND_COLOURPICKER_CHANGED // EVT_COLOURPICKER_CHANGED(id, func);
+    %wxchkver_3_0_0 %wxEventType wxEVT_COLOURPICKER_CHANGED  // wx3.0 alias for wxEVT_COMMAND_COLOURPICKER_CHANGED
 
     wxColourPickerEvent();
     wxColourPickerEvent(wxObject *generator, int id, const wxColour &col);
@@ -283,6 +284,9 @@ class %delete wxFileDirPickerEvent : public wxCommandEvent
     %wxEventType wxEVT_COMMAND_FILEPICKER_CHANGED  // EVT_FILEPICKER_CHANGED(id, fn);
     %wxEventType wxEVT_COMMAND_DIRPICKER_CHANGED   // EVT_DIRPICKER_CHANGED(id, fn);
 
+    %wxchkver_3_0_0 %wxEventType wxEVT_FILEPICKER_CHANGED // wx3.0 alias for wxEVT_COMMAND_FILEPICKER_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_DIRPICKER_CHANGED  // wx3.0 alias for wxEVT_COMMAND_DIRPICKER_CHANGED
+
     //wxFileDirPickerEvent();
     wxFileDirPickerEvent(wxEventType type, wxObject *generator, int id, const wxString &path);
 
@@ -368,6 +372,7 @@ class wxFontPickerCtrl : public wxPickerBase
 class %delete wxFontPickerEvent : public wxCommandEvent
 {
     %wxEventType wxEVT_COMMAND_FONTPICKER_CHANGED // EVT_FONTPICKER_CHANGED(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_FONTPICKER_CHANGED // wx3.0 alias for wxEVT_COMMAND_FONTPICKER_CHANGED
 
     //wxFontPickerEvent();
     wxFontPickerEvent(wxObject *generator, int id, const wxFont &f);

--- a/wxLua/bindings/wxwidgets/wxcore_windows.i
+++ b/wxLua/bindings/wxwidgets/wxcore_windows.i
@@ -647,6 +647,8 @@ class %delete wxNotebookEvent : public wxBookCtrlBaseEvent
 {
     %wxEventType wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED   // EVT_NOTEBOOK_PAGE_CHANGED(winid, fn);
     %wxEventType wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING  // EVT_NOTEBOOK_PAGE_CHANGING(winid, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_NOTEBOOK_PAGE_CHANGED  // wx3.0 alias for wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_NOTEBOOK_PAGE_CHANGING // wx3.0 alias for wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGING
 
     wxNotebookEvent(wxEventType eventType = wxEVT_NULL, int id = 0, int sel = -1, int oldSel = -1);
 
@@ -692,6 +694,8 @@ class %delete wxListbookEvent : public wxBookCtrlBaseEvent
 {
     %wxEventType wxEVT_COMMAND_LISTBOOK_PAGE_CHANGED   // EVT_LISTBOOK_PAGE_CHANGED(winid, fn);
     %wxEventType wxEVT_COMMAND_LISTBOOK_PAGE_CHANGING  // EVT_LISTBOOK_PAGE_CHANGING(winid, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_LISTBOOK_PAGE_CHANGED  // wx3.0 alias for wxEVT_COMMAND_LISTBOOK_PAGE_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_LISTBOOK_PAGE_CHANGING // wx3.0 alias for wxEVT_COMMAND_LISTBOOK_PAGE_CHANGING
 
     wxListbookEvent(wxEventType eventType = wxEVT_NULL, int id = 0, int sel = -1, int oldSel = -1);
 
@@ -737,6 +741,8 @@ class %delete wxChoicebookEvent : public wxBookCtrlBaseEvent
 {
     %wxEventType wxEVT_COMMAND_CHOICEBOOK_PAGE_CHANGED  // EVT_CHOICEBOOK_PAGE_CHANGED(winid, fn);
     %wxEventType wxEVT_COMMAND_CHOICEBOOK_PAGE_CHANGING // EVT_CHOICEBOOK_PAGE_CHANGING(winid, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_CHOICEBOOK_PAGE_CHANGED  // wx3.0 alias for wxEVT_COMMAND_CHOICEBOOK_PAGE_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_CHOICEBOOK_PAGE_CHANGING // wx3.0 alias for wxEVT_COMMAND_CHOICEBOOK_PAGE_CHANGING
 
     wxChoicebookEvent(wxEventType eventType = wxEVT_NULL, int id = 0, int sel = -1, int oldSel = -1);
 
@@ -783,6 +789,10 @@ class %delete wxTreebookEvent : public wxBookCtrlBaseEvent
     %wxEventType wxEVT_COMMAND_TREEBOOK_PAGE_CHANGING  // EVT_TREEBOOK_PAGE_CHANGING(winid, fn);
     %wxEventType wxEVT_COMMAND_TREEBOOK_NODE_COLLAPSED // EVT_TREEBOOK_NODE_COLLAPSED(winid, fn);
     %wxEventType wxEVT_COMMAND_TREEBOOK_NODE_EXPANDED  // EVT_TREEBOOK_NODE_EXPANDED(winid, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREEBOOK_PAGE_CHANGED   // wx3.0 alias for wxEVT_COMMAND_TREEBOOK_PAGE_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREEBOOK_PAGE_CHANGING  // wx3.0 alias for wxEVT_COMMAND_TREEBOOK_PAGE_CHANGING
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREEBOOK_NODE_COLLAPSED // wx3.0 alias for wxEVT_COMMAND_TREEBOOK_NODE_COLLAPSED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TREEBOOK_NODE_EXPANDED  // wx3.0 alias for wxEVT_COMMAND_TREEBOOK_NODE_EXPANDED
 
     wxTreebookEvent(const wxTreebookEvent& event);
     wxTreebookEvent(wxEventType commandType = wxEVT_NULL, int id = 0, int nSel = wxNOT_FOUND, int nOldSel = wxNOT_FOUND);
@@ -815,6 +825,8 @@ class %delete wxToolbookEvent : public wxBookCtrlBaseEvent
 {
     %wxEventType wxEVT_COMMAND_TOOLBOOK_PAGE_CHANGED   // EVT_TOOLBOOK_PAGE_CHANGED(winid, fn);
     %wxEventType wxEVT_COMMAND_TOOLBOOK_PAGE_CHANGING  // EVT_TOOLBOOK_PAGE_CHANGING(winid, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_TOOLBOOK_PAGE_CHANGED  // wx3.0 alias for wxEVT_COMMAND_TOOLBOOK_PAGE_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_TOOLBOOK_PAGE_CHANGING // wx3.0 alias for wxEVT_COMMAND_TOOLBOOK_PAGE_CHANGING
 
     wxToolbookEvent(const wxToolbookEvent& event);
     wxToolbookEvent(wxEventType commandType = wxEVT_NULL, int id = 0, int nSel = wxNOT_FOUND, int nOldSel = wxNOT_FOUND);
@@ -1006,6 +1018,10 @@ class %delete wxSplitterEvent : public wxNotifyEvent
     %wxEventType wxEVT_COMMAND_SPLITTER_SASH_POS_CHANGED   // EVT_SPLITTER_SASH_POS_CHANGED(id, fn);
     %wxEventType wxEVT_COMMAND_SPLITTER_DOUBLECLICKED      // EVT_SPLITTER_DCLICK(id, fn);
     %wxEventType wxEVT_COMMAND_SPLITTER_UNSPLIT            // EVT_SPLITTER_UNSPLIT(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_SPLITTER_SASH_POS_CHANGED  // wx3.0 alias for wxEVT_COMMAND_SPLITTER_SASH_POS_CHANGED
+    %wxchkver_3_0_0 %wxEventType wxEVT_SPLITTER_SASH_POS_CHANGING // wx3.0 alias for wxEVT_COMMAND_SPLITTER_SASH_POS_CHANGING
+    %wxchkver_3_0_0 %wxEventType wxEVT_SPLITTER_DOUBLECLICKED     // wx3.0 alias for wxEVT_COMMAND_SPLITTER_DOUBLECLICKED
+    %wxchkver_3_0_0 %wxEventType wxEVT_SPLITTER_UNSPLIT           // wx3.0 alias for wxEVT_COMMAND_SPLITTER_UNSPLIT
 
     wxSplitterEvent(wxEventType type = wxEVT_NULL, wxSplitterWindow *splitter = NULL);
 
@@ -1083,6 +1099,7 @@ class wxCollapsiblePane : public wxControl
 class %delete wxCollapsiblePaneEvent : public wxCommandEvent
 {
     %wxEventType wxEVT_COMMAND_COLLPANE_CHANGED // EVT_COLLAPSIBLEPANE_CHANGED(id, fn);
+    %wxchkver_3_0_0 %wxEventType wxEVT_COLLAPSIBLEPANE_CHANGED  // wx3.0 alias for wxEVT_COMMAND_COLLPANE_CHANGED
 
     wxCollapsiblePaneEvent();
     wxCollapsiblePaneEvent(wxObject *generator, int id, bool collapsed);

--- a/wxLua/modules/wxbind/src/wxadv_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxadv_bind.cpp
@@ -16828,6 +16828,10 @@ wxLuaBindEvent* wxLuaGetEventList_wxadv(size_t &count)
         { "wxEVT_GRID_SELECT_CELL", WXLUA_GET_wxEventType_ptr(wxEVT_GRID_SELECT_CELL), &wxluatype_wxGridEvent },
 #endif // wxLUA_USE_wxGrid && wxUSE_GRID
 
+#if (wxCHECK_VERSION(2,8,0) && wxUSE_HYPERLINKCTRL && wxLUA_USE_wxHyperlinkCtrl) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_HYPERLINK", WXLUA_GET_wxEventType_ptr(wxEVT_HYPERLINK), &wxluatype_wxHyperlinkEvent },
+#endif // (wxCHECK_VERSION(2,8,0) && wxUSE_HYPERLINKCTRL && wxLUA_USE_wxHyperlinkCtrl) && (wxCHECK_VERSION(3,0,0))
+
 #if wxLUA_USE_wxJoystick && wxUSE_JOYSTICK
         { "wxEVT_JOY_BUTTON_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_JOY_BUTTON_DOWN), &wxluatype_wxJoystickEvent },
         { "wxEVT_JOY_BUTTON_UP", WXLUA_GET_wxEventType_ptr(wxEVT_JOY_BUTTON_UP), &wxluatype_wxJoystickEvent },

--- a/wxLua/modules/wxbind/src/wxaui_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxaui_bind.cpp
@@ -13722,6 +13722,29 @@ wxLuaBindEvent* wxLuaGetEventList_wxaui(size_t &count)
 {
     static wxLuaBindEvent eventList[] =
     {
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+        { "wxEVT_AUINOTEBOOK_ALLOW_DND", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_ALLOW_DND), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_BEGIN_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_BEGIN_DRAG), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_BG_DCLICK", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_BG_DCLICK), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_BUTTON", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_BUTTON), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_DRAG_DONE", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_DRAG_DONE), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_DRAG_MOTION", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_DRAG_MOTION), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_END_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_END_DRAG), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_PAGE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_PAGE_CHANGED), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_PAGE_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_PAGE_CHANGING), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_PAGE_CLOSE", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_PAGE_CLOSE), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_PAGE_CLOSED", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_PAGE_CLOSED), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_TAB_MIDDLE_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_TAB_MIDDLE_DOWN), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_TAB_MIDDLE_UP", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_TAB_MIDDLE_UP), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUINOTEBOOK_TAB_RIGHT_UP", WXLUA_GET_wxEventType_ptr(wxEVT_AUINOTEBOOK_TAB_RIGHT_UP), &wxluatype_wxAuiNotebookEvent },
+        { "wxEVT_AUITOOLBAR_BEGIN_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_AUITOOLBAR_BEGIN_DRAG), &wxluatype_wxAuiToolBarEvent },
+        { "wxEVT_AUITOOLBAR_MIDDLE_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_AUITOOLBAR_MIDDLE_CLICK), &wxluatype_wxAuiToolBarEvent },
+        { "wxEVT_AUITOOLBAR_OVERFLOW_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_AUITOOLBAR_OVERFLOW_CLICK), &wxluatype_wxAuiToolBarEvent },
+        { "wxEVT_AUITOOLBAR_RIGHT_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_AUITOOLBAR_RIGHT_CLICK), &wxluatype_wxAuiToolBarEvent },
+        { "wxEVT_AUITOOLBAR_TOOL_DROPDOWN", WXLUA_GET_wxEventType_ptr(wxEVT_AUITOOLBAR_TOOL_DROPDOWN), &wxluatype_wxAuiToolBarEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI)
+
 #if wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI
         { "wxEVT_AUI_FIND_MANAGER", WXLUA_GET_wxEventType_ptr(wxEVT_AUI_FIND_MANAGER), &wxluatype_wxAuiManagerEvent },
 #endif // wxLUA_USE_wxAUI && wxCHECK_VERSION(2,8,0) && wxUSE_AUI

--- a/wxLua/modules/wxbind/src/wxcore_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_bind.cpp
@@ -78,10 +78,44 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
     {
         { "wxEVT_ACTIVATE", WXLUA_GET_wxEventType_ptr(wxEVT_ACTIVATE), &wxluatype_wxActivateEvent },
         { "wxEVT_ACTIVATE_APP", WXLUA_GET_wxEventType_ptr(wxEVT_ACTIVATE_APP), &wxluatype_wxActivateEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_BUTTON", WXLUA_GET_wxEventType_ptr(wxEVT_BUTTON), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
         { "wxEVT_CHAR", WXLUA_GET_wxEventType_ptr(wxEVT_CHAR), &wxluatype_wxKeyEvent },
         { "wxEVT_CHAR_HOOK", WXLUA_GET_wxEventType_ptr(wxEVT_CHAR_HOOK), &wxluatype_wxKeyEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_CHECKBOX", WXLUA_GET_wxEventType_ptr(wxEVT_CHECKBOX), &wxluatype_wxCommandEvent },
+        { "wxEVT_CHECKLISTBOX", WXLUA_GET_wxEventType_ptr(wxEVT_CHECKLISTBOX), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
         { "wxEVT_CHILD_FOCUS", WXLUA_GET_wxEventType_ptr(wxEVT_CHILD_FOCUS), &wxluatype_wxChildFocusEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_CHOICE", WXLUA_GET_wxEventType_ptr(wxEVT_CHOICE), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxNotebook && wxLUA_USE_wxChoice && wxUSE_CHOICEBOOK)
+        { "wxEVT_CHOICEBOOK_PAGE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_CHOICEBOOK_PAGE_CHANGED), &wxluatype_wxChoicebookEvent },
+        { "wxEVT_CHOICEBOOK_PAGE_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_CHOICEBOOK_PAGE_CHANGING), &wxluatype_wxChoicebookEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxNotebook && wxLUA_USE_wxChoice && wxUSE_CHOICEBOOK)
+
         { "wxEVT_CLOSE_WINDOW", WXLUA_GET_wxEventType_ptr(wxEVT_CLOSE_WINDOW), &wxluatype_wxCloseEvent },
+
+#if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxCollapsiblePane && wxUSE_COLLPANE) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_COLLAPSIBLEPANE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_COLLAPSIBLEPANE_CHANGED), &wxluatype_wxCollapsiblePaneEvent },
+#endif // (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxCollapsiblePane && wxUSE_COLLPANE) && (wxCHECK_VERSION(3,0,0))
+
+#if ((wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker) && (wxLUA_USE_wxColourPickerCtrl && wxUSE_COLOURPICKERCTRL)) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_COLOURPICKER_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_COLOURPICKER_CHANGED), &wxluatype_wxColourPickerEvent },
+#endif // ((wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker) && (wxLUA_USE_wxColourPickerCtrl && wxUSE_COLOURPICKERCTRL)) && (wxCHECK_VERSION(3,0,0))
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_COMBOBOX", WXLUA_GET_wxEventType_ptr(wxEVT_COMBOBOX), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
         { "wxEVT_COMMAND_BUTTON_CLICKED", WXLUA_GET_wxEventType_ptr(wxEVT_COMMAND_BUTTON_CLICKED), &wxluatype_wxCommandEvent },
         { "wxEVT_COMMAND_CHECKBOX_CLICKED", WXLUA_GET_wxEventType_ptr(wxEVT_COMMAND_CHECKBOX_CLICKED), &wxluatype_wxCommandEvent },
         { "wxEVT_COMMAND_CHECKLISTBOX_TOGGLED", WXLUA_GET_wxEventType_ptr(wxEVT_COMMAND_CHECKLISTBOX_TOGGLED), &wxluatype_wxCommandEvent },
@@ -265,6 +299,11 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_CREATE", WXLUA_GET_wxEventType_ptr(wxEVT_CREATE), &wxluatype_wxWindowCreateEvent },
         { "wxEVT_DESTROY", WXLUA_GET_wxEventType_ptr(wxEVT_DESTROY), &wxluatype_wxWindowDestroyEvent },
         { "wxEVT_DETAILED_HELP", WXLUA_GET_wxEventType_ptr(wxEVT_DETAILED_HELP), &wxluatype_wxHelpEvent },
+
+#if (((wxLUA_USE_wxDirPickerCtrl || wxLUA_USE_wxFilePickerCtrl ) && (wxUSE_FILEPICKERCTRL || wxUSE_DIRPICKERCTRL )) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker)) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_DIRPICKER_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_DIRPICKER_CHANGED), &wxluatype_wxFileDirPickerEvent },
+#endif // (((wxLUA_USE_wxDirPickerCtrl || wxLUA_USE_wxFilePickerCtrl ) && (wxUSE_FILEPICKERCTRL || wxUSE_DIRPICKERCTRL )) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker)) && (wxCHECK_VERSION(3,0,0))
+
         { "wxEVT_DISPLAY_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_DISPLAY_CHANGED), &wxluatype_wxDisplayChangedEvent },
 
 #if wxLUA_USE_wxDragDrop && wxUSE_DRAG_AND_DROP
@@ -275,6 +314,23 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_END_SESSION", WXLUA_GET_wxEventType_ptr(wxEVT_END_SESSION), &wxluatype_wxCloseEvent },
         { "wxEVT_ENTER_WINDOW", WXLUA_GET_wxEventType_ptr(wxEVT_ENTER_WINDOW), &wxluatype_wxMouseEvent },
         { "wxEVT_ERASE_BACKGROUND", WXLUA_GET_wxEventType_ptr(wxEVT_ERASE_BACKGROUND), &wxluatype_wxEraseEvent },
+
+#if (((wxLUA_USE_wxDirPickerCtrl || wxLUA_USE_wxFilePickerCtrl ) && (wxUSE_FILEPICKERCTRL || wxUSE_DIRPICKERCTRL )) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker)) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_FILEPICKER_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_FILEPICKER_CHANGED), &wxluatype_wxFileDirPickerEvent },
+#endif // (((wxLUA_USE_wxDirPickerCtrl || wxLUA_USE_wxFilePickerCtrl ) && (wxUSE_FILEPICKERCTRL || wxUSE_DIRPICKERCTRL )) && (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker)) && (wxCHECK_VERSION(3,0,0))
+
+#if (wxCHECK_VERSION(3,0,0)) && (wxUSE_FINDREPLDLG && wxLUA_USE_wxFindReplaceDialog)
+        { "wxEVT_FIND", WXLUA_GET_wxEventType_ptr(wxEVT_FIND), &wxluatype_wxFindDialogEvent },
+        { "wxEVT_FIND_CLOSE", WXLUA_GET_wxEventType_ptr(wxEVT_FIND_CLOSE), &wxluatype_wxFindDialogEvent },
+        { "wxEVT_FIND_NEXT", WXLUA_GET_wxEventType_ptr(wxEVT_FIND_NEXT), &wxluatype_wxFindDialogEvent },
+        { "wxEVT_FIND_REPLACE", WXLUA_GET_wxEventType_ptr(wxEVT_FIND_REPLACE), &wxluatype_wxFindDialogEvent },
+        { "wxEVT_FIND_REPLACE_ALL", WXLUA_GET_wxEventType_ptr(wxEVT_FIND_REPLACE_ALL), &wxluatype_wxFindDialogEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxUSE_FINDREPLDLG && wxLUA_USE_wxFindReplaceDialog)
+
+#if ((wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker) && (wxLUA_USE_wxFontPickerCtrl && wxUSE_FONTPICKERCTRL)) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_FONTPICKER_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_FONTPICKER_CHANGED), &wxluatype_wxFontPickerEvent },
+#endif // ((wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker) && (wxLUA_USE_wxFontPickerCtrl && wxUSE_FONTPICKERCTRL)) && (wxCHECK_VERSION(3,0,0))
+
         { "wxEVT_HELP", WXLUA_GET_wxEventType_ptr(wxEVT_HELP), &wxluatype_wxHelpEvent },
         { "wxEVT_HIBERNATE", WXLUA_GET_wxEventType_ptr(wxEVT_HIBERNATE), &wxluatype_wxActivateEvent },
 
@@ -292,7 +348,45 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_LEFT_DCLICK", WXLUA_GET_wxEventType_ptr(wxEVT_LEFT_DCLICK), &wxluatype_wxMouseEvent },
         { "wxEVT_LEFT_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_LEFT_DOWN), &wxluatype_wxMouseEvent },
         { "wxEVT_LEFT_UP", WXLUA_GET_wxEventType_ptr(wxEVT_LEFT_UP), &wxluatype_wxMouseEvent },
+
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxNotebook && wxLUA_USE_wxListCtrl && wxUSE_LISTBOOK)
+        { "wxEVT_LISTBOOK_PAGE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_LISTBOOK_PAGE_CHANGED), &wxluatype_wxListbookEvent },
+        { "wxEVT_LISTBOOK_PAGE_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_LISTBOOK_PAGE_CHANGING), &wxluatype_wxListbookEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxNotebook && wxLUA_USE_wxListCtrl && wxUSE_LISTBOOK)
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_LISTBOX", WXLUA_GET_wxEventType_ptr(wxEVT_LISTBOX), &wxluatype_wxCommandEvent },
+        { "wxEVT_LISTBOX_DCLICK", WXLUA_GET_wxEventType_ptr(wxEVT_LISTBOX_DCLICK), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxListCtrl && wxUSE_LISTCTRL)
+        { "wxEVT_LIST_BEGIN_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_BEGIN_DRAG), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_BEGIN_LABEL_EDIT", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_BEGIN_LABEL_EDIT), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_BEGIN_RDRAG", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_BEGIN_RDRAG), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_CACHE_HINT", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_CACHE_HINT), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_COL_BEGIN_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_COL_BEGIN_DRAG), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_COL_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_COL_CLICK), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_COL_DRAGGING", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_COL_DRAGGING), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_COL_END_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_COL_END_DRAG), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_COL_RIGHT_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_COL_RIGHT_CLICK), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_DELETE_ALL_ITEMS", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_DELETE_ALL_ITEMS), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_DELETE_ITEM", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_DELETE_ITEM), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_END_LABEL_EDIT", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_END_LABEL_EDIT), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_INSERT_ITEM", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_INSERT_ITEM), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_ITEM_ACTIVATED", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_ITEM_ACTIVATED), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_ITEM_DESELECTED", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_ITEM_DESELECTED), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_ITEM_FOCUSED", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_ITEM_FOCUSED), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_ITEM_MIDDLE_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_ITEM_MIDDLE_CLICK), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_ITEM_RIGHT_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_ITEM_RIGHT_CLICK), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_ITEM_SELECTED", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_ITEM_SELECTED), &wxluatype_wxListEvent },
+        { "wxEVT_LIST_KEY_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_LIST_KEY_DOWN), &wxluatype_wxListEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxListCtrl && wxUSE_LISTCTRL)
+
         { "wxEVT_MAXIMIZE", WXLUA_GET_wxEventType_ptr(wxEVT_MAXIMIZE), &wxluatype_wxMaximizeEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_MENU", WXLUA_GET_wxEventType_ptr(wxEVT_MENU), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
 
 #if wxLUA_USE_wxMenu && wxUSE_MENUS
         { "wxEVT_MENU_CLOSE", WXLUA_GET_wxEventType_ptr(wxEVT_MENU_CLOSE), &wxluatype_wxMenuEvent },
@@ -318,6 +412,12 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
 #endif // wxCHECK_VERSION(2,6,0)
 
         { "wxEVT_NAVIGATION_KEY", WXLUA_GET_wxEventType_ptr(wxEVT_NAVIGATION_KEY), &wxluatype_wxNavigationKeyEvent },
+
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxNotebook && wxUSE_NOTEBOOK)
+        { "wxEVT_NOTEBOOK_PAGE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_NOTEBOOK_PAGE_CHANGED), &wxluatype_wxNotebookEvent },
+        { "wxEVT_NOTEBOOK_PAGE_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_NOTEBOOK_PAGE_CHANGING), &wxluatype_wxNotebookEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxNotebook && wxUSE_NOTEBOOK)
+
         { "wxEVT_NULL", WXLUA_GET_wxEventType_ptr(wxEVT_NULL), &wxluatype_wxCommandEvent },
         { "wxEVT_PAINT", WXLUA_GET_wxEventType_ptr(wxEVT_PAINT), &wxluatype_wxPaintEvent },
         { "wxEVT_PALETTE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_PALETTE_CHANGED), &wxluatype_wxPaletteChangedEvent },
@@ -331,9 +431,20 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
 
         { "wxEVT_QUERY_END_SESSION", WXLUA_GET_wxEventType_ptr(wxEVT_QUERY_END_SESSION), &wxluatype_wxCloseEvent },
         { "wxEVT_QUERY_NEW_PALETTE", WXLUA_GET_wxEventType_ptr(wxEVT_QUERY_NEW_PALETTE), &wxluatype_wxQueryNewPaletteEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_RADIOBOX", WXLUA_GET_wxEventType_ptr(wxEVT_RADIOBOX), &wxluatype_wxCommandEvent },
+        { "wxEVT_RADIOBUTTON", WXLUA_GET_wxEventType_ptr(wxEVT_RADIOBUTTON), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
         { "wxEVT_RIGHT_DCLICK", WXLUA_GET_wxEventType_ptr(wxEVT_RIGHT_DCLICK), &wxluatype_wxMouseEvent },
         { "wxEVT_RIGHT_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_RIGHT_DOWN), &wxluatype_wxMouseEvent },
         { "wxEVT_RIGHT_UP", WXLUA_GET_wxEventType_ptr(wxEVT_RIGHT_UP), &wxluatype_wxMouseEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_SCROLLBAR", WXLUA_GET_wxEventType_ptr(wxEVT_SCROLLBAR), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
         { "wxEVT_SCROLLWIN_BOTTOM", WXLUA_GET_wxEventType_ptr(wxEVT_SCROLLWIN_BOTTOM), &wxluatype_wxScrollWinEvent },
         { "wxEVT_SCROLLWIN_LINEDOWN", WXLUA_GET_wxEventType_ptr(wxEVT_SCROLLWIN_LINEDOWN), &wxluatype_wxScrollWinEvent },
         { "wxEVT_SCROLLWIN_LINEUP", WXLUA_GET_wxEventType_ptr(wxEVT_SCROLLWIN_LINEUP), &wxluatype_wxScrollWinEvent },
@@ -381,15 +492,71 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_SIZING", WXLUA_GET_wxEventType_ptr(wxEVT_SIZING), &wxluatype_wxSizeEvent },
 #endif // wxCHECK_VERSION(2,6,0)
 
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_SLIDER", WXLUA_GET_wxEventType_ptr(wxEVT_SLIDER), &wxluatype_wxCommandEvent },
+        { "wxEVT_SPINCTRL", WXLUA_GET_wxEventType_ptr(wxEVT_SPINCTRL), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
 #if wxLUA_USE_wxSpinCtrlDouble && wxUSE_SPINCTRL
         { "wxEVT_SPINCTRLDOUBLE", WXLUA_GET_wxEventType_ptr(wxEVT_SPINCTRLDOUBLE), &wxluatype_wxSpinDoubleEvent },
 #endif // wxLUA_USE_wxSpinCtrlDouble && wxUSE_SPINCTRL
 
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxSplitterWindow)
+        { "wxEVT_SPLITTER_DOUBLECLICKED", WXLUA_GET_wxEventType_ptr(wxEVT_SPLITTER_DOUBLECLICKED), &wxluatype_wxSplitterEvent },
+        { "wxEVT_SPLITTER_SASH_POS_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_SPLITTER_SASH_POS_CHANGED), &wxluatype_wxSplitterEvent },
+        { "wxEVT_SPLITTER_SASH_POS_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_SPLITTER_SASH_POS_CHANGING), &wxluatype_wxSplitterEvent },
+        { "wxEVT_SPLITTER_UNSPLIT", WXLUA_GET_wxEventType_ptr(wxEVT_SPLITTER_UNSPLIT), &wxluatype_wxSplitterEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxSplitterWindow)
+
         { "wxEVT_SYS_COLOUR_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_SYS_COLOUR_CHANGED), &wxluatype_wxSysColourChangedEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_TEXT", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
+#if ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxClipboard && wxUSE_CLIPBOARD)) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_TEXT_COPY", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_COPY), &wxluatype_wxClipboardTextEvent },
+        { "wxEVT_TEXT_CUT", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_CUT), &wxluatype_wxClipboardTextEvent },
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxClipboard && wxUSE_CLIPBOARD)) && (wxCHECK_VERSION(3,0,0))
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_TEXT_ENTER", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_ENTER), &wxluatype_wxCommandEvent },
+        { "wxEVT_TEXT_MAXLEN", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_MAXLEN), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
+#if ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxClipboard && wxUSE_CLIPBOARD)) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_TEXT_PASTE", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_PASTE), &wxluatype_wxClipboardTextEvent },
+#endif // ((wxCHECK_VERSION(2,8,0)) && (wxLUA_USE_wxClipboard && wxUSE_CLIPBOARD)) && (wxCHECK_VERSION(3,0,0))
+
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
+        { "wxEVT_TEXT_URL", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_URL), &wxluatype_wxTextUrlEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
 #if wxLUA_USE_wxTimer && wxUSE_TIMER
         { "wxEVT_TIMER", WXLUA_GET_wxEventType_ptr(wxEVT_TIMER), &wxluatype_wxTimerEvent },
 #endif // wxLUA_USE_wxTimer && wxUSE_TIMER
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_TOGGLEBUTTON", WXLUA_GET_wxEventType_ptr(wxEVT_TOGGLEBUTTON), &wxluatype_wxCommandEvent },
+        { "wxEVT_TOOL", WXLUA_GET_wxEventType_ptr(wxEVT_TOOL), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
+#if (wxCHECK_VERSION(2,8,0) && wxUSE_TOOLBOOK && wxLUA_USE_wxToolbook) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_TOOLBOOK_PAGE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_TOOLBOOK_PAGE_CHANGED), &wxluatype_wxToolbookEvent },
+        { "wxEVT_TOOLBOOK_PAGE_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_TOOLBOOK_PAGE_CHANGING), &wxluatype_wxToolbookEvent },
+#endif // (wxCHECK_VERSION(2,8,0) && wxUSE_TOOLBOOK && wxLUA_USE_wxToolbook) && (wxCHECK_VERSION(3,0,0))
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_TOOL_ENTER", WXLUA_GET_wxEventType_ptr(wxEVT_TOOL_ENTER), &wxluatype_wxCommandEvent },
+        { "wxEVT_TOOL_RCLICKED", WXLUA_GET_wxEventType_ptr(wxEVT_TOOL_RCLICKED), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
+#if (wxCHECK_VERSION(2,8,0) && wxUSE_TREEBOOK && wxLUA_USE_wxTreebook) && (wxCHECK_VERSION(3,0,0))
+        { "wxEVT_TREEBOOK_NODE_COLLAPSED", WXLUA_GET_wxEventType_ptr(wxEVT_TREEBOOK_NODE_COLLAPSED), &wxluatype_wxTreebookEvent },
+        { "wxEVT_TREEBOOK_NODE_EXPANDED", WXLUA_GET_wxEventType_ptr(wxEVT_TREEBOOK_NODE_EXPANDED), &wxluatype_wxTreebookEvent },
+        { "wxEVT_TREEBOOK_PAGE_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_TREEBOOK_PAGE_CHANGED), &wxluatype_wxTreebookEvent },
+        { "wxEVT_TREEBOOK_PAGE_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_TREEBOOK_PAGE_CHANGING), &wxluatype_wxTreebookEvent },
+#endif // (wxCHECK_VERSION(2,8,0) && wxUSE_TREEBOOK && wxLUA_USE_wxTreebook) && (wxCHECK_VERSION(3,0,0))
 
 #if wxLUA_USE_wxTreeListCtrl && wxUSE_TREELISTCTRL && wxCHECK_VERSION(2,9,3)
         { "wxEVT_TREELIST_COLUMN_SORTED", WXLUA_GET_wxEventType_ptr(wxEVT_TREELIST_COLUMN_SORTED), &wxluatype_wxTreeListEvent },
@@ -401,7 +568,36 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_TREELIST_SELECTION_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_TREELIST_SELECTION_CHANGED), &wxluatype_wxTreeListEvent },
 #endif // wxLUA_USE_wxTreeListCtrl && wxUSE_TREELISTCTRL && wxCHECK_VERSION(2,9,3)
 
+#if (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+        { "wxEVT_TREE_BEGIN_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_BEGIN_DRAG), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_BEGIN_LABEL_EDIT", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_BEGIN_LABEL_EDIT), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_BEGIN_RDRAG", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_BEGIN_RDRAG), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_DELETE_ITEM", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_DELETE_ITEM), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_END_DRAG", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_END_DRAG), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_END_LABEL_EDIT", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_END_LABEL_EDIT), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_GET_INFO", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_GET_INFO), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_ACTIVATED", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_ACTIVATED), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_COLLAPSED", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_COLLAPSED), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_COLLAPSING", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_COLLAPSING), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_EXPANDED", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_EXPANDED), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_EXPANDING", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_EXPANDING), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_GETTOOLTIP", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_GETTOOLTIP), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_MENU", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_MENU), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_MIDDLE_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_MIDDLE_CLICK), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_ITEM_RIGHT_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_ITEM_RIGHT_CLICK), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_KEY_DOWN", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_KEY_DOWN), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_SEL_CHANGED", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_SEL_CHANGED), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_SEL_CHANGING", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_SEL_CHANGING), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_SET_INFO", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_SET_INFO), &wxluatype_wxTreeEvent },
+        { "wxEVT_TREE_STATE_IMAGE_CLICK", WXLUA_GET_wxEventType_ptr(wxEVT_TREE_STATE_IMAGE_CLICK), &wxluatype_wxTreeEvent },
+#endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTreeCtrl && wxUSE_TREECTRL)
+
         { "wxEVT_UPDATE_UI", WXLUA_GET_wxEventType_ptr(wxEVT_UPDATE_UI), &wxluatype_wxUpdateUIEvent },
+
+#if wxCHECK_VERSION(3,0,0)
+        { "wxEVT_VLBOX", WXLUA_GET_wxEventType_ptr(wxEVT_VLBOX), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,0,0)
+
 
         { 0, 0, 0 },
     };


### PR DESCRIPTION
This patch includes the event type aliases (wxEVT_XXXX for wxEVT_COMMAND_XXXX) that were introduced in wxWigdets 3.0.

The list of aliases can be found here:
https://wiki.wxwidgets.org/EventTypes_and_Event-Table_Macros

The 'old' wxEVT_COMMAND_XXXX event types still work, but they are not listed in the wx3.0 documents. It is sometimes very hard to find which event type to use. The above web page is very helpful, but it would be better if we can find the correct symbol from the wx3.0 documents.
