### PR TITLE
Revert "solve compile failed in larger 3.0.0, lua-5.1 (closes #122)."

### DIFF
--- a/wxLua/modules/wxlua/wxlstate.cpp
+++ b/wxLua/modules/wxlua/wxlstate.cpp
@@ -2356,6 +2356,20 @@ void wxLuaState::AddLuaPath(const wxFileName& filename)
 // wxLuaEvent
 //-----------------------------------------------------------------------------
 
+#if wxCHECK_VERSION(3,0,0)
+wxDEFINE_EVENT(wxEVT_LUA_CREATION, wxLuaEvent);
+wxDEFINE_EVENT(wxEVT_LUA_PRINT, wxLuaEvent);
+wxDEFINE_EVENT(wxEVT_LUA_ERROR, wxLuaEvent);
+wxDEFINE_EVENT(wxEVT_LUA_DEBUG_HOOK, wxLuaEvent);
+#else
+DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_CREATION)
+DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_PRINT)
+DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_ERROR)
+DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_DEBUG_HOOK)
+//DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_INIT)
+//DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_DEBUGGERATTACHED)
+#endif
+
 wxLuaEvent::wxLuaEvent(wxEventType commandType, wxWindowID id, const wxLuaState& wxlState)
            :wxNotifyEvent(commandType, id),  m_wxlState(wxlState),
             m_debug_hook_break(false),

--- a/wxLua/modules/wxlua/wxlstate.h
+++ b/wxLua/modules/wxlua/wxlstate.h
@@ -793,18 +793,6 @@ public:
 };
 
 #if wxCHECK_VERSION(3,0,0)
-wxDEFINE_EVENT(wxEVT_LUA_CREATION, wxLuaEvent);
-wxDEFINE_EVENT(wxEVT_LUA_PRINT, wxLuaEvent);
-wxDEFINE_EVENT(wxEVT_LUA_ERROR, wxLuaEvent);
-wxDEFINE_EVENT(wxEVT_LUA_DEBUG_HOOK, wxLuaEvent);
-#else
-DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_CREATION)
-DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_PRINT)
-DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_ERROR)
-DEFINE_LOCAL_EVENT_TYPE(wxEVT_LUA_DEBUG_HOOK)
-#endif
-
-#if wxCHECK_VERSION(3,0,0)
 // A wxLuaState is being created, sent at the end of
 //   wxLuaState(wxEvtHandler, win id) or Create(wxEvtHandler, win id)
 wxDECLARE_EVENT(wxEVT_LUA_CREATION, wxLuaEvent);


### PR DESCRIPTION
This reverts commit bde906e39b19f5179c66c44c9b681f40bf4475e0.

I'm not sure what the original problem this was trying to resolve, but moving the `wxDEFINE_EVENT` macros into `wxlstate.h` duplicates the event definitions and leads to different translation units having different IDs for the same events.