### PR TITLE
wxEVT_SEARCH and wxEVT_SEARCH_CANCEL require >=3.1.1

### DIFF
--- a/wxLua/bindings/wxwidgets/wxcore_event.i
+++ b/wxLua/bindings/wxwidgets/wxcore_event.i
@@ -97,8 +97,8 @@ class %delete wxCommandEvent : public wxEvent
     %wxchkver_3_0_0 %wxEventType wxEVT_BUTTON            // wx3.0 alias for wxEVT_COMMAND_BUTTON_CLICKED
     %wxchkver_3_0_0 %wxEventType wxEVT_TOGGLEBUTTON      // wx3.0 alias for wxEVT_COMMAND_TOGGLEBUTTON_CLICKED
 
-    %wxEventType wxEVT_SEARCH_CANCEL        // EVT_SEARCH_CANCEL(winid, func);
-    %wxEventType wxEVT_SEARCH               // EVT_SEARCH(winid, func);
+    %wxchkver_3_1_1 %wxEventType wxEVT_SEARCH_CANCEL        // EVT_SEARCH_CANCEL(winid, func);
+    %wxchkver_3_1_1 %wxEventType wxEVT_SEARCH               // EVT_SEARCH(winid, func);
 
     wxCommandEvent(wxEventType commandEventType = wxEVT_NULL, int id = 0);
 

--- a/wxLua/modules/wxbind/src/wxcore_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_bind.cpp
@@ -503,8 +503,12 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_SCROLL_THUMBTRACK", WXLUA_GET_wxEventType_ptr(wxEVT_SCROLL_THUMBTRACK), &wxluatype_wxScrollEvent },
 #endif // 1
         { "wxEVT_SCROLL_TOP", WXLUA_GET_wxEventType_ptr(wxEVT_SCROLL_TOP), &wxluatype_wxScrollEvent },
+
+#if wxCHECK_VERSION(3,1,1)
         { "wxEVT_SEARCH", WXLUA_GET_wxEventType_ptr(wxEVT_SEARCH), &wxluatype_wxCommandEvent },
         { "wxEVT_SEARCH_CANCEL", WXLUA_GET_wxEventType_ptr(wxEVT_SEARCH_CANCEL), &wxluatype_wxCommandEvent },
+#endif // wxCHECK_VERSION(3,1,1)
+
         { "wxEVT_SET_CURSOR", WXLUA_GET_wxEventType_ptr(wxEVT_SET_CURSOR), &wxluatype_wxSetCursorEvent },
         { "wxEVT_SET_FOCUS", WXLUA_GET_wxEventType_ptr(wxEVT_SET_FOCUS), &wxluatype_wxFocusEvent },
         { "wxEVT_SHOW", WXLUA_GET_wxEventType_ptr(wxEVT_SHOW), &wxluatype_wxShowEvent },


### PR DESCRIPTION
This fix should allow compilation with wxWidgets 3.0.x.
