### PR TITLE
Enabling wxEVT_THREAD events in wxLua

### DIFF
--- a/wxLua/CMakeLists.txt
+++ b/wxLua/CMakeLists.txt
@@ -442,7 +442,7 @@ endif()
 install(DIRECTORY   "${wxLua_ROOT_DIR}/docs/"
         DESTINATION "${WXLUA_SHARE_DIR}doc/wxLua"
         FILES_MATCHING
-        PATTERN "*.md" PATTERN "*.html"
+        PATTERN "*.md" PATTERN "*.html" PATTERN "*.css"
         PATTERN "CVS"     EXCLUDE
         PATTERN ".svn"    EXCLUDE
         PATTERN "doxygen" EXCLUDE)

--- a/wxLua/bindings/wxwidgets/wx_datatypes.lua
+++ b/wxLua/bindings/wxwidgets/wx_datatypes.lua
@@ -6505,6 +6505,14 @@ wx_dataTypeTable =
     Name = "wxTextValidator",
     ValueType = "class",
   },
+  wxThreadEvent = {
+    BaseClasses = {
+      [1] = "wxEvent",
+    },
+    IsNumber = false,
+    Name = "wxThreadEvent",
+    ValueType = "class",
+  },
   wxTimePickerCtrl = {
     BaseClasses = {
       [1] = "wxControl",

--- a/wxLua/bindings/wxwidgets/wxcore_event.i
+++ b/wxLua/bindings/wxwidgets/wxcore_event.i
@@ -113,7 +113,7 @@ class %delete wxCommandEvent : public wxEvent
     bool IsSelection();
     void SetClientData(voidptr_long number); // C++ is (void *clientData) You can put a number here
     void SetClientObject(wxClientData* clientObject);
-    void SetExtraLong(int extraLong);
+    void SetExtraLong(long extraLong);
     void SetInt(int intCommand);
     void SetString(const wxString &string);
 };
@@ -994,4 +994,26 @@ class %delete wxHelpEvent : public wxCommandEvent
     %wxchkver_2_8 void SetOrigin(wxHelpEvent::Origin origin);
     void SetPosition(const wxPoint& pos);
     void SetTarget(const wxString& target);
+};
+
+// ---------------------------------------------------------------------------
+// wxThreadEvent
+
+#include "wx/event.h"
+
+class %delete wxThreadEvent : public wxEvent
+{
+    %wxEventType wxEVT_THREAD
+
+    wxThreadEvent(wxEventType eventType = wxEVT_THREAD, int id = wxID_ANY);
+
+    // GetEventCategory() not implemented
+    // SetPayload() not implemented
+    // GetPayload() not implemented
+    long GetExtraLong();
+    int GetInt();
+    wxString GetString();
+    void SetExtraLong(long extraLong);
+    void SetInt(int intCommand);
+    void SetString(const wxString &string);
 };

--- a/wxLua/modules/wxbind/include/wxcore_bind.h
+++ b/wxLua/modules/wxbind/include/wxcore_bind.h
@@ -833,6 +833,7 @@ extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxSetCursorEvent;
 extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxShowEvent;
 extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxSizeEvent;
 extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxSysColourChangedEvent;
+extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxThreadEvent;
 extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxUpdateUIEvent;
 extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxVisualAttributes;
 extern WXDLLIMPEXP_DATA_BINDWXCORE(int) wxluatype_wxWindow;

--- a/wxLua/modules/wxbind/src/wxcore_bind.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_bind.cpp
@@ -575,6 +575,8 @@ wxLuaBindEvent* wxLuaGetEventList_wxcore(size_t &count)
         { "wxEVT_TEXT_URL", WXLUA_GET_wxEventType_ptr(wxEVT_TEXT_URL), &wxluatype_wxTextUrlEvent },
 #endif // (wxCHECK_VERSION(3,0,0)) && (wxLUA_USE_wxTextCtrl && wxUSE_TEXTCTRL)
 
+        { "wxEVT_THREAD", WXLUA_GET_wxEventType_ptr(wxEVT_THREAD), &wxluatype_wxThreadEvent },
+
 #if wxLUA_USE_wxTimer && wxUSE_TIMER
         { "wxEVT_TIMER", WXLUA_GET_wxEventType_ptr(wxEVT_TIMER), &wxluatype_wxTimerEvent },
 #endif // wxLUA_USE_wxTimer && wxUSE_TIMER
@@ -5575,6 +5577,7 @@ static const char* wxluaclassname_wxTextEntry = "wxTextEntry";
 static const char* wxluaclassname_wxTextEntryDialog = "wxTextEntryDialog";
 static const char* wxluaclassname_wxTextUrlEvent = "wxTextUrlEvent";
 static const char* wxluaclassname_wxTextValidator = "wxTextValidator";
+static const char* wxluaclassname_wxThreadEvent = "wxThreadEvent";
 static const char* wxluaclassname_wxTimePickerCtrl = "wxTimePickerCtrl";
 static const char* wxluaclassname_wxTimer = "wxTimer";
 static const char* wxluaclassname_wxTimerEvent = "wxTimerEvent";
@@ -6125,6 +6128,8 @@ static const char* wxluabaseclassnames_wxTextUrlEvent[] = { wxluaclassname_wxCom
 static wxLuaBindClass* wxluabaseclassbinds_wxTextUrlEvent[] = { NULL };
 static const char* wxluabaseclassnames_wxTextValidator[] = { wxluaclassname_wxValidator, NULL };
 static wxLuaBindClass* wxluabaseclassbinds_wxTextValidator[] = { NULL };
+static const char* wxluabaseclassnames_wxThreadEvent[] = { wxluaclassname_wxEvent, NULL };
+static wxLuaBindClass* wxluabaseclassbinds_wxThreadEvent[] = { NULL };
 static const char* wxluabaseclassnames_wxTimePickerCtrl[] = { wxluaclassname_wxControl, NULL };
 static wxLuaBindClass* wxluabaseclassbinds_wxTimePickerCtrl[] = { NULL };
 static const char* wxluabaseclassnames_wxTimer[] = { wxluaclassname_wxEvtHandler, NULL };
@@ -6684,6 +6689,9 @@ extern void wxLua_wxSizeEvent_delete_function(void** p);
 extern wxLuaBindMethod wxSysColourChangedEvent_methods[];
 extern int wxSysColourChangedEvent_methodCount;
 extern void wxLua_wxSysColourChangedEvent_delete_function(void** p);
+extern wxLuaBindMethod wxThreadEvent_methods[];
+extern int wxThreadEvent_methodCount;
+extern void wxLua_wxThreadEvent_delete_function(void** p);
 extern wxLuaBindMethod wxUpdateUIEvent_methods[];
 extern int wxUpdateUIEvent_methodCount;
 extern void wxLua_wxUpdateUIEvent_delete_function(void** p);
@@ -8684,6 +8692,8 @@ wxLuaBindClass* wxLuaGetClassList_wxcore(size_t &count)
 #if (wxLUA_USE_wxTextValidator) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
         { wxluaclassname_wxTextValidator, wxTextValidator_methods, wxTextValidator_methodCount, CLASSINFO(wxTextValidator), &wxluatype_wxTextValidator, wxluabaseclassnames_wxTextValidator, wxluabaseclassbinds_wxTextValidator, NULL, NULL, NULL, 0, &wxLua_wxTextValidator_delete_function, }, 
 #endif // (wxLUA_USE_wxTextValidator) && (wxLUA_USE_wxValidator && wxUSE_VALIDATORS)
+
+        { wxluaclassname_wxThreadEvent, wxThreadEvent_methods, wxThreadEvent_methodCount, CLASSINFO(wxThreadEvent), &wxluatype_wxThreadEvent, wxluabaseclassnames_wxThreadEvent, wxluabaseclassbinds_wxThreadEvent, NULL, NULL, NULL, 0, &wxLua_wxThreadEvent_delete_function, }, 
 
 #if (wxCHECK_VERSION(2,8,0) && wxLUA_USE_wxPicker) && (wxLUA_USE_wxTimePickerCtrl && wxUSE_TIMEPICKCTRL && wxCHECK_VERSION(2,9,3))
         { wxluaclassname_wxTimePickerCtrl, wxTimePickerCtrl_methods, wxTimePickerCtrl_methodCount, CLASSINFO(wxTimePickerCtrl), &wxluatype_wxTimePickerCtrl, wxluabaseclassnames_wxTimePickerCtrl, wxluabaseclassbinds_wxTimePickerCtrl, NULL, NULL, NULL, 0, &wxLua_wxTimePickerCtrl_delete_function, }, 

--- a/wxLua/modules/wxbind/src/wxcore_event.cpp
+++ b/wxLua/modules/wxbind/src/wxcore_event.cpp
@@ -345,11 +345,11 @@ static int LUACALL wxLua_wxCommandEvent_SetClientObject(lua_State *L)
 static wxLuaArgType s_wxluatypeArray_wxLua_wxCommandEvent_SetExtraLong[] = { &wxluatype_wxCommandEvent, &wxluatype_TNUMBER, NULL };
 static int LUACALL wxLua_wxCommandEvent_SetExtraLong(lua_State *L);
 static wxLuaBindCFunc s_wxluafunc_wxLua_wxCommandEvent_SetExtraLong[1] = {{ wxLua_wxCommandEvent_SetExtraLong, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxCommandEvent_SetExtraLong }};
-//     void SetExtraLong(int extraLong);
+//     void SetExtraLong(long extraLong);
 static int LUACALL wxLua_wxCommandEvent_SetExtraLong(lua_State *L)
 {
-    // int extraLong
-    int extraLong = (int)wxlua_getnumbertype(L, 2);
+    // long extraLong
+    long extraLong = (long)wxlua_getnumbertype(L, 2);
     // get this
     wxCommandEvent * self = (wxCommandEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxCommandEvent);
     // call SetExtraLong
@@ -5215,4 +5215,172 @@ wxLuaBindNumber wxHelpEvent_enums[] = {
     { NULL, 0, },
 };
 int wxHelpEvent_enumCount = sizeof(wxHelpEvent_enums)/sizeof(wxLuaBindNumber) - 1;
+
+// ---------------------------------------------------------------------------
+// Bind class wxThreadEvent
+// ---------------------------------------------------------------------------
+
+// Lua MetaTable Tag for Class 'wxThreadEvent'
+int wxluatype_wxThreadEvent = WXLUA_TUNKNOWN;
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_GetExtraLong[] = { &wxluatype_wxThreadEvent, NULL };
+static int LUACALL wxLua_wxThreadEvent_GetExtraLong(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_GetExtraLong[1] = {{ wxLua_wxThreadEvent_GetExtraLong, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxThreadEvent_GetExtraLong }};
+//     long GetExtraLong();
+static int LUACALL wxLua_wxThreadEvent_GetExtraLong(lua_State *L)
+{
+    // get this
+    wxThreadEvent * self = (wxThreadEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxThreadEvent);
+    // call GetExtraLong
+    long returns = (self->GetExtraLong());
+    // push the result number
+#if LUA_VERSION_NUM >= 503
+if ((double)(lua_Integer)returns == (double)returns) {
+    // Exactly representable as lua_Integer
+    lua_pushinteger(L, returns);
+} else
+#endif
+{
+    lua_pushnumber(L, returns);
+}
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_GetInt[] = { &wxluatype_wxThreadEvent, NULL };
+static int LUACALL wxLua_wxThreadEvent_GetInt(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_GetInt[1] = {{ wxLua_wxThreadEvent_GetInt, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxThreadEvent_GetInt }};
+//     int GetInt();
+static int LUACALL wxLua_wxThreadEvent_GetInt(lua_State *L)
+{
+    // get this
+    wxThreadEvent * self = (wxThreadEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxThreadEvent);
+    // call GetInt
+    int returns = (self->GetInt());
+    // push the result number
+#if LUA_VERSION_NUM >= 503
+if ((double)(lua_Integer)returns == (double)returns) {
+    // Exactly representable as lua_Integer
+    lua_pushinteger(L, returns);
+} else
+#endif
+{
+    lua_pushnumber(L, returns);
+}
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_GetString[] = { &wxluatype_wxThreadEvent, NULL };
+static int LUACALL wxLua_wxThreadEvent_GetString(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_GetString[1] = {{ wxLua_wxThreadEvent_GetString, WXLUAMETHOD_METHOD, 1, 1, s_wxluatypeArray_wxLua_wxThreadEvent_GetString }};
+//     wxString GetString();
+static int LUACALL wxLua_wxThreadEvent_GetString(lua_State *L)
+{
+    // get this
+    wxThreadEvent * self = (wxThreadEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxThreadEvent);
+    // call GetString
+    wxString returns = (self->GetString());
+    // push the result string
+    wxlua_pushwxString(L, returns);
+
+    return 1;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_SetExtraLong[] = { &wxluatype_wxThreadEvent, &wxluatype_TNUMBER, NULL };
+static int LUACALL wxLua_wxThreadEvent_SetExtraLong(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_SetExtraLong[1] = {{ wxLua_wxThreadEvent_SetExtraLong, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxThreadEvent_SetExtraLong }};
+//     void SetExtraLong(long extraLong);
+static int LUACALL wxLua_wxThreadEvent_SetExtraLong(lua_State *L)
+{
+    // long extraLong
+    long extraLong = (long)wxlua_getnumbertype(L, 2);
+    // get this
+    wxThreadEvent * self = (wxThreadEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxThreadEvent);
+    // call SetExtraLong
+    self->SetExtraLong(extraLong);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_SetInt[] = { &wxluatype_wxThreadEvent, &wxluatype_TNUMBER, NULL };
+static int LUACALL wxLua_wxThreadEvent_SetInt(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_SetInt[1] = {{ wxLua_wxThreadEvent_SetInt, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxThreadEvent_SetInt }};
+//     void SetInt(int intCommand);
+static int LUACALL wxLua_wxThreadEvent_SetInt(lua_State *L)
+{
+    // int intCommand
+    int intCommand = (int)wxlua_getnumbertype(L, 2);
+    // get this
+    wxThreadEvent * self = (wxThreadEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxThreadEvent);
+    // call SetInt
+    self->SetInt(intCommand);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_SetString[] = { &wxluatype_wxThreadEvent, &wxluatype_TSTRING, NULL };
+static int LUACALL wxLua_wxThreadEvent_SetString(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_SetString[1] = {{ wxLua_wxThreadEvent_SetString, WXLUAMETHOD_METHOD, 2, 2, s_wxluatypeArray_wxLua_wxThreadEvent_SetString }};
+//     void SetString(const wxString &string);
+static int LUACALL wxLua_wxThreadEvent_SetString(lua_State *L)
+{
+    // const wxString string
+    const wxString string = wxlua_getwxStringtype(L, 2);
+    // get this
+    wxThreadEvent * self = (wxThreadEvent *)wxluaT_getuserdatatype(L, 1, wxluatype_wxThreadEvent);
+    // call SetString
+    self->SetString(string);
+
+    return 0;
+}
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_delete[] = { &wxluatype_wxThreadEvent, NULL };
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_delete[1] = {{ wxlua_userdata_delete, WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, 1, 1, s_wxluatypeArray_wxLua_wxThreadEvent_delete }};
+
+static wxLuaArgType s_wxluatypeArray_wxLua_wxThreadEvent_constructor[] = { &wxluatype_TNUMBER, &wxluatype_TNUMBER, NULL };
+static int LUACALL wxLua_wxThreadEvent_constructor(lua_State *L);
+static wxLuaBindCFunc s_wxluafunc_wxLua_wxThreadEvent_constructor[1] = {{ wxLua_wxThreadEvent_constructor, WXLUAMETHOD_CONSTRUCTOR, 0, 2, s_wxluatypeArray_wxLua_wxThreadEvent_constructor }};
+//     wxThreadEvent(wxEventType eventType = wxEVT_THREAD, int id = wxID_ANY);
+static int LUACALL wxLua_wxThreadEvent_constructor(lua_State *L)
+{
+    // get number of arguments
+    int argCount = lua_gettop(L);
+    // int id = wxID_ANY
+    int id = (argCount >= 2 ? (int)wxlua_getnumbertype(L, 2) : wxID_ANY);
+    // wxEventType eventType = wxEVT_THREAD
+    wxEventType eventType = (argCount >= 1 ? (wxEventType)wxlua_getnumbertype(L, 1) : wxEVT_THREAD);
+    // call constructor
+    wxThreadEvent* returns = new wxThreadEvent(eventType, id);
+    // add to tracked memory list
+    wxluaO_addgcobject(L, returns, wxluatype_wxThreadEvent);
+    // push the constructed class pointer
+    wxluaT_pushuserdatatype(L, returns, wxluatype_wxThreadEvent);
+
+    return 1;
+}
+
+
+
+void wxLua_wxThreadEvent_delete_function(void** p)
+{
+    wxThreadEvent* o = (wxThreadEvent*)(*p);
+    delete o;
+}
+
+// Map Lua Class Methods to C Binding Functions
+wxLuaBindMethod wxThreadEvent_methods[] = {
+    { "GetExtraLong", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxThreadEvent_GetExtraLong, 1, NULL },
+    { "GetInt", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxThreadEvent_GetInt, 1, NULL },
+    { "GetString", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxThreadEvent_GetString, 1, NULL },
+    { "SetExtraLong", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxThreadEvent_SetExtraLong, 1, NULL },
+    { "SetInt", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxThreadEvent_SetInt, 1, NULL },
+    { "SetString", WXLUAMETHOD_METHOD, s_wxluafunc_wxLua_wxThreadEvent_SetString, 1, NULL },
+    { "delete", WXLUAMETHOD_METHOD|WXLUAMETHOD_DELETE, s_wxluafunc_wxLua_wxThreadEvent_delete, 1, NULL },
+    { "wxThreadEvent", WXLUAMETHOD_CONSTRUCTOR, s_wxluafunc_wxLua_wxThreadEvent_constructor, 1, NULL },
+    { 0, 0, 0, 0 },
+};
+
+int wxThreadEvent_methodCount = sizeof(wxThreadEvent_methods)/sizeof(wxLuaBindMethod) - 1;
+
 


### PR DESCRIPTION
This PR enables `wxEVT_THREAD` events in `wxLua`. Minimum code changes, just an extension in `bindings/wxwidgets/wxcore_event.i` (together with a small cosmetic fix in `class %delete wxCommandEvent : public wxEvent`) and regenerated bindings:
- `bindings/wxwidgets/wx_datatypes.lua`
- `modules/wxbind/include/wxcore_bind.h`
- `modules/wxbind/src/wxcore_bind.cpp`
- `modules/wxbind/src/wxcore_event.cpp`

Enabling `wxEVT_THREAD` events lets you post events from worker threads to the main GUI thread when using `wxLua` with `lanes`. This is handy for updating widgets with data from worker threads without having to poll the threads using timer events.