### PR TITLE
wxLua Compatibility with Lua 5.5

### DIFF
--- a/wxLua/bindings/any-bind-sync.lua
+++ b/wxLua/bindings/any-bind-sync.lua
@@ -198,8 +198,9 @@ for interface, substeps in pairs(steps) do
       local infile = false
       local output = {}
       local dups = {}
-      for line in io.lines(header) do
-        if not infile and line:find(process.from)
+      for ln in io.lines(header) do
+	local line = ln
+	if not infile and line:find(process.from)
         or infile and line:find(process.to) then
           infile = not infile
           -- if the last line was "protected:", then remove it

--- a/wxLua/bindings/genwxbind.lua
+++ b/wxLua/bindings/genwxbind.lua
@@ -1463,8 +1463,8 @@ function ReadOverrideFile(override_file)
         return
     end
 
-    for line in io.lines(filename) do
-        line = line:gsub("%s+$","") -- drop all trailing whitespaces not handled by io.lines
+    for ln in io.lines(filename) do
+        local line = ln:gsub("%s+$","") -- drop all trailing whitespaces not handled by io.lines
         local lineData = SplitString(line, delimiters)
         local isOverride = false
         local isEnd = false
@@ -1548,8 +1548,8 @@ function ReadInterfaceFile(filename)
     local fileData   = {}
     local linenumber = 0
 
-    for line in io.lines(filename) do
-        line = line:gsub("%s+$","") -- drop all trailing whitespaces not handled by io.lines
+    for ln in io.lines(filename) do
+        local line = ln:gsub("%s+$","") -- drop all trailing whitespaces not handled by io.lines
         linenumber = linenumber + 1
 
         local lineTable =

--- a/wxLua/bindings/stc-bind-sync.lua
+++ b/wxLua/bindings/stc-bind-sync.lua
@@ -58,7 +58,8 @@ end
 local function merge(defines, process, target)
   local step = -1
   local output = {}
-  for line in io.lines(sync) do
+  for ln in io.lines(sync) do
+     local line = ln
     if step < 0 and -step <= #process and line:find(process[-step].from) then
       step = -step
     elseif step > 0 and line:find(process[step].to) then

--- a/wxLua/modules/wxlua/wxlstate.cpp
+++ b/wxLua/modules/wxlua/wxlstate.cpp
@@ -608,8 +608,13 @@ bool wxLuaState::Create(lua_State* L, int state_type)
         // Make the GC a little more aggressive since we push void* data
         // that may be quite large. The upshot is that Lua runs faster.
         // Empirically found by timing: "for i = 1, 1E6 do local p = wx.wxPoint() end"
+#if LUA_VERSION_NUM >= 505
+	lua_gc(L, LUA_GCPARAM, LUA_GCPPAUSE, 120);
+	lua_gc(L, LUA_GCPARAM, LUA_GCPSTEPMUL, 400);
+#else
         lua_gc(L, LUA_GCSETPAUSE, 120);
         lua_gc(L, LUA_GCSETSTEPMUL, 400);
+#endif
 
         // Create a new state to push into Lua, the last wxLuaStateRefData will delete it.
         // Note: we call SetRefData() so that we don't increase the ref count.

--- a/wxLua/samples/editor.wx.lua
+++ b/wxLua/samples/editor.wx.lua
@@ -1442,7 +1442,8 @@ frame:Connect(ID_COMMENT, wx.wxEVT_COMMAND_MENU_SELECTED,
                 local lineNumber = editor:GetCurrentLine()
                 editor:SetSelection(editor:PositionFromLine(lineNumber), editor:GetLineEndPosition(lineNumber))
             end
-            for line in string.gmatch(editor:GetSelectedText()..'\n', "(.-)\r?\n") do
+            for ln in string.gmatch(editor:GetSelectedText()..'\n', "(.-)\r?\n") do
+	        local line = ln
                 if string.sub(line,1,2) == '--' then
                     line = string.sub(line,3)
                 else

--- a/wxLua/samples/wxluasudoku.wx.lua
+++ b/wxLua/samples/wxluasudoku.wx.lua
@@ -258,11 +258,12 @@ function sudoku.Open(fileName)
     local value_count = 0 -- number of cols in line
     local row_count   = 0 -- number of rows read
     local line_n      = 0 -- actual line number in file
-    for line in io.lines(fileName) do
+    for ln in io.lines(fileName) do
+        local line = ln
         line_n = line_n + 1
         local col_count = 0
-        for k, v in string.gmatch(line, "%d") do
-            k = tonumber(k)
+        for digit in string.gmatch(line, "%d") do
+            local k = tonumber(digit)
             if (k >= 0) and (k <= 9) then
                 table.insert(values, k)
                 col_count = col_count + 1


### PR DESCRIPTION
Updated several binding and sample scripts to comply with Lua 5.5's stricter enforcement of read-only loop control variables. Also moved to new GC constants.

**Key changes:**
- Refactored `for line in io.lines()` and `for k in gmatch()` loops to use a separate local variable for transformations.
- Fixed `attempt to assign to const variable` errors in:
    - wxLua bindings (any-bind-sync, genwxbind, stc-bind-sync)
    - Samples (editor, wxluasudoku)
- Applied new GC constants
  `LUA_GCSETPAUSE`   -> `LUA_GCPARAM, LUA_GCPPAUSE`
  `LUA_GCSETSTEPMUL` -> `LUA_GCPARAM, LUA_GCPSTEPMUL`

This ensures the build system and samples remain functional across Lua 5.1 to 5.5.