### PR TITLE
Don't rely on implicit wxString -> wxChar* conversion for string constants.

### DIFF
--- a/wxLua/bindings/genwxbind.lua
+++ b/wxLua/bindings/genwxbind.lua
@@ -3585,7 +3585,7 @@ if ((double)(lua_Integer)(%s) == (double)(%s)) {
                 local stringBinding =
                 {
                     LuaName   = luaname,
-                    Map       = "        { \""..luaname.."\", "..value..", NULL },\n",
+                    Map       = "        wxLuaBindString( \""..luaname.."\", "..value.."),\n",
                     Condition = fullcondition
                 }
 
@@ -3601,7 +3601,7 @@ if ((double)(lua_Integer)(%s) == (double)(%s)) {
                 local stringBinding =
                 {
                     LuaName   = luaname,
-                    Map       = "        { \""..luaname.."\", NULL, "..value.." },\n",
+                    Map       = "        wxLuaBindString( \""..luaname.."\", "..value.."),\n",
                     Condition = fullcondition
                 }
 

--- a/wxLua/bindings/wxlua/override.hpp
+++ b/wxLua/bindings/wxlua/override.hpp
@@ -861,8 +861,8 @@ int LUACALL wxluabind_wxLuaBinding__index(lua_State* L)
                 lua_pushstring(L, wxlString->name);
                 lua_rawset(L, -3);
                 lua_pushstring(L, "value");
-                if (wxlString->wxchar_string != NULL)
-                    lua_pushstring(L, wx2lua(wxlString->wxchar_string));
+                if (wxlString->wx_string != NULL)
+                    lua_pushstring(L, wx2lua(*(wxlString->wx_string)));
                 else
                     lua_pushstring(L, wxlString->c_string);
                 lua_rawset(L, -3);

--- a/wxLua/modules/wxlua/wxlbind.cpp
+++ b/wxLua/modules/wxlua/wxlbind.cpp
@@ -927,8 +927,8 @@ void wxLuaBinding::DoRegisterBinding(const wxLuaState& wxlState) const
     for (n = 0; n < m_stringCount; ++n, ++wxlString)
     {
         lua_pushstring(L, wxlString->name);
-        if (wxlString->wxchar_string != NULL)
-            lua_pushstring(L, wx2lua(wxlString->wxchar_string));
+        if (wxlString->wx_string != NULL)
+            lua_pushstring(L, wx2lua(*(wxlString->wx_string)));
         else
             lua_pushstring(L, wxlString->c_string);
         lua_rawset(L, -3);
@@ -1438,4 +1438,32 @@ void wxLuaBinding::InitAllBindings(bool force_update)
     }
 
     sm_bindingArray_initialized = binding_count;
+}
+
+wxLuaBindString::wxLuaBindString(const char *name, const char *c_string):
+    name(name),
+    c_string(c_string),
+    wx_string(NULL) {}
+
+wxLuaBindString::wxLuaBindString(const char *name, const wxString &wx_string):
+    name(name),
+    c_string(NULL),
+    wx_string(new wxString(wx_string)) {}
+
+wxLuaBindString::wxLuaBindString(const wxLuaBindString &other):
+    name(other.name),
+    c_string(other.c_string),
+    wx_string(other.wx_string != NULL ? new wxString(*(other.wx_string)) : NULL) {}
+
+wxLuaBindString::wxLuaBindString(wxLuaBindString &&other):
+    name(other.name),
+    c_string(other.c_string),
+    wx_string(other.wx_string)
+{
+    other.wx_string = NULL;
+}
+
+wxLuaBindString::~wxLuaBindString()
+{
+    delete wx_string;
 }

--- a/wxLua/modules/wxlua/wxlbind.h
+++ b/wxLua/modules/wxlua/wxlbind.h
@@ -200,9 +200,20 @@ struct WXDLLIMPEXP_WXLUA wxLuaBindNumber
 
 struct WXDLLIMPEXP_WXLUA wxLuaBindString
 {
-    const char*   name;          // name
-    const char*   c_string;      // string value
-    const wxChar* wxchar_string; // string value
+    const char* name;          // name
+    const char* c_string;      // string value
+    wxString *wx_string;
+    
+    wxLuaBindString(const char *name, const char *c_string);
+    wxLuaBindString(const char *name, const wxString &wx_string);
+    
+    wxLuaBindString(const wxLuaBindString &other);
+    wxLuaBindString &operator=(const wxLuaBindString&) = delete;
+    
+    wxLuaBindString(wxLuaBindString &&other);
+    wxLuaBindString &operator=(wxLuaBindString&&) = delete;
+    
+    ~wxLuaBindString();
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a build issue with propgrid under MinGW.