### PR TITLE
Some wxGraphicsContext methods accept Lua table as an array of wxPoint2DDoubles

### DIFF
--- a/wxLua/bindings/genwxbind.lua
+++ b/wxLua/bindings/genwxbind.lua
@@ -289,6 +289,7 @@ function InitDataTypes()
     --AllocDataType("wxArrayInt",            "special", true) -- special, but we only convert input, not output
     AllocDataType("IntArray_FromLuaTable", "special", true)
     AllocDataType("wxPointArray_FromLuaTable", "special", true);
+    AllocDataType("wxPoint2DDoubleArray_FromLuaTable", "special", true);
     AllocDataType("voidptr_long",          "special", true)
     AllocDataType("any",                   "special", true)
 
@@ -3744,6 +3745,12 @@ if ((double)(lua_Integer)(%s) == (double)(%s)) {
                         overload_argList = overload_argList.."&wxluatype_TTABLE, "
                         argItem = "wxlua_getwxPointArray(L, "..argNum..")"
                         declare = "wxLuaSharedPtr<std::vector<wxPoint> >"
+                        argListOverride = "(int)("..argName.." ? "..argName.."->size() : 0), ("..argName.." && (!"..argName.."->empty())) ? &"..argName .. "->at(0) : NULL"
+
+                    elseif (argType == "wxPoint2DDoubleArray_FromLuaTable") then
+                        overload_argList = overload_argList.."&wxluatype_TTABLE, "
+                        argItem = "wxlua_getwxPoint2DDoubleArray(L, "..argNum..")"
+                        declare = "wxLuaSharedPtr<std::vector<wxPoint2DDouble> >"
                         argListOverride = "(int)("..argName.." ? "..argName.."->size() : 0), ("..argName.." && (!"..argName.."->empty())) ? &"..argName .. "->at(0) : NULL"
 
                     elseif argType == "LuaTable" then

--- a/wxLua/bindings/wxwidgets/wx_datatypes.lua
+++ b/wxLua/bindings/wxwidgets/wx_datatypes.lua
@@ -4066,6 +4066,11 @@ wx_dataTypeTable =
     Name = "wxPoint2DDouble",
     ValueType = "class",
   },
+  wxPoint2DDoubleArray_FromLuaTable = {
+    IsNumber = true,
+    Name = "wxPoint2DDoubleArray_FromLuaTable",
+    ValueType = "special",
+  },
   wxPoint2DInt = {
     Condition = "wxLUA_USE_Geometry && wxUSE_GEOMETRY",
     IsNumber = false,

--- a/wxLua/bindings/wxwidgets/wxcore_graphics.i
+++ b/wxLua/bindings/wxwidgets/wxcore_graphics.i
@@ -566,13 +566,21 @@ class %delete wxGraphicsContext : public wxGraphicsObject
     virtual void StrokeLine( wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2);
 
     // stroke lines connecting each of the points
-    virtual void StrokeLines( size_t n, const wxPoint2DDouble *points);
+    // virtual void StrokeLines( size_t n, const wxPoint2DDouble *points);
+    // Provide a Lua Table of {{1,2},{3,4},...}, {{x=1,y=2},{x=3,y=4},...}, or {wx.wxPoint2DDouble(1,2),wx.wxPoint2DDouble(3,4),...}
+    virtual void StrokeLines( wxPoint2DDoubleArray_FromLuaTable points );
 
     // stroke disconnected lines from begin to end points
-    virtual void StrokeLines( size_t n, const wxPoint2DDouble *beginPoints, const wxPoint2DDouble *endPoints);
+    // virtual void StrokeLines( size_t n, const wxPoint2DDouble *beginPoints, const wxPoint2DDouble *endPoints);
+    // Provide a Lua Table of {{1,2},{3,4},...}, {{x=1,y=2},{x=3,y=4},...}, or {wx.wxPoint2DDouble(1,2),wx.wxPoint2DDouble(3,4),...}
+    // Note: We need an override here, because the C++ API accepts only one 'n',
+    //  both for beginPoints and endPoints.
+    virtual void StrokeLines( wxPoint2DDoubleArray_FromLuaTable beginPoints, wxPoint2DDoubleArray_FromLuaTable endPoints );
 
     // draws a polygon
-    virtual void DrawLines( size_t n, const wxPoint2DDouble *points, wxPolygonFillMode fillStyle = wxODDEVEN_RULE );
+    // virtual void DrawLines( size_t n, const wxPoint2DDouble *points, wxPolygonFillMode fillStyle = wxODDEVEN_RULE );
+    // Provide a Lua Table of {{1,2},{3,4},...}, {{x=1,y=2},{x=3,y=4},...}, or {wx.wxPoint2DDouble(1,2),wx.wxPoint2DDouble(3,4),...}
+    virtual void DrawLines(wxPoint2DDoubleArray_FromLuaTable points, wxPolygonFillMode fillStyle = wxODDEVEN_RULE ;
 
     // draws a rectangle
     virtual void DrawRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h);

--- a/wxLua/bindings/wxwidgets/wxcore_override.hpp
+++ b/wxLua/bindings/wxwidgets/wxcore_override.hpp
@@ -2921,3 +2921,21 @@ static int LUACALL wxLua_wxGraphicsContext_GetTextExtent(lua_State *L)
     return 4;
 }
 %end
+
+%override wxLua_wxGraphicsContext_StrokeLines1
+//     virtual void StrokeLines( wxPoint2DDoubleArray_FromLuaTable beginPoints, wxPoint2DDoubleArray_FromLuaTable endPoints );
+static int LUACALL wxLua_wxGraphicsContext_StrokeLines1(lua_State *L)
+{
+    // wxPoint2DDoubleArray_FromLuaTable endPoints
+    wxLuaSharedPtr<std::vector<wxPoint2DDouble> > endPoints = wxlua_getwxPoint2DDoubleArray(L, 3);
+    // wxPoint2DDoubleArray_FromLuaTable beginPoints
+    wxLuaSharedPtr<std::vector<wxPoint2DDouble> > beginPoints = wxlua_getwxPoint2DDoubleArray(L, 2);
+    // get this
+    wxGraphicsContext * self = (wxGraphicsContext *)wxluaT_getuserdatatype(L, 1, wxluatype_wxGraphicsContext);
+    // call StrokeLines
+    self->StrokeLines((int)(beginPoints ? beginPoints->size() : 0), (beginPoints && (!beginPoints->empty())) ? &beginPoints->at(0) : NULL, (endPoints && (!endPoints->empty())) ? &endPoints->at(0) : NULL);
+
+    return 0;
+}
+%end
+

--- a/wxLua/modules/wxbind/src/wxcore_graphics.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_graphics.cpp
@@ -2726,30 +2726,22 @@ static int LUACALL wxLua_wxGraphicsContext_DrawIcon(lua_State *L)
 
 #endif // (wxLUA_USE_wxIcon) && (wxUSE_GRAPHICS_CONTEXT)
 
-#if ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxLUA_USE_wxDC)) && (wxUSE_GRAPHICS_CONTEXT)
-static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_DrawLines[] = { &wxluatype_wxGraphicsContext, &wxluatype_TINTEGER, &wxluatype_wxPoint2DDouble, &wxluatype_TINTEGER, NULL };
+static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_DrawLines[] = { &wxluatype_wxGraphicsContext, &wxluatype_TTABLE, NULL };
 static int LUACALL wxLua_wxGraphicsContext_DrawLines(lua_State *L);
-static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_DrawLines[1] = {{ wxLua_wxGraphicsContext_DrawLines, WXLUAMETHOD_METHOD, 3, 4, s_wxluatypeArray_wxLua_wxGraphicsContext_DrawLines }};
-//     virtual void DrawLines( size_t n, const wxPoint2DDouble *points, wxPolygonFillMode fillStyle = wxODDEVEN_RULE );
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_DrawLines[1] = {{ wxLua_wxGraphicsContext_DrawLines, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxGraphicsContext_DrawLines }};
+//     virtual void DrawLines(wxPoint2DDoubleArray_FromLuaTable points, wxPolygonFillMode fillStyle = wxODDEVEN_RULE ;
 static int LUACALL wxLua_wxGraphicsContext_DrawLines(lua_State *L)
 {
-    // get number of arguments
-    int argCount = lua_gettop(L);
-    // wxPolygonFillMode fillStyle = wxODDEVEN_RULE
-    wxPolygonFillMode fillStyle = (argCount >= 4 ? (wxPolygonFillMode)wxlua_getenumtype(L, 4) : wxODDEVEN_RULE);
-    // const wxPoint2DDouble points
-    const wxPoint2DDouble * points = (const wxPoint2DDouble *)wxluaT_getuserdatatype(L, 3, wxluatype_wxPoint2DDouble);
-    // size_t n
-    size_t n = (size_t)wxlua_getuintegertype(L, 2);
+    // wxPoint2DDoubleArray_FromLuaTable points
+    wxLuaSharedPtr<std::vector<wxPoint2DDouble> > points = wxlua_getwxPoint2DDoubleArray(L, 2);
     // get this
     wxGraphicsContext * self = (wxGraphicsContext *)wxluaT_getuserdatatype(L, 1, wxluatype_wxGraphicsContext);
     // call DrawLines
-    self->DrawLines(n, points, fillStyle);
+    self->DrawLines((int)(points ? points->size() : 0), (points && (!points->empty())) ? &points->at(0) : NULL);
 
     return 0;
 }
 
-#endif // ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxLUA_USE_wxDC)) && (wxUSE_GRAPHICS_CONTEXT)
 
 #if (wxLUA_USE_wxDC) && (wxUSE_GRAPHICS_CONTEXT)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_DrawPath[] = { &wxluatype_wxGraphicsContext, &wxluatype_wxGraphicsPath, &wxluatype_TINTEGER, NULL };
@@ -3605,47 +3597,41 @@ static int LUACALL wxLua_wxGraphicsContext_StrokeLine(lua_State *L)
     return 0;
 }
 
-
-#if (wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT)
-static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines1[] = { &wxluatype_wxGraphicsContext, &wxluatype_TINTEGER, &wxluatype_wxPoint2DDouble, &wxluatype_wxPoint2DDouble, NULL };
+static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines1[] = { &wxluatype_wxGraphicsContext, &wxluatype_TTABLE, &wxluatype_TTABLE, NULL };
 static int LUACALL wxLua_wxGraphicsContext_StrokeLines1(lua_State *L);
-// static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines1[1] = {{ wxLua_wxGraphicsContext_StrokeLines1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines1 }};
-//     virtual void StrokeLines( size_t n, const wxPoint2DDouble *beginPoints, const wxPoint2DDouble *endPoints);
+// static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines1[1] = {{ wxLua_wxGraphicsContext_StrokeLines1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines1 }};
+// %override wxLua_wxGraphicsContext_StrokeLines1
+//     virtual void StrokeLines( wxPoint2DDoubleArray_FromLuaTable beginPoints, wxPoint2DDoubleArray_FromLuaTable endPoints );
 static int LUACALL wxLua_wxGraphicsContext_StrokeLines1(lua_State *L)
 {
-    // const wxPoint2DDouble endPoints
-    const wxPoint2DDouble * endPoints = (const wxPoint2DDouble *)wxluaT_getuserdatatype(L, 4, wxluatype_wxPoint2DDouble);
-    // const wxPoint2DDouble beginPoints
-    const wxPoint2DDouble * beginPoints = (const wxPoint2DDouble *)wxluaT_getuserdatatype(L, 3, wxluatype_wxPoint2DDouble);
-    // size_t n
-    size_t n = (size_t)wxlua_getuintegertype(L, 2);
+    // wxPoint2DDoubleArray_FromLuaTable endPoints
+    wxLuaSharedPtr<std::vector<wxPoint2DDouble> > endPoints = wxlua_getwxPoint2DDoubleArray(L, 3);
+    // wxPoint2DDoubleArray_FromLuaTable beginPoints
+    wxLuaSharedPtr<std::vector<wxPoint2DDouble> > beginPoints = wxlua_getwxPoint2DDoubleArray(L, 2);
     // get this
     wxGraphicsContext * self = (wxGraphicsContext *)wxluaT_getuserdatatype(L, 1, wxluatype_wxGraphicsContext);
     // call StrokeLines
-    self->StrokeLines(n, beginPoints, endPoints);
+    self->StrokeLines((int)(beginPoints ? beginPoints->size() : 0), (beginPoints && (!beginPoints->empty())) ? &beginPoints->at(0) : NULL, (endPoints && (!endPoints->empty())) ? &endPoints->at(0) : NULL);
 
     return 0;
 }
 
-static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines[] = { &wxluatype_wxGraphicsContext, &wxluatype_TINTEGER, &wxluatype_wxPoint2DDouble, NULL };
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines[] = { &wxluatype_wxGraphicsContext, &wxluatype_TTABLE, NULL };
 static int LUACALL wxLua_wxGraphicsContext_StrokeLines(lua_State *L);
-// static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines[1] = {{ wxLua_wxGraphicsContext_StrokeLines, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines }};
-//     virtual void StrokeLines( size_t n, const wxPoint2DDouble *points);
+// static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines[1] = {{ wxLua_wxGraphicsContext_StrokeLines, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines }};
+//     virtual void StrokeLines( wxPoint2DDoubleArray_FromLuaTable points );
 static int LUACALL wxLua_wxGraphicsContext_StrokeLines(lua_State *L)
 {
-    // const wxPoint2DDouble points
-    const wxPoint2DDouble * points = (const wxPoint2DDouble *)wxluaT_getuserdatatype(L, 3, wxluatype_wxPoint2DDouble);
-    // size_t n
-    size_t n = (size_t)wxlua_getuintegertype(L, 2);
+    // wxPoint2DDoubleArray_FromLuaTable points
+    wxLuaSharedPtr<std::vector<wxPoint2DDouble> > points = wxlua_getwxPoint2DDoubleArray(L, 2);
     // get this
     wxGraphicsContext * self = (wxGraphicsContext *)wxluaT_getuserdatatype(L, 1, wxluatype_wxGraphicsContext);
     // call StrokeLines
-    self->StrokeLines(n, points);
+    self->StrokeLines((int)(points ? points->size() : 0), (points && (!points->empty())) ? &points->at(0) : NULL);
 
     return 0;
 }
-
-#endif // (wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT)
 
 static wxLuaArgType s_wxluatypeArray_wxLua_wxGraphicsContext_StrokePath[] = { &wxluatype_wxGraphicsContext, &wxluatype_wxGraphicsPath, NULL };
 static int LUACALL wxLua_wxGraphicsContext_StrokePath(lua_State *L);
@@ -3860,22 +3846,16 @@ static int s_wxluafunc_wxLua_wxGraphicsContext_SetPen_overload_count = sizeof(s_
 
 #endif // ((wxLUA_USE_wxColourPenBrush) && (wxUSE_GRAPHICS_CONTEXT))||(wxUSE_GRAPHICS_CONTEXT)
 
-#if ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT))
+#if (wxUSE_GRAPHICS_CONTEXT)
 // function overload table
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines_overload[] =
 {
-
-#if (wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT)
-    { wxLua_wxGraphicsContext_StrokeLines1, WXLUAMETHOD_METHOD, 4, 4, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines1 },
-#endif // (wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT)
-
-#if (wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT)
-    { wxLua_wxGraphicsContext_StrokeLines, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines },
-#endif // (wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT)
+    { wxLua_wxGraphicsContext_StrokeLines1, WXLUAMETHOD_METHOD, 3, 3, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines1 },
+    { wxLua_wxGraphicsContext_StrokeLines, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxGraphicsContext_StrokeLines },
 };
 static int s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines_overload_count = sizeof(s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines_overload)/sizeof(wxLuaBindCFunc);
 
-#endif // ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT))
+#endif // (wxUSE_GRAPHICS_CONTEXT)
 
 void wxLua_wxGraphicsContext_delete_function(void** p)
 {
@@ -3952,9 +3932,7 @@ wxLuaBindMethod wxGraphicsContext_methods[] = {
     { "DrawIcon", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_DrawIcon, 1, NULL },
 #endif // (wxLUA_USE_wxIcon) && (wxUSE_GRAPHICS_CONTEXT)
 
-#if ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxLUA_USE_wxDC)) && (wxUSE_GRAPHICS_CONTEXT)
     { "DrawLines", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_DrawLines, 1, NULL },
-#endif // ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxLUA_USE_wxDC)) && (wxUSE_GRAPHICS_CONTEXT)
 
 #if (wxLUA_USE_wxDC) && (wxUSE_GRAPHICS_CONTEXT)
     { "DrawPath", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_DrawPath, 1, NULL },
@@ -4035,9 +4013,9 @@ wxLuaBindMethod wxGraphicsContext_methods[] = {
     { "StartPage", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_StartPage, 1, NULL },
     { "StrokeLine", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_StrokeLine, 1, NULL },
 
-#if ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT))
+#if (wxUSE_GRAPHICS_CONTEXT)
     { "StrokeLines", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines_overload, s_wxluafunc_wxLua_wxGraphicsContext_StrokeLines_overload_count, 0 },
-#endif // ((wxLUA_USE_Geometry && wxUSE_GEOMETRY) && (wxUSE_GRAPHICS_CONTEXT))
+#endif // (wxUSE_GRAPHICS_CONTEXT)
 
     { "StrokePath", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_StrokePath, 1, NULL },
     { "Translate", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxGraphicsContext_Translate, 1, NULL },

--- a/wxLua/modules/wxlua/wxlbind.cpp
+++ b/wxLua/modules/wxlua/wxlbind.cpp
@@ -56,6 +56,7 @@ int* p_wxluatype_wxSortedArrayString = &wxluatype_TUNKNOWN;
 int* p_wxluatype_wxArrayInt          = &wxluatype_TUNKNOWN;
 int* p_wxluatype_wxArrayDouble       = &wxluatype_TUNKNOWN;
 int* p_wxluatype_wxPoint             = &wxluatype_TUNKNOWN;
+int* p_wxluatype_wxPoint2DDouble     = &wxluatype_TUNKNOWN;
 
 // ----------------------------------------------------------------------------
 // wxlua_tableErrorHandler

--- a/wxLua/modules/wxlua/wxlbind.h
+++ b/wxLua/modules/wxlua/wxlbind.h
@@ -124,6 +124,7 @@ extern WXDLLIMPEXP_DATA_WXLUA(int*) p_wxluatype_wxSortedArrayString; // wxLua ty
 extern WXDLLIMPEXP_DATA_WXLUA(int*) p_wxluatype_wxArrayInt;    // wxLua type for wxArrayInt
 extern WXDLLIMPEXP_DATA_WXLUA(int*) p_wxluatype_wxArrayDouble; // wxLua type for wxArrayDouble
 extern WXDLLIMPEXP_DATA_WXLUA(int*) p_wxluatype_wxPoint;       // wxLua type for wxPoint
+extern WXDLLIMPEXP_DATA_WXLUA(int*) p_wxluatype_wxPoint2DDouble;       // wxLua type for wxPoint2DDouble
 
 // ----------------------------------------------------------------------------
 // wxLuaArgType a pointer to a declared wxLua type, see wxLuaBindCFunc::argtypes

--- a/wxLua/modules/wxlua/wxllua.h
+++ b/wxLua/modules/wxlua/wxllua.h
@@ -551,6 +551,9 @@ WXDLLIMPEXP_WXLUA wxLuaSmartwxArrayDouble LUACALL wxlua_getwxArrayDouble(lua_Sta
 // Convert a table array at the stack_idx to a vector of wxPoints.
 // Valid tables are : {{1,2},...}, {{x=1,y=2},...}, or {wx.wxPoint(1,2),,...}
 WXDLLIMPEXP_WXLUA wxLuaSharedPtr<std::vector<wxPoint> > LUACALL wxlua_getwxPointArray(lua_State* L, int stack_idx);
+// Convert a table array at the stack_idx to a vector of wxPoint2DDoubles.
+// Valid tables are : {{1,2},...}, {{x=1,y=2},...}, or {wx.wxPoint2DDouble(1,2),,...}
+WXDLLIMPEXP_WXLUA wxLuaSharedPtr<std::vector<wxPoint2DDouble> > LUACALL wxlua_getwxPoint2DDoubleArray(lua_State* L, int stack_idx);
 // Creates a Lua table array and pushes Lua strings into it, returns the number of items added.
 //   The table is left on the stack.
 WXDLLIMPEXP_WXLUA int LUACALL wxlua_pushwxArrayStringtable(lua_State* L, const wxArrayString& strArray);


### PR DESCRIPTION
DrawLines(), StrokeLines() (two variants) need an array of wxPoint2DDoubles, just like wxDC:DrawLines() needs an array of wxPoints. The arguments of these methods are modified so that they work similarly as in wxDC:DrawLines(). One of the variants of StrokeLines() needs an override, because it accepts only one 'n' (= the number of wxPoint2DDoubles) argument but two arrays of wxPoint2DDoubles.
