### PR TITLE
wxLuaDataObjectSimple::GetDataHere() fix

### DIFF
--- a/wxLua/modules/wxbind/src/wxcore_wxlcore.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_wxlcore.cpp
@@ -71,7 +71,7 @@ bool wxLuaDataObjectSimple::GetDataHere(void* buf) const
         int nOldTop = m_wxlState.lua_GetTop();
         m_wxlState.wxluaT_PushUserDataType(this, wxluatype_wxLuaDataObjectSimple, true);
 
-        if (m_wxlState.LuaPCall(0, 2) == 0)
+        if (m_wxlState.LuaPCall(1, 2) == 0)
         {
             result = m_wxlState.GetBooleanType(-2);
 

--- a/wxLua/modules/wxbind/src/wxcore_wxlcore.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_wxlcore.cpp
@@ -75,8 +75,8 @@ bool wxLuaDataObjectSimple::GetDataHere(void* buf) const
         {
             result = m_wxlState.GetBooleanType(-2);
 
-            const void *lua_buf = m_wxlState.lua_ToString(-1);
-            size_t len = (size_t)m_wxlState.lua_StrLen(-1);
+            size_t len;
+            const void *lua_buf = (const void *)wxlua_getstringtypelen(m_wxlState.GetLuaState(), -1, &len);
 
             memcpy(buf, lua_buf, len);
         }


### PR DESCRIPTION
wxLuaDataObjectSimple::GetDataHere() is supposed to call the derived method in Lua, but the implementation was broken. LuaPCall(0, 2) should be LuaPCall(1, 2).
In addition, the handling of the returned value is modified, so that wxMemoryBuffer can be returned.
